### PR TITLE
fix(ci): add pull-requests write permission to thanks-on-merge workflow

### DIFF
--- a/.github/workflows/thanks-on-merge.yml
+++ b/.github/workflows/thanks-on-merge.yml
@@ -8,6 +8,7 @@ on:
 permissions:
     contents: read
     issues: write
+    pull-requests: write
 
 jobs:
     thanks-on-merge:


### PR DESCRIPTION
## Summary

Add `pull-requests: write` permission to the `thanks-on-merge` workflow. Without it, the GitHub API returns 403 when the workflow attempts to post a thank-you comment on merged PRs.

The `POST /repos/{owner}/{repo}/issues/{number}/comments` endpoint requires both `issues=write` and `pull_requests=write` permissions (per the `x-accepted-github-permissions` response header). The workflow only declared `issues: write`.

## Related issue or RFC

- Closes #166

## AI assistance disclosure

- Tool(s) used: Claude Code
- Scope of assistance: Diagnosed the 403 error from workflow logs and applied the one-line permission fix
- Human review or rewrite performed: User reviewed and approved
- Architecture or boundary impact: None — CI-only change

## Testing evidence

```text
Workflow is triggered by pull_request_target on merge; the fix can only be verified after merging this PR and triggering a new contributor merge.
```

## Risk notes

- AgentService, runtime, MCP, or schema impact: None
- database baseline or migration impact: None
- release or packaging impact: None

## Screenshots or recordings

N/A — CI-only change with no UI impact.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.