### PR TITLE
fix: resolve monaco worker build

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -68,7 +68,13 @@ const chunkGroups = [
 export default defineConfig({
   plugins: [
     monacoEditorEsmPlugin({
-      languageWorkers: ['editorWorkerService'],
+      languageWorkers: [],
+      customWorkers: [
+        {
+          label: 'editorWorkerService',
+          entry: 'monaco-editor/esm/vs/editor/editor.worker.js',
+        },
+      ],
     }),
     Icons({
       compiler: 'vue3',


### PR DESCRIPTION
## Summary
- Configure the Monaco editor worker as an explicit custom worker entry with the `.js` suffix.
- Avoid the stale `vite-plugin-monaco-editor-esm` default worker path that fails with `monaco-editor@0.55.1`.

## Test Plan
- [x] `pnpm build`
- [x] `pnpm tauri build`