### PR TITLE
fix(ui): prevent default provider badge squeeze

### DIFF
--- a/src/views/SettingsView/components/AiServices/components/ProviderCard.vue
+++ b/src/views/SettingsView/components/AiServices/components/ProviderCard.vue
@@ -64,23 +64,24 @@
             :name="provider.name"
             size="small"
             :show-badge="provider.is_builtin === 1"
+            class="shrink-0"
         />
 
         <div class="min-w-0 flex-1">
-            <div class="flex items-center gap-2">
-                <h3 class="truncate font-serif text-sm font-medium text-gray-900">
+            <div class="flex min-w-0 items-center gap-2">
+                <h3 class="min-w-0 flex-1 truncate font-serif text-sm font-medium text-gray-900">
                     {{ provider.name }}
                 </h3>
                 <span
                     v-if="hasDefaultModel"
-                    class="bg-primary-50 text-primary-600 rounded-full px-2 py-0.5 text-xs"
+                    class="bg-primary-50 text-primary-600 shrink-0 rounded-full px-2 py-0.5 text-xs whitespace-nowrap"
                 >
                     默认
                 </span>
             </div>
         </div>
 
-        <label class="relative inline-flex cursor-pointer items-center" @click.stop>
+        <label class="relative inline-flex shrink-0 cursor-pointer items-center" @click.stop>
             <input
                 type="checkbox"
                 :checked="provider.enabled === 1"


### PR DESCRIPTION
## Summary

- Prevent long AI service provider names from squeezing the default badge in provider cards.
- Keep the existing provider card visual style while adding flex shrink/no-wrap layout constraints.

## Related issue or RFC

- Closes #160

## AI assistance disclosure

- Tool(s) used: OpenAI Codex
- Scope of assistance: implemented the frontend layout class changes, ran local validation, and helped prepare the PR.
- Human review or rewrite performed: human user reviewed the behavior locally before the PR was marked ready.
- Architecture or boundary impact: none; frontend-only layout change.

## Testing evidence

```text
pnpm type:check
pnpm lint:check
pnpm format:check
cargo check --manifest-path src-tauri/Cargo.toml --all-targets
```

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: none.
- database baseline or migration impact: none.
- release or packaging impact: none.

## Screenshots or recordings

UI behavior was checked locally with a long provider name in the Settings > AI Services provider card. Screenshot evidence will be added in a PR comment.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.