### PR TITLE
fix(search): move loading indicator to model logo

### DIFF
--- a/src/components/ModelLogo.vue
+++ b/src/components/ModelLogo.vue
@@ -42,11 +42,13 @@
         modelId: string;
         name?: string;
         size?: 'sm' | 'md' | 'lg';
+        isLoading?: boolean;
     }
 
     const props = withDefaults(defineProps<Props>(), {
         name: '',
         size: 'md',
+        isLoading: false,
     });
 
     const sizeClass = computed(() => {
@@ -98,20 +100,65 @@
 </script>
 
 <template>
-    <img
-        v-if="logoSrc"
-        :src="logoSrc"
-        :alt="name || modelId"
-        :class="[sizeClass, 'rounded-full object-cover']"
-    />
     <div
-        v-else
         :class="[
             sizeClass,
-            fallbackTextClass,
-            'flex items-center justify-center rounded-full bg-gray-100 font-semibold text-gray-500',
+            'model-logo relative inline-flex shrink-0 rounded-full',
+            isLoading ? 'model-logo--loading' : '',
         ]"
     >
-        {{ fallbackChar }}
+        <img
+            v-if="logoSrc"
+            :src="logoSrc"
+            :alt="name || modelId"
+            class="h-full w-full rounded-full object-cover"
+        />
+        <span
+            v-else
+            :class="[
+                fallbackTextClass,
+                'flex h-full w-full items-center justify-center rounded-full bg-gray-100 font-semibold text-gray-500',
+            ]"
+        >
+            {{ fallbackChar }}
+        </span>
     </div>
 </template>
+
+<style scoped>
+    .model-logo--loading {
+        padding: 2px;
+    }
+
+    .model-logo--loading::before {
+        position: absolute;
+        inset: 0;
+        padding: 2px;
+        content: '';
+        background: conic-gradient(
+            from 0deg,
+            var(--color-blue-500),
+            var(--color-violet-500),
+            var(--color-pink-500),
+            transparent,
+            var(--color-blue-500)
+        );
+        border-radius: inherit;
+        animation: logo-spin 0.9s linear infinite;
+        mask:
+            linear-gradient(#fff 0 0) content-box,
+            linear-gradient(#fff 0 0);
+        mask-composite: exclude;
+        -webkit-mask:
+            linear-gradient(#fff 0 0) content-box,
+            linear-gradient(#fff 0 0);
+        -webkit-mask-composite: xor;
+        pointer-events: none;
+    }
+
+    @keyframes logo-spin {
+        to {
+            transform: rotate(360deg);
+        }
+    }
+</style>

--- a/src/views/SearchView/components/SearchBar/index.vue
+++ b/src/views/SearchView/components/SearchBar/index.vue
@@ -19,7 +19,11 @@
                 v-if="selectedModel || activeModel"
                 :model-id="selectedModel?.model_id || activeModel?.model_id || ''"
                 :name="selectedModel?.name || activeModel?.name || 'model'"
-                class="border-2 border-gray-300 transition-colors hover:border-gray-400"
+                :is-loading="isLoading"
+                :class="[
+                    'transition-colors',
+                    isLoading ? '' : 'border-2 border-gray-300 hover:border-gray-400',
+                ]"
             />
             <img v-else :src="logo" alt="TouchAI" class="h-8 w-8 object-contain select-none" />
         </div>
@@ -63,19 +67,21 @@
         queryText?: string;
         attachments?: Index[];
         modelOverride?: SearchModelOverride;
+        isLoading?: boolean;
     }
 
     const props = withDefaults(defineProps<Props>(), {
         disabled: false,
         queryText: '',
         attachments: () => [],
+        isLoading: false,
         modelOverride: () => ({
             modelId: null,
             providerId: null,
         }),
     });
 
-    const { disabled, queryText, attachments, modelOverride } = toRefs(props);
+    const { disabled, queryText, attachments, modelOverride, isLoading } = toRefs(props);
     const searchBarContainerRef = ref<HTMLElement | null>(null);
     const editorHostRef = ref<HTMLElement | null>(null);
     let selectionDragCleanup: (() => void) | null = null;

--- a/src/views/SearchView/index.vue
+++ b/src/views/SearchView/index.vue
@@ -743,7 +743,6 @@
         tabindex="-1"
         :class="[
             'search-view-container bg-background-primary relative flex h-full w-full flex-col items-center justify-start overflow-hidden rounded-lg backdrop-blur-xl focus:outline-none',
-            isLoading ? 'loading' : '',
         ]"
         @paste.capture="handlePagePaste"
     >
@@ -781,6 +780,7 @@
                 :query-text="queryText"
                 :attachments="attachments"
                 :model-override="modelOverride"
+                :is-loading="isLoading"
                 @update:query-text="handleQueryTextChange"
                 @attachment-remove-request="handleAttachmentRemoveRequest"
                 @model-change="handleModelChange"
@@ -808,85 +808,5 @@
 <style scoped>
     .search-view-container {
         border: 1.5px solid var(--color-gray-300);
-    }
-
-    .search-view-container.loading {
-        border: 2px solid transparent;
-        background-image:
-            linear-gradient(var(--color-background-primary), var(--color-background-primary)),
-            linear-gradient(
-                90deg,
-                var(--color-blue-500),
-                var(--color-violet-500),
-                var(--color-pink-500),
-                var(--color-violet-500),
-                var(--color-blue-500)
-            );
-        background-origin: border-box;
-        background-clip: padding-box, border-box;
-        animation: border-flow 1.5s linear infinite;
-    }
-
-    @keyframes border-flow {
-        0% {
-            background-image:
-                linear-gradient(var(--color-background-primary), var(--color-background-primary)),
-                linear-gradient(
-                    90deg,
-                    var(--color-blue-500),
-                    var(--color-violet-500),
-                    var(--color-pink-500),
-                    var(--color-violet-500),
-                    var(--color-blue-500)
-                );
-        }
-        25% {
-            background-image:
-                linear-gradient(var(--color-background-primary), var(--color-background-primary)),
-                linear-gradient(
-                    90deg,
-                    var(--color-violet-500),
-                    var(--color-pink-500),
-                    var(--color-violet-500),
-                    var(--color-blue-500),
-                    var(--color-violet-500)
-                );
-        }
-        50% {
-            background-image:
-                linear-gradient(var(--color-background-primary), var(--color-background-primary)),
-                linear-gradient(
-                    90deg,
-                    var(--color-pink-500),
-                    var(--color-violet-500),
-                    var(--color-blue-500),
-                    var(--color-violet-500),
-                    var(--color-pink-500)
-                );
-        }
-        75% {
-            background-image:
-                linear-gradient(var(--color-background-primary), var(--color-background-primary)),
-                linear-gradient(
-                    90deg,
-                    var(--color-violet-500),
-                    var(--color-blue-500),
-                    var(--color-violet-500),
-                    var(--color-pink-500),
-                    var(--color-violet-500)
-                );
-        }
-        100% {
-            background-image:
-                linear-gradient(var(--color-background-primary), var(--color-background-primary)),
-                linear-gradient(
-                    90deg,
-                    var(--color-blue-500),
-                    var(--color-violet-500),
-                    var(--color-pink-500),
-                    var(--color-violet-500),
-                    var(--color-blue-500)
-                );
-        }
     }
 </style>


### PR DESCRIPTION
## Summary
- replace the full SearchView border-flow loading animation with a logo-level loading ring
- add an isLoading prop to ModelLogo and pipe SearchView loading state through SearchBar
- keep the static gray logo border when not loading

Fixes #131

## Testing
- corepack pnpm run type:check
- corepack pnpm run lint:check
- corepack pnpm run test:run
- corepack pnpm exec prettier --check src/components/ModelLogo.vue src/views/SearchView/components/SearchBar/index.vue src/views/SearchView/index.vue
- corepack pnpm run build

## AI assistance disclosure
Supported by Codex.