### PR TITLE
feat(conversation): smooth scroll the back-to-bottom action

### DIFF
--- a/src/views/SearchView/components/ConversationPanel/index.vue
+++ b/src/views/SearchView/components/ConversationPanel/index.vue
@@ -277,6 +277,16 @@
         lastScrollTop.value = conversationContainer.value.scrollTop;
     }
 
+    function smoothScrollToBottom() {
+        if (!conversationContainer.value) return;
+        lastAutoScrollAt.value = Date.now();
+        conversationContainer.value.scrollTo({
+            top: conversationContainer.value.scrollHeight,
+            behavior: 'smooth',
+        });
+        lastScrollTop.value = conversationContainer.value.scrollTop;
+    }
+
     /**
      * 统一按当前位置刷新“跳到底部”按钮，避免时间轴跳转和消息追加各自维护一套显示条件。
      */
@@ -335,7 +345,7 @@
 
     // 滚动到底部
     function scrollToBottom() {
-        syncToBottom();
+        smoothScrollToBottom();
         isAutoScrollEnabled.value = outputScrollBehavior.value === 'follow_output';
         showScrollToBottom.value = false;
     }


### PR DESCRIPTION
## Summary

Smooth the conversation back-to-bottom action so user-triggered jumps animate to the latest message instead of snapping instantly.

The automatic follow-output path still uses instant scrolling, which avoids jitter during streaming responses while making the explicit back-to-bottom action feel more polished.

## Related issue or RFC

Link the issue or RFC:

- Closes #107
- Related to #107

## AI assistance disclosure

- Tool(s) used: OpenAI Codex
- Scope of assistance: repository exploration, implementation of the focused frontend change, and drafting commit/PR text
- Human review or rewrite performed: reviewed the touched Vue component, verified the final diff, and ran the requested local checks before submission
- Architecture or boundary impact: none; this stays inside the existing conversation panel UI logic

## Testing evidence

List the commands you ran and the results you observed.

```text
pnpm type:check                     ✅ pass
pnpm lint:check                     ✅ pass
pnpm format:check                   ✅ pass
pnpm test:run                       ✅ pass (6 files, 11 tests)
cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check   ✅ pass
cargo check --manifest-path src-tauri/Cargo.toml --all-targets    ✅ pass
```

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: none
- database baseline or migration impact: none
- release or packaging impact: none

## Screenshots or recordings

No screenshot attached. This change only affects the scroll animation of an existing button and does not alter layout or static visuals.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [x] I added tests or explained why tests are not appropriate.
- [ ] I updated docs when behavior changed.
