### PR TITLE
fix: clear active session terminal status

### DIFF
--- a/src/views/SearchView/composables/useSearchRequest.ts
+++ b/src/views/SearchView/composables/useSearchRequest.ts
@@ -180,6 +180,15 @@ export function useSearchRequestFlow(options: UseSearchRequestFlowOptions) {
                 return;
             }
 
+            if (event.sessionId === currentSessionId.value) {
+                void dismissSessionTerminalStatus(event.sessionId).catch((error) => {
+                    console.error(
+                        '[SearchView] Failed to dismiss active session terminal status:',
+                        error
+                    );
+                });
+            }
+
             // 会话运行允许脱离当前页面继续进行；
             // 旧会话进入终态时，当前页不一定还能收到 useAgent 的 onComplete/onError。
             // 这里统一按全局状态事件作废历史列表缓存，保证 popup 能看到最新终态圆点。

--- a/src/views/SearchView/index.vue
+++ b/src/views/SearchView/index.vue
@@ -202,6 +202,10 @@
             return runtimeStatus;
         }
 
+        if (sessionId === currentSessionId.value) {
+            return null;
+        }
+
         return pendingTerminalStatus ?? null;
     }
 


### PR DESCRIPTION
Summary:
- Dismiss terminal session status when the current active session completes or fails.
- Suppress stale pending terminal badges for the active session while preserving background-session badges.

Test plan:
- `git diff --check`
- Attempted `pnpm install --frozen-lockfile --ignore-scripts`, but pnpm is unavailable in this Codex shell.

Closes #77