### PR TITLE
fix(agent-service): retry transport send failures

### DIFF
--- a/src/services/AgentService/contracts/errors.spec.ts
+++ b/src/services/AgentService/contracts/errors.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { AiError, AiErrorCode } from './errors';
+
+describe('AiError.fromError', () => {
+    it('classifies low-level send failures as retryable network errors', () => {
+        const error = AiError.fromError(
+            new Error(
+                'Request failed: error sending request for url (https://example.com/v1/chat/completions)'
+            )
+        );
+
+        expect(error.code).toBe(AiErrorCode.NETWORK_ERROR);
+        expect(error.message).toContain('error sending request for url');
+        expect(error.isRetryable()).toBe(true);
+    });
+
+    it('keeps aborted requests non-retryable', () => {
+        const error = AiError.fromError(new Error('The operation was aborted'));
+
+        expect(error.code).toBe(AiErrorCode.REQUEST_CANCELLED);
+        expect(error.isRetryable()).toBe(false);
+    });
+});

--- a/src/services/AgentService/contracts/errors.ts
+++ b/src/services/AgentService/contracts/errors.ts
@@ -85,6 +85,30 @@ const ERROR_MESSAGES: Record<AiErrorCode, string> = {
     [AiErrorCode.UNKNOWN]: '未知错误',
 };
 
+const TRANSIENT_TRANSPORT_ERROR_PATTERNS = [
+    'error sending request',
+    'failed to fetch',
+    'connection refused',
+    'connection reset',
+    'connection closed',
+    'connection aborted',
+    'connection timed out',
+    'connection error',
+    'network unreachable',
+    'temporary failure',
+    'tls handshake',
+    'dns error',
+    'econnrefused',
+    'econnreset',
+    'etimedout',
+    'enotfound',
+    'epipe',
+];
+
+function isTransientTransportErrorMessage(message: string): boolean {
+    return TRANSIENT_TRANSPORT_ERROR_PATTERNS.some((pattern) => message.includes(pattern));
+}
+
 /**
  * AI 服务统一错误类
  */
@@ -169,7 +193,7 @@ export class AiError extends Error {
         const cause = error === undefined ? undefined : error;
 
         if (error instanceof Error || typeof error == 'string') {
-            const message = error instanceof Error ? error.message.toLowerCase() : error;
+            const message = (error instanceof Error ? error.message : error).toLowerCase();
             const originalMessage = error instanceof Error ? error.message : String(error);
 
             // 取消相关（abort / cancel / AbortError）
@@ -184,7 +208,11 @@ export class AiError extends Error {
             }
 
             // 网络错误
-            if (message.includes('network') || message.includes('fetch')) {
+            if (
+                message.includes('network') ||
+                message.includes('fetch') ||
+                isTransientTransportErrorMessage(message)
+            ) {
                 return new AiError(AiErrorCode.NETWORK_ERROR, error, originalMessage, {
                     cause,
                 });


### PR DESCRIPTION
## Summary
- classify low-level HTTP send failures as retryable network errors
- preserve the original provider/transport error message for final failure reporting
- add coverage for send-failure retry classification and cancelled-request handling

Fixes #93

## Testing
- corepack pnpm exec vitest run src/services/AgentService/contracts/errors.spec.ts --passWithNoTests
- corepack pnpm run type:check
- corepack pnpm run lint:check
- corepack pnpm run test:run
- corepack pnpm exec prettier --check src/services/AgentService/contracts/errors.ts src/services/AgentService/contracts/errors.spec.ts

## AI assistance disclosure
Supported by Codex.