### PR TITLE
feat(search): move loading animation to model logo (#131)

### DIFF
--- a/src/components/ModelLogo.vue
+++ b/src/components/ModelLogo.vue
@@ -42,11 +42,13 @@
         modelId: string;
         name?: string;
         size?: 'sm' | 'md' | 'lg';
+        isLoading?: boolean;
     }
 
     const props = withDefaults(defineProps<Props>(), {
         name: '',
         size: 'md',
+        isLoading: false,
     });
 
     const sizeClass = computed(() => {
@@ -98,20 +100,60 @@
 </script>
 
 <template>
-    <img
-        v-if="logoSrc"
-        :src="logoSrc"
-        :alt="name || modelId"
-        :class="[sizeClass, 'rounded-full object-cover']"
-    />
-    <div
-        v-else
+    <span
         :class="[
             sizeClass,
-            fallbackTextClass,
-            'flex items-center justify-center rounded-full bg-gray-100 font-semibold text-gray-500',
+            'model-logo relative inline-flex items-center justify-center rounded-full',
+            isLoading ? 'model-logo--loading' : '',
         ]"
     >
-        {{ fallbackChar }}
-    </div>
+        <img
+            v-if="logoSrc"
+            :src="logoSrc"
+            :alt="name || modelId"
+            class="h-full w-full rounded-full object-cover"
+        />
+        <span
+            v-else
+            :class="[
+                fallbackTextClass,
+                'flex h-full w-full items-center justify-center rounded-full bg-gray-100 font-semibold text-gray-500',
+            ]"
+        >
+            {{ fallbackChar }}
+        </span>
+    </span>
 </template>
+
+<style scoped>
+    .model-logo--loading::before {
+        position: absolute;
+        inset: 0;
+        padding: 2px;
+        content: '';
+        pointer-events: none;
+        background: conic-gradient(
+            from 0deg,
+            var(--color-blue-500),
+            var(--color-violet-500),
+            var(--color-pink-500),
+            transparent 78%
+        );
+        border-radius: inherit;
+        animation: logo-spin 1s linear infinite;
+        -webkit-mask:
+            linear-gradient(#000 0 0) content-box,
+            linear-gradient(#000 0 0);
+        -webkit-mask-composite: xor;
+        mask:
+            linear-gradient(#000 0 0) content-box,
+            linear-gradient(#000 0 0);
+        mask-composite: exclude;
+    }
+
+    @keyframes logo-spin {
+        to {
+            transform: rotate(360deg);
+        }
+    }
+</style>

--- a/src/views/SearchView/components/SearchBar/index.vue
+++ b/src/views/SearchView/components/SearchBar/index.vue
@@ -19,7 +19,12 @@
                 v-if="selectedModel || activeModel"
                 :model-id="selectedModel?.model_id || activeModel?.model_id || ''"
                 :name="selectedModel?.name || activeModel?.name || 'model'"
-                class="border-2 border-gray-300 transition-colors hover:border-gray-400"
+                :is-loading="isLoading"
+                :class="
+                    isLoading
+                        ? ''
+                        : 'border-2 border-gray-300 transition-colors hover:border-gray-400'
+                "
             />
             <img v-else :src="logo" alt="TouchAI" class="h-8 w-8 object-contain select-none" />
         </div>
@@ -60,6 +65,7 @@
 
     interface Props {
         disabled?: boolean;
+        isLoading?: boolean;
         queryText?: string;
         attachments?: Index[];
         modelOverride?: SearchModelOverride;
@@ -67,6 +73,7 @@
 
     const props = withDefaults(defineProps<Props>(), {
         disabled: false,
+        isLoading: false,
         queryText: '',
         attachments: () => [],
         modelOverride: () => ({
@@ -75,7 +82,7 @@
         }),
     });
 
-    const { disabled, queryText, attachments, modelOverride } = toRefs(props);
+    const { disabled, isLoading, queryText, attachments, modelOverride } = toRefs(props);
     const searchBarContainerRef = ref<HTMLElement | null>(null);
     const editorHostRef = ref<HTMLElement | null>(null);
     let selectionDragCleanup: (() => void) | null = null;

--- a/src/views/SearchView/index.vue
+++ b/src/views/SearchView/index.vue
@@ -741,10 +741,7 @@
     <div
         ref="pageContainer"
         tabindex="-1"
-        :class="[
-            'search-view-container bg-background-primary relative flex h-full w-full flex-col items-center justify-start overflow-hidden rounded-lg backdrop-blur-xl focus:outline-none',
-            isLoading ? 'loading' : '',
-        ]"
+        class="search-view-container bg-background-primary relative flex h-full w-full flex-col items-center justify-start overflow-hidden rounded-lg backdrop-blur-xl focus:outline-none"
         @paste.capture="handlePagePaste"
     >
         <div
@@ -778,6 +775,7 @@
             <SearchBar
                 ref="searchBar"
                 :disabled="isWaitingForCompletion || Boolean(pendingToolApproval)"
+                :is-loading="isLoading"
                 :query-text="queryText"
                 :attachments="attachments"
                 :model-override="modelOverride"
@@ -808,85 +806,5 @@
 <style scoped>
     .search-view-container {
         border: 1.5px solid var(--color-gray-300);
-    }
-
-    .search-view-container.loading {
-        border: 2px solid transparent;
-        background-image:
-            linear-gradient(var(--color-background-primary), var(--color-background-primary)),
-            linear-gradient(
-                90deg,
-                var(--color-blue-500),
-                var(--color-violet-500),
-                var(--color-pink-500),
-                var(--color-violet-500),
-                var(--color-blue-500)
-            );
-        background-origin: border-box;
-        background-clip: padding-box, border-box;
-        animation: border-flow 1.5s linear infinite;
-    }
-
-    @keyframes border-flow {
-        0% {
-            background-image:
-                linear-gradient(var(--color-background-primary), var(--color-background-primary)),
-                linear-gradient(
-                    90deg,
-                    var(--color-blue-500),
-                    var(--color-violet-500),
-                    var(--color-pink-500),
-                    var(--color-violet-500),
-                    var(--color-blue-500)
-                );
-        }
-        25% {
-            background-image:
-                linear-gradient(var(--color-background-primary), var(--color-background-primary)),
-                linear-gradient(
-                    90deg,
-                    var(--color-violet-500),
-                    var(--color-pink-500),
-                    var(--color-violet-500),
-                    var(--color-blue-500),
-                    var(--color-violet-500)
-                );
-        }
-        50% {
-            background-image:
-                linear-gradient(var(--color-background-primary), var(--color-background-primary)),
-                linear-gradient(
-                    90deg,
-                    var(--color-pink-500),
-                    var(--color-violet-500),
-                    var(--color-blue-500),
-                    var(--color-violet-500),
-                    var(--color-pink-500)
-                );
-        }
-        75% {
-            background-image:
-                linear-gradient(var(--color-background-primary), var(--color-background-primary)),
-                linear-gradient(
-                    90deg,
-                    var(--color-violet-500),
-                    var(--color-blue-500),
-                    var(--color-violet-500),
-                    var(--color-pink-500),
-                    var(--color-violet-500)
-                );
-        }
-        100% {
-            background-image:
-                linear-gradient(var(--color-background-primary), var(--color-background-primary)),
-                linear-gradient(
-                    90deg,
-                    var(--color-blue-500),
-                    var(--color-violet-500),
-                    var(--color-pink-500),
-                    var(--color-violet-500),
-                    var(--color-blue-500)
-                );
-        }
     }
 </style>


### PR DESCRIPTION
## Summary

- Removes the full SearchView `border-flow` loading animation.
- Passes the request loading state from `SearchView` into `SearchBar` and `ModelLogo`.
- Adds an `isLoading` state to `ModelLogo` that replaces the normal gray border with a lightweight conic-gradient spinner ring around the model logo.

## Validation

- `pnpm format:check`
- `pnpm lint:check`
- `pnpm type:check`
- `pnpm test:run` (passes; repo currently has no matching test files)
- `pnpm build`
- `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
- `cargo check --manifest-path src-tauri/Cargo.toml --all-targets`

## Notes

- I tried a browser-only visual check with `pnpm dev`, but the SearchView does not render outside the Tauri runtime because it calls Tauri window/event APIs. The production Vite build and Tauri Rust checks pass.
- Material AI assistance disclosure: this change was prepared with Codex assistance and reviewed locally before submission.

Closes #131
