### PR TITLE
fix(ui): align model dropdown empty state

### DIFF
--- a/src/composables/useWindowResize.ts
+++ b/src/composables/useWindowResize.ts
@@ -28,8 +28,9 @@ export function useWindowResize(options: WindowResizeOptions) {
     const center = options.center ?? isMainWindow;
 
     let resizeObserver: ResizeObserver | null = null;
+    let observedElement: HTMLElement | null = null;
 
-    async function resize(pageHeight: number) {
+    async function resize(pageHeight: number, force = false) {
         const clamped = Math.max(minHeight, Math.min(pageHeight, maxHeight));
         const newHeight = Math.ceil(clamped);
 
@@ -40,7 +41,7 @@ export function useWindowResize(options: WindowResizeOptions) {
             }
         }
 
-        if (newHeight === currentHeight.value) {
+        if (!force && newHeight === currentHeight.value) {
             return;
         }
 
@@ -60,6 +61,7 @@ export function useWindowResize(options: WindowResizeOptions) {
     }
 
     function observeTarget(el: HTMLElement) {
+        observedElement = el;
         resizeObserver = new ResizeObserver((entries) => {
             for (const entry of entries) {
                 const target = entry.target as HTMLElement;
@@ -84,6 +86,7 @@ export function useWindowResize(options: WindowResizeOptions) {
             resizeObserver.disconnect();
             resizeObserver = null;
         }
+        observedElement = null;
     }
 
     watch(
@@ -101,6 +104,11 @@ export function useWindowResize(options: WindowResizeOptions) {
 
     return {
         currentHeight,
+        requestResize: async () => {
+            if (observedElement) {
+                await resize(measureElementHeight(observedElement), true);
+            }
+        },
         resetMeasuredHeight: () => {
             currentHeight.value = 0;
         },

--- a/src/views/PopupView/components/ModelDropdownPopup/index.vue
+++ b/src/views/PopupView/components/ModelDropdownPopup/index.vue
@@ -89,11 +89,18 @@
                     {{ emptyStateMessage }}
                 </p>
                 <p class="text-[11px] leading-4 text-stone-500">
-                    {{
-                        effectiveSearchQuery
-                            ? '可以尝试更短的关键词重新搜索'
-                            : '请先在设置中心配置模型'
-                    }}
+                    <span v-if="effectiveSearchQuery">可以尝试更短的关键词重新搜索</span>
+                    <span v-else class="inline-flex items-baseline">
+                        <span>请先在</span>
+                        <button
+                            type="button"
+                            class="text-primary-600 hover:text-primary-700 decoration-primary-300 cursor-pointer font-medium underline underline-offset-2 transition-colors"
+                            @click="openSettingsFromEmptyState"
+                        >
+                            设置中心
+                        </button>
+                        <span>配置模型</span>
+                    </span>
                 </p>
             </div>
         </div>
@@ -106,6 +113,7 @@
     import ModelCapabilityTags from '@components/ModelCapabilityTags.vue';
     import ModelLogo from '@components/ModelLogo.vue';
     import { AppEvent, eventService } from '@services/EventService';
+    import { native } from '@services/NativeService';
     import type {
         ModelDropdownData,
         ModelDropdownPopupItem,
@@ -166,6 +174,15 @@
             modelDbId,
         });
         emit('close');
+    }
+
+    async function openSettingsFromEmptyState() {
+        try {
+            await native.window.openSettingsWindow();
+            emit('close');
+        } catch (error) {
+            console.error('[SearchView] Failed to open settings from model dropdown:', error);
+        }
     }
 
     function handleSearchInput(event: Event) {

--- a/src/views/PopupView/index.vue
+++ b/src/views/PopupView/index.vue
@@ -21,7 +21,7 @@
         handleKeyDown?: (e: KeyboardEvent) => void;
         handlePopupShown?: () => void;
     } | null>(null);
-    const popupContainer = ref<HTMLElement | null>(null);
+    const popupContent = ref<HTMLElement | null>(null);
     const unlisteners: (() => void)[] = [];
     const closedPopupIds = new Set<string>();
 
@@ -90,8 +90,8 @@
     popupType.value = type;
 
     const config = type ? popupRegistry.get(type) : null;
-    const { resetMeasuredHeight } = useWindowResize({
-        target: popupContainer,
+    const { requestResize, resetMeasuredHeight } = useWindowResize({
+        target: popupContent,
         maxHeight: config?.height,
         minHeight: config?.minHeight,
     });
@@ -127,6 +127,11 @@
                 popupSessionVersion.value = payload.popupSessionVersion;
                 popupType.value = payload.type;
                 popupData.value = payload.data;
+                await nextTick();
+                if (!isCurrentPayloadSession(payload)) {
+                    return;
+                }
+                await requestResize();
                 // 原生窗口已由 PopupManager.show() 显示；PopupView 只在首次数据到达后接管焦点与初始选中态。
                 if (payload.isShow) {
                     await nextTick();
@@ -196,14 +201,10 @@
 </script>
 
 <template>
-    <div ref="popupContainer" class="popup-container w-screen bg-transparent">
-        <component
-            :is="popupComponent"
-            v-if="popupComponent"
-            ref="componentRef"
-            v-bind="popupProps"
-            @close="close"
-        />
+    <div class="popup-container w-screen bg-transparent">
+        <div v-if="popupComponent" ref="popupContent" class="popup-content w-screen">
+            <component :is="popupComponent" ref="componentRef" v-bind="popupProps" @close="close" />
+        </div>
     </div>
 </template>
 


### PR DESCRIPTION
﻿## Summary

- Make the model dropdown empty-state text actionable by turning `设置中心` into an inline settings link.
- Resize popup windows against actual popup content so short empty states do not leave an extra translucent glass panel.
- Force a content-height resize whenever popup data is shown or refreshed, covering reopen cases where the native popup starts at its registered max height.

## Related issue or RFC

Closes #152

## AI assistance disclosure

- Tool(s) used: OpenAI Codex
- Scope of assistance: implementation, local validation, and PR preparation
- Human review or rewrite performed: manually verified the UI behavior and requested the inline-link design
- Architecture or boundary impact: no AgentService, runtime, MCP, schema, or public API changes; this is limited to popup sizing and UI behavior

## Testing evidence

```text
pnpm type:check
pnpm lint:check
pnpm format:check
cargo check --manifest-path src-tauri/Cargo.toml --all-targets
```

Also manually verified the empty model dropdown state opens Settings from the inline `设置中心` link and no longer leaves the extra glass panel below the dropdown content.

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: none
- database baseline or migration impact: none
- release or packaging impact: none

## Screenshots or recordings

<img width="824" height="316" alt="image" src="https://github.com/user-attachments/assets/ec9ac648-b80c-4516-a7d7-16e3c43e1262" />

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.
