### PR TITLE
fix: esc key now clears input progressively (text → model → exit)

### DIFF
--- a/src/views/SearchView/composables/interaction/useSearchKeyboardRouter.ts
+++ b/src/views/SearchView/composables/interaction/useSearchKeyboardRouter.ts
@@ -43,6 +43,7 @@ interface CreateSearchKeyboardRouterOptions {
     onClearModelOverride: () => void;
     onHideWindow: () => void | Promise<void>;
     onClearSession: () => void;
+    onClearDraft: () => void;
     onClearAll: () => void;
     onPrimaryShortcut: (key: SearchPrimaryShortcutKey) => void | Promise<void>;
 }
@@ -126,6 +127,7 @@ export function createSearchKeyboardRouter(options: CreateSearchKeyboardRouterOp
         onClearModelOverride,
         onHideWindow,
         onClearSession,
+        onClearDraft,
         onClearAll,
         onPrimaryShortcut,
     } = options;
@@ -178,22 +180,26 @@ export function createSearchKeyboardRouter(options: CreateSearchKeyboardRouterOp
                 return true;
             }
 
-            if (!queryText.trim() && hasModelOverride()) {
+            // Step 1: Clear input text first without exiting the current conversation
+            if (queryText.trim()) {
+                onClearDraft();
+                return true;
+            }
+
+            // Step 2: Clear model selection
+            if (hasModelOverride()) {
                 onClearModelOverride();
                 return true;
             }
 
-            if (!queryText.trim() && getSessionHistoryCount() === 0) {
-                runKeyboardEffect(onHideWindow);
-                return true;
-            }
-
+            // Step 3: Exit conversation if session exists
             if (getSessionHistoryCount() > 0) {
                 onClearSession();
                 return true;
             }
 
-            onClearAll();
+            // Step 4: Hide window if no session
+            runKeyboardEffect(onHideWindow);
             return true;
         }
 

--- a/src/views/SearchView/composables/interaction/useSearchKeyboardRouter.ts
+++ b/src/views/SearchView/composables/interaction/useSearchKeyboardRouter.ts
@@ -128,7 +128,6 @@ export function createSearchKeyboardRouter(options: CreateSearchKeyboardRouterOp
         onHideWindow,
         onClearSession,
         onClearDraft,
-        onClearAll,
         onPrimaryShortcut,
     } = options;
 

--- a/src/views/SearchView/composables/searchInteraction.ts
+++ b/src/views/SearchView/composables/searchInteraction.ts
@@ -134,6 +134,7 @@ interface CreateSearchKeyboardRouterOptions {
     onClearModelOverride: () => void;
     onHideWindow: () => void | Promise<void>;
     onClearSession: () => void;
+    onClearDraft: () => void;
     onClearAll: () => void;
     onPrimaryShortcut: (key: SearchPrimaryShortcutKey) => void | Promise<void>;
 }
@@ -606,6 +607,7 @@ export function createSearchKeyboardRouter(options: CreateSearchKeyboardRouterOp
         onClearModelOverride,
         onHideWindow,
         onClearSession,
+        onClearDraft,
         onClearAll,
         onPrimaryShortcut,
     } = options;
@@ -655,22 +657,26 @@ export function createSearchKeyboardRouter(options: CreateSearchKeyboardRouterOp
                 return true;
             }
 
-            if (!queryText.trim() && hasModelOverride()) {
+            // Step 1: Clear input text first without exiting the current conversation
+            if (queryText.trim()) {
+                onClearDraft();
+                return true;
+            }
+
+            // Step 2: Clear model selection
+            if (hasModelOverride()) {
                 onClearModelOverride();
                 return true;
             }
 
-            if (!queryText.trim() && getSessionHistoryCount() === 0) {
-                runKeyboardEffect(onHideWindow);
-                return true;
-            }
-
+            // Step 3: Exit conversation if session exists
             if (getSessionHistoryCount() > 0) {
                 onClearSession();
                 return true;
             }
 
-            onClearAll();
+            // Step 4: Hide window if no session
+            runKeyboardEffect(onHideWindow);
             return true;
         }
 
@@ -861,6 +867,9 @@ export function createSearchKeydownHandler(options: UseSearchKeyboardOptions) {
         },
         onClearSession: () => {
             clearSession();
+        },
+        onClearDraft: () => {
+            queryText.value = '';
         },
         onClearAll: () => {
             clearAll();

--- a/src/views/SearchView/composables/searchInteraction.ts
+++ b/src/views/SearchView/composables/searchInteraction.ts
@@ -608,7 +608,6 @@ export function createSearchKeyboardRouter(options: CreateSearchKeyboardRouterOp
         onHideWindow,
         onClearSession,
         onClearDraft,
-        onClearAll,
         onPrimaryShortcut,
     } = options;
 


### PR DESCRIPTION
## Summary
Fixes the ESC key behavior to follow the expected progressive clearing workflow instead of immediately exiting the conversation.

## Related issue or RFC
Fixes #121

## Changes
- Added `onClearDraft` callback to `CreateSearchKeyboardRouterOptions` interface
- Reordered ESC key logic in keyboard router to implement progressive clearing:
  1. **First press**: Clear input text only (preserves model selection and conversation)
  2. **Second press**: Clear model selection (preserves conversation)
  3. **Third press**: Exit current conversation
- Updated both `searchInteraction.ts` and `interaction/useSearchKeyboardRouter.ts` (duplicate implementations)
- Removed unused `onClearAll` declarations to fix TypeScript TS6133 errors

## Root Cause
The previous logic checked `getSessionHistoryCount() > 0` before checking if input text existed, causing the first ESC press to immediately exit the conversation instead of clearing the input text.

## Solution
Reordered the ESC key conditions to check for input text first, and added a dedicated `onClearDraft` callback that only clears the input text without affecting the session state.

## AI assistance disclosure
This PR was developed with AI assistance (Claude via OpenClaw) for code analysis and implementation.

## Testing evidence
Manual testing steps:
1. Open TouchAI and start a conversation
2. Type some text in the input box
3. Press ESC → text should clear, conversation remains active
4. Press ESC again → model selection should clear (if set)
5. Press ESC again → conversation should exit

Existing keyboard router logic continues to work for other ESC key scenarios (cancel request, close popups, etc.).

TypeScript type checking passes after removing unused `onClearAll` declarations.

## Risk notes
- Low risk: Changes are isolated to keyboard event handling logic
- No breaking changes to existing API or user workflows
- Preserves all existing ESC key behaviors (popup closing, request cancellation, etc.)

## Screenshots or recordings
N/A - Keyboard interaction behavior (can provide demo video if needed)

## Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/TouchAI-org/TouchAI/blob/main/CONTRIBUTING.md)
- [x] I have signed the [Contributor License Agreement](https://cla-assistant.io/TouchAI-org/TouchAI)
- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] I have tested my changes locally
