### PR TITLE
fix(search): link empty model dropdown to settings

### DIFF
--- a/src/views/PopupView/components/ModelDropdownPopup/index.spec.ts
+++ b/src/views/PopupView/components/ModelDropdownPopup/index.spec.ts
@@ -1,3 +1,5 @@
+// @vitest-environment happy-dom
+
 import { mount } from '@vue/test-utils';
 import { describe, expect, it, vi } from 'vitest';
 

--- a/src/views/PopupView/components/ModelDropdownPopup/index.spec.ts
+++ b/src/views/PopupView/components/ModelDropdownPopup/index.spec.ts
@@ -1,0 +1,75 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+
+import ModelDropdownPopup from './index.vue';
+
+const { openSettingsWindow } = vi.hoisted(() => ({
+    openSettingsWindow: vi.fn(),
+}));
+
+vi.mock('@services/NativeService', () => ({
+    native: {
+        window: {
+            openSettingsWindow,
+        },
+    },
+}));
+
+vi.mock('@components/AppIcon.vue', () => ({
+    default: {
+        name: 'AppIcon',
+        template: '<span data-testid="app-icon" />',
+    },
+}));
+
+vi.mock('@components/ModelCapabilityTags.vue', () => ({
+    default: {
+        name: 'ModelCapabilityTags',
+        template: '<span data-testid="model-capability-tags" />',
+    },
+}));
+
+vi.mock('@components/ModelLogo.vue', () => ({
+    default: {
+        name: 'ModelLogo',
+        template: '<span data-testid="model-logo" />',
+    },
+}));
+
+describe('ModelDropdownPopup', () => {
+    it('shows a settings action when no models are configured', async () => {
+        const wrapper = mount(ModelDropdownPopup, {
+            props: {
+                data: {
+                    activeModelId: '',
+                    activeProviderId: null,
+                    selectedModelId: '',
+                    selectedProviderId: null,
+                    models: [],
+                    searchQuery: '',
+                },
+                isInPopup: true,
+                popupIdentity: {
+                    popupId: 'model-dropdown-popup-1',
+                    windowLabel: 'popup-1',
+                    popupSessionVersion: 1,
+                },
+            },
+            global: {
+                stubs: {
+                    AppIcon: true,
+                    ModelCapabilityTags: true,
+                    ModelLogo: true,
+                },
+            },
+        });
+
+        const settingsButton = wrapper.get('button');
+        expect(settingsButton.text()).toBe('前往设置中心');
+
+        await settingsButton.trigger('click');
+
+        expect(openSettingsWindow).toHaveBeenCalledOnce();
+        expect(wrapper.emitted('close')).toHaveLength(1);
+    });
+});

--- a/src/views/PopupView/components/ModelDropdownPopup/index.vue
+++ b/src/views/PopupView/components/ModelDropdownPopup/index.vue
@@ -4,11 +4,15 @@
     <div
         data-model-dropdown-popover="true"
         :class="[
-            'model-dropdown-popover max-h-96 overflow-hidden rounded-lg border border-stone-200/90 bg-white shadow-lg backdrop-blur',
+            'model-dropdown-popover max-h-96 overflow-hidden rounded-lg border border-stone-200/90 bg-white shadow-lg',
+            hasConfiguredModels || effectiveSearchQuery ? 'backdrop-blur' : '',
             isInPopup ? 'w-full' : 'absolute top-full left-0 z-[9999] mt-2 w-80',
         ]"
     >
-        <div class="border-b border-stone-200/80 px-3 py-2.5">
+        <div
+            v-if="hasConfiguredModels || effectiveSearchQuery"
+            class="border-b border-stone-200/80 px-3 py-2.5"
+        >
             <label
                 class="history-search-field focus-within:border-primary-300 flex items-center gap-2 rounded-lg border border-stone-200 bg-stone-50 px-3 py-2 transition-colors focus-within:bg-white"
             >
@@ -95,6 +99,15 @@
                             : '请先在设置中心配置模型'
                     }}
                 </p>
+                <button
+                    v-if="!effectiveSearchQuery"
+                    type="button"
+                    class="text-primary-600 hover:text-primary-700 mt-1 inline-flex items-center gap-1.5 rounded-md border border-stone-200 bg-white px-2.5 py-1.5 text-xs font-medium shadow-sm transition-colors hover:border-stone-300"
+                    @click="handleOpenSettings"
+                >
+                    <AppIcon name="settings" class="h-3.5 w-3.5" />
+                    <span>前往设置中心</span>
+                </button>
             </div>
         </div>
     </div>
@@ -106,6 +119,7 @@
     import ModelCapabilityTags from '@components/ModelCapabilityTags.vue';
     import ModelLogo from '@components/ModelLogo.vue';
     import { AppEvent, eventService } from '@services/EventService';
+    import { native } from '@services/NativeService';
     import type {
         ModelDropdownData,
         ModelDropdownPopupItem,
@@ -138,6 +152,7 @@
     const selectedProviderId = computed(() => props.data?.selectedProviderId ?? null);
     const searchQuery = computed(() => props.data?.searchQuery ?? '');
     const models = computed<ModelDropdownPopupItem[]>(() => props.data?.models ?? []);
+    const hasConfiguredModels = computed(() => models.value.length > 0);
     const effectiveSearchQuery = computed(() => {
         return localSearchQuery.value.trim() || searchQuery.value.trim();
     });
@@ -179,6 +194,15 @@
             ...props.popupIdentity,
             query: target.value,
         });
+    }
+
+    async function handleOpenSettings() {
+        try {
+            await native.window.openSettingsWindow();
+            emit('close');
+        } catch (error) {
+            console.error('[ModelDropdownPopup] Failed to open settings window:', error);
+        }
     }
 
     const scrollToHighlighted = async () => {


### PR DESCRIPTION
## Summary

Fixes the empty model dropdown state so users can go directly to settings when no models are configured.

- Hide the search header when there are no configured models and no active search query.
- Remove the extra backdrop blur in the no-model empty state.
- Add a "前往设置中心" action that opens the settings window and closes the popup.
- Add component coverage for the new empty-state settings action.

## Related issue or RFC

- Closes #152

## AI assistance disclosure

- Tool(s) used: OpenAI Codex
- Scope of assistance: implemented the focused Vue component change, added the component test, and ran local verification commands.
- Human review or rewrite performed: I reviewed the affected files, verified the UI behavior locally, and confirmed the PR scope before submission.
- Architecture or boundary impact: none.

## Testing evidence

```text
pnpm exec vitest run src/views/PopupView/components/ModelDropdownPopup/index.spec.ts --environment happy-dom
Test Files 1 passed (1), Tests 1 passed (1)

pnpm run lint:check
exit 0

pnpm run type:check
exit 0

pnpm run format:check
All matched files use Prettier code style.

cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check
exit 0

pnpm run check:rust
Finished dev profile with existing dead_code warnings only.

git diff --check HEAD^..HEAD
exit 0
```

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: none.
- database baseline or migration impact: none.
- release or packaging impact: none.

## Screenshots or recordings

Manually verified the no-model dropdown empty state in a local component preview.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] This does not touch `AgentService`, runtime, MCP, or schema boundaries.
- [x] This does not change architecture or add a new cross-boundary abstraction.
- [x] I added tests or explained why tests are not appropriate.
- [x] No docs update is needed for this focused empty-state UI fix.
