### PR TITLE
fix: use commit hash in CI artifact names and fix TouchAI.exe casing at source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,10 @@ jobs:
               with:
                   workspaces: src-tauri -> target
 
+            - name: Get short commit SHA
+              id: sha
+              run: echo "short=$(git rev-parse --short HEAD)" >> $env:GITHUB_OUTPUT
+
             - name: Install frontend dependencies
               run: pnpm install --frozen-lockfile
 
@@ -246,7 +250,7 @@ jobs:
             - name: Upload installers
               uses: actions/upload-artifact@v4
               with:
-                  name: touchai-installers-windows
+                  name: touchai-installers-windows-${{ steps.sha.outputs.short }}
                   path: |
                       src-tauri/target/release/bundle/nsis/*.exe
                       src-tauri/target/release/bundle/msi/*.msi
@@ -255,6 +259,6 @@ jobs:
             - name: Upload portable
               uses: actions/upload-artifact@v4
               with:
-                  name: touchai-portable-windows
+                  name: touchai-portable-windows-${{ steps.sha.outputs.short }}
                   path: src-tauri/target/release/TouchAI.exe
                   if-no-files-found: warn

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -7,6 +7,10 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[[bin]]
+name = "TouchAI"
+path = "src/main.rs"
+
 [lib]
 # The `_lib` suffix may seem redundant but it is necessary
 # to make the lib name unique and wouldn't conflict with the bin name.


### PR DESCRIPTION
## Summary
- Add `[[bin]] name = "TouchAI"` to `src-tauri/Cargo.toml` so Cargo compiles the binary directly as `TouchAI.exe` from the source, matching the product name casing.
- Append short commit hash to CI Windows artifact names (e.g. `touchai-portable-windows-6aa632f`) so snapshot builds are traceable to their exact commit and cannot be mistaken for release packages.

Closes #129

## Test plan
- [ ] Verify `cargo metadata` reports binary target name as `TouchAI` (already confirmed locally)
- [ ] Verify CI Windows build produces `TouchAI.exe` with correct casing
- [ ] Verify CI artifact names include short commit hash suffix