### PR TITLE
fix: align everything sdk static lib name

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -27,7 +27,7 @@ fn main() {
     {
         cc::Build::new()
             .file("vendor/everything/Everything.c")
-            .compile("everything");
+            .compile("everything_sdk");
     }
 
     tauri_build::build()


### PR DESCRIPTION
## Summary
Fix Windows native static library link mismatch for Everything SDK.

## Changes
- Update src-tauri/build.rs to compile the C source as everything_sdk
- Keep Rust FFI link target consistent with #[link(name = everything_sdk, kind = static)]

## Why
cargo build/release link step failed with:
could not find native static library everything_sdk
because build output name and link name were inconsistent.

## Validation
- 
px tsc --noEmit
- pre-commit checks passed (cargo check --all-targets, ue-tsc --noEmit)