### PR TITLE
fix(search): handle escape progressive reset

### DIFF
--- a/src/views/SearchView/composables/searchInteraction.spec.ts
+++ b/src/views/SearchView/composables/searchInteraction.spec.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createSearchKeyboardRouter } from './searchInteraction';
+
+function createRouterState() {
+    return {
+        queryText: '',
+        hasDraftContent: false,
+        hasModelOverride: false,
+        sessionHistoryCount: 0,
+        isLoading: false,
+        activeSurface: 'search-surface' as const,
+    };
+}
+
+function createRouter(state = createRouterState()) {
+    const handlers = {
+        promptApprovalAttention: vi.fn(),
+        rejectApproval: vi.fn(),
+        approveApproval: vi.fn(),
+        forwardToPopup: vi.fn(),
+        submit: vi.fn(),
+        openQuickSearch: vi.fn(),
+        moveQuickSearchSelection: vi.fn(),
+        openHighlightedQuickSearchItem: vi.fn(),
+        closeQuickSearch: vi.fn(),
+        hideAllPopups: vi.fn(),
+        cancelRequest: vi.fn(),
+        clearDraft: vi.fn(() => {
+            state.queryText = '';
+            state.hasDraftContent = false;
+        }),
+        clearModelOverride: vi.fn(() => {
+            state.hasModelOverride = false;
+        }),
+        hideWindow: vi.fn(),
+        clearSession: vi.fn(() => {
+            state.sessionHistoryCount = 0;
+        }),
+        primaryShortcut: vi.fn(),
+    };
+
+    const router = createSearchKeyboardRouter({
+        getPendingApproval: () => null,
+        getActiveSurface: () => state.activeSurface,
+        hasActivePopupWindowFocus: () => false,
+        getQueryText: () => state.queryText,
+        hasDraftContent: () => state.hasDraftContent,
+        isQuickSearchOpen: () => false,
+        hasQuickSearchHighlight: () => false,
+        shouldTriggerQuickSearch: () => false,
+        isMultiLineCursor: () => false,
+        hasModelOverride: () => state.hasModelOverride,
+        getSessionHistoryCount: () => state.sessionHistoryCount,
+        isLoading: () => state.isLoading,
+        onPromptApprovalAttention: handlers.promptApprovalAttention,
+        onRejectApproval: handlers.rejectApproval,
+        onApproveApproval: handlers.approveApproval,
+        onForwardToPopup: handlers.forwardToPopup,
+        onSubmit: handlers.submit,
+        onOpenQuickSearch: handlers.openQuickSearch,
+        onMoveQuickSearchSelection: handlers.moveQuickSearchSelection,
+        onOpenHighlightedQuickSearchItem: handlers.openHighlightedQuickSearchItem,
+        onCloseQuickSearch: handlers.closeQuickSearch,
+        onHideAllPopups: handlers.hideAllPopups,
+        onCancelRequest: handlers.cancelRequest,
+        onClearDraft: handlers.clearDraft,
+        onClearModelOverride: handlers.clearModelOverride,
+        onHideWindow: handlers.hideWindow,
+        onClearSession: handlers.clearSession,
+        onPrimaryShortcut: handlers.primaryShortcut,
+    });
+
+    return {
+        router,
+        state,
+        handlers,
+    };
+}
+
+describe('createSearchKeyboardRouter', () => {
+    it('clears draft before model override or conversation session on Escape', () => {
+        const { router, handlers } = createRouter({
+            ...createRouterState(),
+            queryText: 'hello',
+            hasDraftContent: true,
+            hasModelOverride: true,
+            sessionHistoryCount: 2,
+        });
+
+        expect(router.route({ key: 'Escape' })).toBe(true);
+
+        expect(handlers.clearDraft).toHaveBeenCalledOnce();
+        expect(handlers.clearModelOverride).not.toHaveBeenCalled();
+        expect(handlers.clearSession).not.toHaveBeenCalled();
+        expect(handlers.hideWindow).not.toHaveBeenCalled();
+    });
+
+    it('clears model override before exiting an active conversation on Escape', () => {
+        const { router, handlers } = createRouter({
+            ...createRouterState(),
+            hasModelOverride: true,
+            sessionHistoryCount: 2,
+        });
+
+        expect(router.route({ key: 'Escape' })).toBe(true);
+
+        expect(handlers.clearModelOverride).toHaveBeenCalledOnce();
+        expect(handlers.clearSession).not.toHaveBeenCalled();
+        expect(handlers.hideWindow).not.toHaveBeenCalled();
+    });
+
+    it('exits the active conversation after draft and model override are clear on Escape', () => {
+        const { router, handlers } = createRouter({
+            ...createRouterState(),
+            sessionHistoryCount: 2,
+        });
+
+        expect(router.route({ key: 'Escape' })).toBe(true);
+
+        expect(handlers.clearSession).toHaveBeenCalledOnce();
+        expect(handlers.hideWindow).not.toHaveBeenCalled();
+    });
+});

--- a/src/views/SearchView/composables/searchInteraction.ts
+++ b/src/views/SearchView/composables/searchInteraction.ts
@@ -112,6 +112,7 @@ interface CreateSearchKeyboardRouterOptions {
     getActiveSurface: () => SearchKeyboardSurface;
     hasActivePopupWindowFocus: () => boolean;
     getQueryText: () => string;
+    hasDraftContent: () => boolean;
     isQuickSearchOpen: () => boolean;
     hasQuickSearchHighlight: () => boolean;
     shouldTriggerQuickSearch: (query: string) => boolean;
@@ -130,10 +131,10 @@ interface CreateSearchKeyboardRouterOptions {
     onCloseQuickSearch: () => void;
     onHideAllPopups: () => void | Promise<void>;
     onCancelRequest: () => void;
+    onClearDraft: () => void;
     onClearModelOverride: () => void;
     onHideWindow: () => void | Promise<void>;
     onClearSession: () => void;
-    onClearAll: () => void;
     onPrimaryShortcut: (key: SearchPrimaryShortcutKey) => void | Promise<void>;
 }
 
@@ -152,6 +153,7 @@ export interface UseSearchKeyboardOptions {
     approvePendingToolApproval: (callId?: string) => boolean;
     rejectPendingToolApproval: (callId?: string) => boolean;
     promptPendingToolApprovalAttention: () => void;
+    hasDraftContent: () => boolean;
     getActivePopupType: () => SearchPopupSurfaceType | null;
     hasActivePopupWindowFocus: () => boolean;
     isQuickSearchOpen: ComputedRef<boolean>;
@@ -165,6 +167,7 @@ export interface UseSearchKeyboardOptions {
     startNewSession: () => Promise<void>;
     toggleWindowPin: () => Promise<void>;
     handleSubmit: (query: string) => Promise<void>;
+    clearDraft: (options?: { preserveModelTag?: boolean }) => void;
     clearAll: () => void;
     cancelRequest: () => void;
     clearSession: () => void;
@@ -576,6 +579,7 @@ export function createSearchKeyboardRouter(options: CreateSearchKeyboardRouterOp
         getActiveSurface,
         hasActivePopupWindowFocus,
         getQueryText,
+        hasDraftContent,
         isQuickSearchOpen,
         hasQuickSearchHighlight,
         shouldTriggerQuickSearch,
@@ -594,10 +598,10 @@ export function createSearchKeyboardRouter(options: CreateSearchKeyboardRouterOp
         onCloseQuickSearch,
         onHideAllPopups,
         onCancelRequest,
+        onClearDraft,
         onClearModelOverride,
         onHideWindow,
         onClearSession,
-        onClearAll,
         onPrimaryShortcut,
     } = options;
 
@@ -646,13 +650,13 @@ export function createSearchKeyboardRouter(options: CreateSearchKeyboardRouterOp
                 return true;
             }
 
-            if (!queryText.trim() && hasModelOverride()) {
-                onClearModelOverride();
+            if (hasDraftContent()) {
+                onClearDraft();
                 return true;
             }
 
-            if (!queryText.trim() && getSessionHistoryCount() === 0) {
-                runKeyboardEffect(onHideWindow);
+            if (hasModelOverride()) {
+                onClearModelOverride();
                 return true;
             }
 
@@ -661,7 +665,7 @@ export function createSearchKeyboardRouter(options: CreateSearchKeyboardRouterOp
                 return true;
             }
 
-            onClearAll();
+            runKeyboardEffect(onHideWindow);
             return true;
         }
 
@@ -763,6 +767,7 @@ export function createSearchKeydownHandler(options: UseSearchKeyboardOptions) {
         approvePendingToolApproval,
         rejectPendingToolApproval,
         promptPendingToolApprovalAttention,
+        hasDraftContent,
         getActivePopupType,
         hasActivePopupWindowFocus,
         isQuickSearchOpen,
@@ -776,6 +781,7 @@ export function createSearchKeydownHandler(options: UseSearchKeyboardOptions) {
         startNewSession,
         toggleWindowPin,
         handleSubmit,
+        clearDraft,
         clearAll,
         cancelRequest,
         clearSession,
@@ -805,6 +811,7 @@ export function createSearchKeydownHandler(options: UseSearchKeyboardOptions) {
         },
         hasActivePopupWindowFocus,
         getQueryText: () => queryText.value,
+        hasDraftContent,
         isQuickSearchOpen: () => isQuickSearchOpen.value,
         hasQuickSearchHighlight: () => controller.isQuickSearchItemHighlighted(),
         shouldTriggerQuickSearch,
@@ -843,6 +850,9 @@ export function createSearchKeydownHandler(options: UseSearchKeyboardOptions) {
         onCancelRequest: () => {
             cancelRequest();
         },
+        onClearDraft: () => {
+            clearDraft({ preserveModelTag: true });
+        },
         onClearModelOverride: () => {
             modelOverride.value = createEmptyModelOverride();
         },
@@ -851,9 +861,6 @@ export function createSearchKeydownHandler(options: UseSearchKeyboardOptions) {
         },
         onClearSession: () => {
             clearSession();
-        },
-        onClearAll: () => {
-            clearAll();
         },
         onPrimaryShortcut: async (key) => {
             if (key === 'h') {

--- a/src/views/SearchView/index.vue
+++ b/src/views/SearchView/index.vue
@@ -326,6 +326,7 @@
         approvePendingToolApproval,
         rejectPendingToolApproval,
         promptPendingToolApprovalAttention,
+        hasDraftContent: () => Boolean(queryText.value.trim()) || attachments.value.length > 0,
         getActivePopupType: () =>
             isLiveActivePopupSession() ? searchInteractionContext.state.activePopupType : null,
         hasActivePopupWindowFocus: () => isLiveActivePopupSession(),
@@ -340,6 +341,7 @@
         startNewSession: handleStartNewSession,
         toggleWindowPin: handleToggleWindowPin,
         handleSubmit,
+        clearDraft,
         clearAll,
         cancelRequest,
         clearSession,


### PR DESCRIPTION
## Summary
- make Escape clear draft content before clearing the selected model or active conversation
- keep the selected model while clearing draft input/attachments
- add focused keyboard-router coverage for the progressive Escape reset flow

Fixes #121

## Testing
- corepack pnpm run type:check
- corepack pnpm run lint:check
- corepack pnpm run test:run
- corepack pnpm exec prettier --check src/views/SearchView/index.vue src/views/SearchView/composables/searchInteraction.ts src/views/SearchView/composables/searchInteraction.spec.ts

## AI assistance disclosure
This pull request was prepared with material AI assistance from OpenAI Codex. The change was reviewed locally and validated with the commands listed above.