### PR TITLE
fix: accept multiline issue references in PR template check

### DIFF
--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -17,52 +17,13 @@ jobs:
         if: github.event.pull_request.user.type != 'Bot'
         runs-on: ubuntu-latest
         steps:
-            - name: Validate PR body structure and linkage
-              uses: actions/github-script@v9
+            - name: Check out base branch workflow files
+              uses: actions/checkout@v4
               with:
-                  script: |
-                      const body = context.payload.pull_request.body ?? '';
-                      const requiredHeaders = [
-                        '## Summary',
-                        '## Related issue or RFC',
-                        '## AI assistance disclosure',
-                        '## Testing evidence',
-                        '## Risk notes',
-                        '## Screenshots or recordings',
-                        '## Checklist',
-                      ];
+                  ref: ${{ github.event.pull_request.base.sha }}
+                  persist-credentials: false
 
-                      for (const header of requiredHeaders) {
-                        if (!body.includes(header)) {
-                          core.setFailed(`Missing required PR template section: ${header}`);
-                          return;
-                        }
-                      }
-
-                      const relatedSectionMatch = body.match(
-                        /## Related issue or RFC\s+([\s\S]*?)(?=\n## |\s*$)/m,
-                      );
-
-                      if (!relatedSectionMatch) {
-                        core.setFailed('Missing body for "## Related issue or RFC".');
-                        return;
-                      }
-
-                      const relatedSection = relatedSectionMatch[1].trim();
-
-                      if (!relatedSection) {
-                        core.setFailed('"## Related issue or RFC" must not be empty.');
-                        return;
-                      }
-
-                      const issueReferencePattern =
-                        /(?:\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|related to)\s+#\d+\b|(?:^|\s)#\d+\b|TouchAI-org\/TouchAI#\d+\b|https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/(?:issues|pull|discussions)\/\d+\b)/im;
-
-                      if (!issueReferencePattern.test(relatedSection)) {
-                        core.setFailed(
-                          '"## Related issue or RFC" must include an issue, RFC, or repository link.',
-                        );
-                        return;
-                      }
-
-                      core.info('PR template structure and linkage checks passed.');
+            - name: Validate PR body structure and linkage
+              env:
+                  PR_BODY: ${{ github.event.pull_request.body || '' }}
+              run: node scripts/ci/pr-template-check.js

--- a/scripts/ci/pr-template-check.js
+++ b/scripts/ci/pr-template-check.js
@@ -1,0 +1,72 @@
+import { pathToFileURL } from 'node:url';
+
+const REQUIRED_HEADERS = [
+    '## Summary',
+    '## Related issue or RFC',
+    '## AI assistance disclosure',
+    '## Testing evidence',
+    '## Risk notes',
+    '## Screenshots or recordings',
+    '## Checklist',
+];
+
+const ISSUE_REFERENCE_PATTERN =
+    /(?:\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|related to)\s+#\d+\b|(?:^|\s)#\d+\b|TouchAI-org\/TouchAI#\d+\b|https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/(?:issues|pull|discussions)\/\d+\b)/im;
+
+function normalizeBody(body) {
+    return body.replace(/\r\n/g, '\n');
+}
+
+export function extractMarkdownSection(body, header) {
+    const normalizedBody = normalizeBody(body);
+    const headerIndex = normalizedBody.indexOf(header);
+    if (headerIndex < 0) {
+        return null;
+    }
+
+    const sectionStart = headerIndex + header.length;
+    const remainder = normalizedBody.slice(sectionStart);
+    const nextHeaderIndex = remainder.search(/\n## /);
+    const section = nextHeaderIndex < 0 ? remainder : remainder.slice(0, nextHeaderIndex);
+
+    return section.trim();
+}
+
+export function validatePrTemplateBody(body) {
+    for (const header of REQUIRED_HEADERS) {
+        if (!body.includes(header)) {
+            return `Missing required PR template section: ${header}`;
+        }
+    }
+
+    const relatedSection = extractMarkdownSection(body, '## Related issue or RFC');
+    if (relatedSection === null) {
+        return 'Missing body for "## Related issue or RFC".';
+    }
+
+    if (!relatedSection) {
+        return '"## Related issue or RFC" must not be empty.';
+    }
+
+    if (!ISSUE_REFERENCE_PATTERN.test(relatedSection)) {
+        return '"## Related issue or RFC" must include an issue, RFC, or repository link.';
+    }
+
+    return null;
+}
+
+function main() {
+    const body = process.env.PR_BODY ?? '';
+    const error = validatePrTemplateBody(body);
+
+    if (error) {
+        console.error(error);
+        process.exit(1);
+    }
+
+    console.log('PR template structure and linkage checks passed.');
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    main();
+}

--- a/tests/ci/pr-template-check.test.ts
+++ b/tests/ci/pr-template-check.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+async function loadValidator(): Promise<((body: string) => string | null) | undefined> {
+    try {
+        const module = await import('../../scripts/ci/pr-template-check.js');
+        return module.validatePrTemplateBody as (body: string) => string | null;
+    } catch {
+        return undefined;
+    }
+}
+
+describe('validatePrTemplateBody', () => {
+    it('accepts multiline issue references in the Related issue or RFC section', async () => {
+        const validatePrTemplateBody = await loadValidator();
+        const body = `## Summary
+
+Describe the change and the user-facing impact.
+
+## Related issue or RFC
+
+Link the issue or RFC:
+
+- Closes #123
+- Related to #456
+
+## AI assistance disclosure
+
+- Tool(s) used: Codex
+
+## Testing evidence
+
+\`\`\`text
+pnpm test:run
+\`\`\`
+
+## Risk notes
+
+- none
+
+## Screenshots or recordings
+
+None.
+
+## Checklist
+
+- [x] ready`;
+
+        expect(validatePrTemplateBody).toBeTypeOf('function');
+        expect(validatePrTemplateBody?.(body)).toBeNull();
+    });
+
+    it('reports missing issue references when the Related issue or RFC section has no links', async () => {
+        const validatePrTemplateBody = await loadValidator();
+        const body = `## Summary
+
+Describe the change and the user-facing impact.
+
+## Related issue or RFC
+
+Link the issue or RFC:
+
+## AI assistance disclosure
+
+- Tool(s) used: Codex
+
+## Testing evidence
+
+\`\`\`text
+pnpm test:run
+\`\`\`
+
+## Risk notes
+
+- none
+
+## Screenshots or recordings
+
+None.
+
+## Checklist
+
+- [x] ready`;
+
+        expect(validatePrTemplateBody).toBeTypeOf('function');
+        expect(validatePrTemplateBody?.(body)).toBe(
+            '"## Related issue or RFC" must include an issue, RFC, or repository link.'
+        );
+    });
+});


### PR DESCRIPTION
## Summary

Extract the PR template validator into a repository script and fix related-section parsing so multiline issue references are accepted.

Add regression coverage for multiline references and for related sections that still omit links.

## Related issue or RFC

Closes #173

## AI assistance disclosure

- Tool(s) used: Codex
- Scope of assistance: Root cause analysis, validator refactor, regression test authoring, and PR preparation.
- Human review or rewrite performed: I reviewed every affected change locally and adjusted the script entrypoint and formatting.
- Architecture or boundary impact: None.

## Testing evidence

```text
pnpm exec vitest run tests/ci/pr-template-check.test.ts
pnpm exec eslint scripts/ci/pr-template-check.js tests/ci/pr-template-check.test.ts
pnpm exec vue-tsc --noEmit
npx tsc --noEmit
```

## Risk notes

- AgentService, runtime, MCP, or schema impact: none
- database baseline or migration impact: none
- release or packaging impact: low, CI-only validation behavior change

## Screenshots or recordings

None. This change only affects CI validation.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [x] I added tests or explained why tests are not appropriate.
- [ ] I updated docs when behavior changed.
