### PR TITLE
feat: add pagination, list view, and context menu to quick search (#78)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -56,3 +56,4 @@ rust-temp/
 
 src-tauri/target/**/*
 src-tauri/gen/**/*
+.claude/

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
         "@types/node": "^25.8.0",
         "@types/turndown": "^5.0.6",
         "@vitejs/plugin-vue": "^6.0.7",
-        "@vitest/coverage-v8": "^4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
         "@vitest/ui": "^4.1.6",
         "@vue/test-utils": "^2.4.10",
         "drizzle-kit": "^0.31.10",

--- a/src-tauri/src/commands/quick_search.rs
+++ b/src-tauri/src/commands/quick_search.rs
@@ -4,15 +4,16 @@
 
 use std::collections::HashMap;
 
-use crate::core::search::{self, QuickSearchFileItem, QuickSearchStatus, QuickShortcutItem};
+use crate::core::search::{self, QuickSearchFileItem, QuickSearchResult, QuickSearchStatus};
 
 /// 搜索快捷项（前端主查询入口）。
 #[tauri::command]
 pub async fn quick_search_search_shortcuts(
     query: String,
-    limit: Option<usize>,
-) -> Result<Vec<QuickShortcutItem>, String> {
-    search::quick_search_search_shortcuts(query, limit).await
+    page_size: Option<usize>,
+    offset: Option<u32>,
+) -> Result<QuickSearchResult, String> {
+    search::quick_search_search_shortcuts(query, page_size, offset).await
 }
 
 /// 搜索普通文件（内置 `file_search` 工具入口）。

--- a/src-tauri/src/core/search/manager.rs
+++ b/src-tauri/src/core/search/manager.rs
@@ -7,7 +7,7 @@
 //! 2. 组合“本地索引 + Everything 前台查询”的两阶段搜索；
 //! 3. 在后台异步补全 `.lnk` 目标信息，避免把主查询链路拖慢。
 
-use super::types::{QuickSearchFileItem, QuickSearchStatus, QuickShortcutItem};
+use super::types::{QuickSearchFileItem, QuickSearchResult, QuickSearchStatus, QuickShortcutItem};
 use log::{debug, warn};
 use std::{
     collections::{HashMap, HashSet, VecDeque},
@@ -47,9 +47,6 @@ use sync::{lock_mutex, read_lock, try_lock_mutex, write_lock};
 const INDEX_REFRESH_TTL: Duration = Duration::from_secs(30);
 const TARGET_RESOLVER_WORKERS: usize = 2;
 const EVERYTHING_QUERY_MIN_RESULTS: usize = 24;
-const EVERYTHING_QUERY_MAX_RESULTS: usize = 120;
-const EVERYTHING_QUERY_LIMIT_MULTIPLIER: usize = 2;
-const EVERYTHING_QUERY_EXTRA_RESULTS: usize = 12;
 
 /// 快速搜索调度器。
 struct QuickSearchManager {
@@ -94,27 +91,44 @@ impl QuickSearchManager {
         }
     }
 
-    /// 执行两阶段搜索。
+    /// 执行两阶段分页搜索。
     ///
-    /// 第一阶段优先走本地快捷方式索引，保证大部分查询能以低延迟返回；
-    /// 如果索引结果不足，再前台补查 Everything 普通文件，把剩余名额补齐。
-    /// 这样既保留了快捷方式排序质量，也避免所有查询都落到较重的 IPC 调用上。
-    fn search(self: &'static Self, query: &str, limit: usize) -> Vec<QuickShortcutItem> {
+    /// 第一阶段获取全部匹配的快捷方式（不限制数量）；
+    /// 第二阶段从 Everything 获取文件结果并按页切片。
+    /// 返回 QuickSearchResult，shortcuts 仅在 page=0 时非空。
+    fn search(
+        self: &'static Self,
+        query: &str,
+        page_size: usize,
+        offset: u32,
+    ) -> QuickSearchResult {
         let trimmed_query = query.trim();
         if trimmed_query.is_empty() {
-            return Vec::new();
+            return QuickSearchResult {
+                shortcuts: Vec::new(),
+                files: Vec::new(),
+                total_files: 0,
+                total_results: 0,
+                next_offset: 0,
+            };
         }
 
         let query_tokens = tokenize_query(trimmed_query);
         if query_tokens.is_empty() {
-            return Vec::new();
+            return QuickSearchResult {
+                shortcuts: Vec::new(),
+                files: Vec::new(),
+                total_files: 0,
+                total_results: 0,
+                next_offset: 0,
+            };
         }
 
         let started = Instant::now();
         let state = read_lock(&self.state);
         let shortcut_records = &state.records;
 
-        // 第一阶段：用本地索引做模糊匹配排序。
+        // 第一阶段：用本地索引做模糊匹配，获取全部匹配快捷方式。
         let mut shortcut_entries: Vec<(QuickShortcutItem, i32, String, String, String)> =
             shortcut_records
                 .iter()
@@ -140,12 +154,9 @@ impl QuickSearchManager {
                 .then_with(|| left.3.cmp(&right.3))
         });
 
-        // 两套去重同时存在：
-        // - 快捷方式去重键：去掉指向同一目标的重复快捷方式别名；
-        // - 路径：避免第二阶段文件结果把第一阶段已有路径重新塞回来。
         let mut seen_paths = HashSet::new();
         let mut seen_shortcut_keys = HashSet::new();
-        let mut results = Vec::with_capacity(limit);
+        let mut matched_shortcuts = Vec::new();
 
         for (item, _, dedupe_key, path_norm, _) in shortcut_entries {
             if !seen_shortcut_keys.insert(dedupe_key) {
@@ -154,50 +165,35 @@ impl QuickSearchManager {
             if !seen_paths.insert(path_norm) {
                 continue;
             }
-            results.push(item);
-            if results.len() >= limit {
-                break;
-            }
+            matched_shortcuts.push(item);
         }
 
-        let remaining_slots = limit.saturating_sub(results.len());
-        if remaining_slots == 0 {
-            debug!(
-                "[QuickSearch] fuzzy_match_ms={} result_count={} stage=shortcut_only",
-                started.elapsed().as_millis(),
-                results.len()
-            );
-            return results;
-        }
+        let shortcut_count = matched_shortcuts.len();
 
-        let query_limit = (remaining_slots
-            .saturating_mul(EVERYTHING_QUERY_LIMIT_MULTIPLIER)
-            .saturating_add(EVERYTHING_QUERY_EXTRA_RESULTS))
-        .clamp(EVERYTHING_QUERY_MIN_RESULTS, EVERYTHING_QUERY_MAX_RESULTS);
+        // 第二阶段：从 Everything 获取文件，使用 offset 翻页，多取一些补偿去重损耗。
+        let fetch_limit = (page_size + shortcut_count).max(EVERYTHING_QUERY_MIN_RESULTS);
+        let fetch_offset = offset;
 
-        // 第二阶段：尝试前台向 Everything 查询补足普通文件结果。
-        let everything_paths = match try_lock_mutex(&self.everything_client) {
-            Some(mut client) => match client.query_paths(trimmed_query, query_limit as u32) {
-                Ok(paths) => Some(paths),
+        // 等待 Everything 客户端锁可用（refresh_worker 可能正在占用）。
+        let mut client = lock_mutex(&self.everything_client);
+        let everything_result =
+            match client.query_file_paths(trimmed_query, fetch_limit as u32, fetch_offset, false) {
+                Ok(result) => Some(result),
                 Err(error) => {
                     debug!(
-                        "[QuickSearch] foreground query failed, fallback to cached results only: {}",
-                        error.message
-                    );
+                    "[QuickSearch] foreground query failed, fallback to cached results only: {}",
+                    error.message
+                );
                     None
                 }
-            },
-            None => {
-                debug!(
-                    "[QuickSearch] everything client busy, skip foreground file query this round"
-                );
-                None
-            }
-        };
+            };
+        drop(client);
 
-        let mut file_entries: Vec<(QuickShortcutItem, bool, String, String)> = Vec::new();
-        if let Some(paths) = everything_paths {
-            for path in paths {
+        let mut total_results: u32 = 0;
+        let mut deduped_files: Vec<QuickShortcutItem> = Vec::new();
+        if let Some(result) = everything_result {
+            total_results = result.total;
+            for path in result.paths {
                 let path_norm = normalize_path_str(&path);
                 if seen_paths.contains(&path_norm) {
                     continue;
@@ -208,50 +204,48 @@ impl QuickSearchManager {
                 let Some(name) = display_name_from_path(path_obj, is_shortcut) else {
                     continue;
                 };
-                let name_norm = normalize_for_match(&name);
                 let source = if is_shortcut {
                     classify_shortcut_source(&path_norm, &self.roots).to_string()
                 } else {
                     "file".to_string()
                 };
 
-                file_entries.push((
-                    QuickShortcutItem { name, path, source },
-                    is_shortcut,
-                    path_norm,
-                    name_norm,
-                ));
+                seen_paths.insert(path_norm);
+                deduped_files.push(QuickShortcutItem { name, path, source });
             }
         }
 
-        file_entries.sort_by(|left, right| {
-            right
-                .1
-                .cmp(&left.1)
-                .then_with(|| left.3.cmp(&right.3))
-                .then_with(|| left.2.cmp(&right.2))
-        });
+        // 文件按名称排序，保证分页稳定。
+        deduped_files.sort_by(|left, right| left.name.cmp(&right.name));
 
-        for (item, _, path_norm, _) in file_entries {
-            if !seen_paths.insert(path_norm) {
-                continue;
-            }
-            results.push(item);
-            if results.len() >= limit {
-                break;
-            }
-        }
+        // 已按 offset 从 Everything 获取，直接取前 page_size 条（去重后可能少于 page_size）。
+        let total_files = deduped_files.len();
+        let files = deduped_files[..total_files.min(page_size)].to_vec();
+
+        let shortcuts = if offset == 0 {
+            matched_shortcuts
+        } else {
+            Vec::new()
+        };
 
         debug!(
-            "[QuickSearch] fuzzy_match_ms={} result_count={} query_limit={}",
+            "[QuickSearch] fuzzy_match_ms={} shortcut_count={} total_files={} offset={} page_size={}",
             started.elapsed().as_millis(),
-            results.len(),
-            query_limit
+            shortcut_count,
+            total_files,
+            offset,
+            page_size
         );
 
-        // 异步触发后台刷新，不阻塞当前搜索返回。
         let _ = self.refresh_index(false, true);
-        results
+
+        QuickSearchResult {
+            shortcuts,
+            files,
+            total_files,
+            total_results,
+            next_offset: offset + fetch_limit as u32,
+        }
     }
 
     /// 直接查询 Everything 普通文件结果。
@@ -278,8 +272,9 @@ impl QuickSearchManager {
             }
 
             client
-                .query_file_paths(trimmed_query, limit as u32, include_shortcuts)
+                .query_file_paths(trimmed_query, limit as u32, 0, include_shortcuts)
                 .map_err(|error| self.map_everything_error(error))?
+                .paths
         };
 
         self.mark_everything_ready();
@@ -669,9 +664,9 @@ pub fn get_status() -> QuickSearchStatus {
     manager().status()
 }
 
-/// 执行搜索并返回排序后的快捷项结果。
-pub fn search_shortcuts(query: &str, limit: usize) -> Vec<QuickShortcutItem> {
-    manager().search(query, limit.max(1))
+/// 执行分页搜索并返回快捷方式与文件结果。
+pub fn search_shortcuts(query: &str, page_size: usize, offset: u32) -> QuickSearchResult {
+    manager().search(query, page_size.max(1), offset)
 }
 
 /// 执行文件搜索并返回 Everything 结果。

--- a/src-tauri/src/core/search/mod.rs
+++ b/src-tauri/src/core/search/mod.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 use tauri::async_runtime;
 
 mod types;
-pub use types::{QuickSearchFileItem, QuickSearchStatus, QuickShortcutItem};
+pub use types::{QuickSearchFileItem, QuickSearchResult, QuickSearchStatus};
 
 #[cfg(target_os = "windows")]
 mod assets;
@@ -20,6 +20,8 @@ mod manager;
 #[cfg(target_os = "windows")]
 mod provider_everything;
 
+const DEFAULT_PAGE_SIZE: usize = 60;
+const MAX_PAGE_SIZE: usize = 200;
 const DEFAULT_LIMIT: usize = 60;
 const MAX_LIMIT: usize = 200;
 const DEFAULT_ICON_SIZE: u32 = 48;
@@ -33,19 +35,24 @@ const MAX_ICON_SIZE: u32 = 256;
 #[cfg(target_os = "windows")]
 pub async fn quick_search_search_shortcuts(
     query: String,
-    limit: Option<usize>,
-) -> Result<Vec<QuickShortcutItem>, String> {
-    // 限制查询条数，避免前端一次性请求过多结果。
-    let normalized_limit = limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
+    page_size: Option<usize>,
+    offset: Option<u32>,
+) -> Result<QuickSearchResult, String> {
+    let normalized_page_size = page_size
+        .unwrap_or(DEFAULT_PAGE_SIZE)
+        .clamp(1, MAX_PAGE_SIZE);
+    let normalized_offset = offset.unwrap_or(0);
     // 搜索过程含阻塞调用，放到阻塞线程池避免卡住异步运行时。
-    let shortcuts =
-        async_runtime::spawn_blocking(move || manager::search_shortcuts(&query, normalized_limit))
-            .await
-            .map_err(|err| format!("quick_search_search_shortcuts task join failed: {}", err))?;
+    let result = async_runtime::spawn_blocking(move || {
+        manager::search_shortcuts(&query, normalized_page_size, normalized_offset)
+    })
+    .await
+    .map_err(|err| format!("quick_search_search_shortcuts task join failed: {}", err))?;
 
     // 记住返回路径，缩略图请求按白名单校验。
-    assets::remember_search_paths(&shortcuts);
-    Ok(shortcuts)
+    assets::remember_search_paths(&result.shortcuts);
+    assets::remember_search_paths(&result.files);
+    Ok(result)
 }
 
 /// 搜索普通文件列表（Windows）。
@@ -70,11 +77,17 @@ pub async fn quick_search_search_files(
 /// 搜索快捷项列表（非 Windows 平台降级实现）。
 #[cfg(not(target_os = "windows"))]
 pub async fn quick_search_search_shortcuts(
-    query: String,
-    _limit: Option<usize>,
-) -> Result<Vec<QuickShortcutItem>, String> {
-    let _ = query;
-    Ok(Vec::new())
+    _query: String,
+    _page_size: Option<usize>,
+    _offset: Option<u32>,
+) -> Result<QuickSearchResult, String> {
+    Ok(QuickSearchResult {
+        shortcuts: Vec::new(),
+        files: Vec::new(),
+        total_files: 0,
+        total_results: 0,
+        next_offset: 0,
+    })
 }
 
 /// 搜索普通文件列表（非 Windows 平台降级实现）。

--- a/src-tauri/src/core/search/provider_everything.rs
+++ b/src-tauri/src/core/search/provider_everything.rs
@@ -30,6 +30,15 @@ impl EverythingError {
     }
 }
 
+/// Everything 查询结果。
+#[derive(Debug)]
+pub(crate) struct QueryPathsResult {
+    /// 当前页的路径列表。
+    pub(crate) paths: Vec<String>,
+    /// Everything 报告的匹配总数。
+    pub(crate) total: u32,
+}
+
 /// Everything 查询客户端（轻量无状态包装）。
 pub(crate) struct EverythingClient;
 
@@ -64,7 +73,8 @@ impl EverythingClient {
         &mut self,
         search_text: &str,
         max_results: u32,
-    ) -> Result<Vec<String>, EverythingError> {
+        offset: u32,
+    ) -> Result<QueryPathsResult, EverythingError> {
         unsafe {
             // 每次查询前重置 SDK 内部状态，避免沿用上次参数。
             Everything_Reset();
@@ -76,6 +86,7 @@ impl EverythingClient {
             Everything_SetMatchCase(0);
             Everything_SetRegex(0);
             Everything_SetMax(max_results);
+            Everything_SetOffset(offset);
 
             if Everything_QueryW(1) == 0 {
                 let error_code = Everything_GetLastError();
@@ -87,6 +98,7 @@ impl EverythingClient {
                 });
             }
 
+            let total = Everything_GetTotResults();
             let result_count = Everything_GetNumResults();
             let mut results = Vec::with_capacity(result_count as usize);
             // 复用缓冲区以减少每条结果的分配开销。
@@ -115,7 +127,10 @@ impl EverythingClient {
             }
 
             Everything_Reset();
-            Ok(results)
+            Ok(QueryPathsResult {
+                paths: results,
+                total,
+            })
         }
     }
 
@@ -124,11 +139,15 @@ impl EverythingClient {
         &mut self,
         search_text: &str,
         max_results: u32,
+        offset: u32,
         include_shortcuts: bool,
-    ) -> Result<Vec<String>, EverythingError> {
+    ) -> Result<QueryPathsResult, EverythingError> {
         let trimmed_query = search_text.trim();
         if trimmed_query.is_empty() {
-            return Ok(Vec::new());
+            return Ok(QueryPathsResult {
+                paths: Vec::new(),
+                total: 0,
+            });
         }
 
         let mut query_parts = vec![EVERYTHING_FILE_ONLY_FILTER.to_string()];
@@ -136,10 +155,10 @@ impl EverythingClient {
             query_parts.push(EVERYTHING_EXCLUDE_SHORTCUT_FILTER.to_string());
         }
         // 把过滤器前缀和用户查询拼成一次 Everything 搜索表达式，
-        // 这样“只搜文件 / 是否包含 .lnk”两个约束始终在同一个 IPC 请求里生效。
+        // 这样"只搜文件 / 是否包含 .lnk"两个约束始终在同一个 IPC 请求里生效。
         query_parts.push(trimmed_query.to_string());
 
-        self.query_paths(&query_parts.join(" "), max_results)
+        self.query_paths(&query_parts.join(" "), max_results, offset)
     }
 
     /// 查询系统中所有快捷方式路径。
@@ -147,7 +166,9 @@ impl EverythingClient {
         self.query_paths(
             EVERYTHING_SHORTCUT_SEARCH_TERM,
             EVERYTHING_QUERY_ALL_RESULTS,
+            0,
         )
+        .map(|result| result.paths)
     }
 }
 
@@ -161,8 +182,10 @@ unsafe extern "system" {
     fn Everything_SetMatchCase(bEnable: i32);
     fn Everything_SetRegex(bEnable: i32);
     fn Everything_SetMax(dwMax: u32);
+    fn Everything_SetOffset(dwOffset: u32);
     fn Everything_QueryW(bWait: i32) -> i32;
     fn Everything_GetNumResults() -> u32;
+    fn Everything_GetTotResults() -> u32;
     fn Everything_GetResultFullPathNameW(
         dwIndex: u32,
         wbuf: *mut u16,

--- a/src-tauri/src/core/search/types.rs
+++ b/src-tauri/src/core/search/types.rs
@@ -24,6 +24,21 @@ pub struct QuickSearchFileItem {
     pub path: String,
 }
 
+/// 分页搜索结果。
+#[derive(Debug, Clone, Serialize)]
+pub struct QuickSearchResult {
+    /// 匹配的快捷方式列表（仅 page=0 时非空）。
+    pub shortcuts: Vec<QuickShortcutItem>,
+    /// 当前页的文件结果。
+    pub files: Vec<QuickShortcutItem>,
+    /// 去重后的文件结果总数（用于分页）。
+    pub total_files: usize,
+    /// Everything 报告的匹配总数（用于状态栏显示）。
+    pub total_results: u32,
+    /// 下次 loadMore 应传回的 Everything 偏移量。
+    pub next_offset: u32,
+}
+
 /// 快速搜索运行时状态快照。
 #[derive(Debug, Clone, Serialize)]
 pub struct QuickSearchStatus {

--- a/src/components/appIconMap.ts
+++ b/src/components/appIconMap.ts
@@ -17,9 +17,11 @@ import IconFile from '~icons/bx/file';
 import IconFileBlank from '~icons/bx/file-blank';
 import IconFolderOpen from '~icons/bx/folder-open';
 import IconFullscreen from '~icons/bx/fullscreen';
+import IconGridAlt from '~icons/bx/grid-alt';
 import IconHide from '~icons/bx/hide';
 import IconHistory from '~icons/bx/history';
 import IconInfoCircle from '~icons/bx/info-circle';
+import IconMenu from '~icons/bx/menu';
 import IconMinus from '~icons/bx/minus';
 import IconPin from '~icons/bx/pin';
 import IconPlay from '~icons/bx/play';
@@ -53,7 +55,9 @@ export const appIconMap = {
     file: IconFile,
     'folder-open': IconFolderOpen,
     fullscreen: IconFullscreen,
+    'grid-alt': IconGridAlt,
     history: IconHistory,
+    'list-ul': IconMenu,
     'information-circle': IconInfoCircle,
     llm: IconBrain,
     mcp: IconPlug,

--- a/src/composables/useContextMenu.ts
+++ b/src/composables/useContextMenu.ts
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2026. 千诚. Licensed under GPL v3.
+// Copyright (c) 2026. 千诚. Licensed under GPL v3.
 
 import type { AppIconName } from '@components/appIconMap';
 import ContextMenuVue from '@components/ContextMenu.vue';
@@ -18,8 +18,14 @@ export function useContextMenu<T = void>(
     const context = ref<T | undefined>(undefined) as { value: T | undefined };
     let mountedApp: App | null = null;
     let container: HTMLDivElement | null = null;
+    let keydownHandler: ((e: KeyboardEvent) => void) | null = null;
+    let activeIndex = 0;
 
     const cleanup = () => {
+        if (keydownHandler) {
+            document.removeEventListener('keydown', keydownHandler, true);
+            keydownHandler = null;
+        }
         if (mountedApp) {
             mountedApp.unmount();
             mountedApp = null;
@@ -28,13 +34,48 @@ export function useContextMenu<T = void>(
             container.remove();
             container = null;
         }
+        activeIndex = 0;
     };
+
+    /** 获取当前菜单项元素列表。 */
+    function getMenuItems(): HTMLElement[] {
+        if (!container) return [];
+        const menuEl = container.querySelector('[role="menu"]');
+        if (!menuEl) return [];
+        return Array.from(menuEl.querySelectorAll('[role="menuitem"]')) as HTMLElement[];
+    }
+
+    /** 更新视觉高亮：手动设置 data-highlighted 属性。 */
+    function updateHighlight() {
+        const items = getMenuItems();
+        if (items.length === 0) return;
+        activeIndex = Math.min(activeIndex, items.length - 1);
+        items.forEach((el, i) => {
+            if (i === activeIndex) {
+                el.setAttribute('data-highlighted', '');
+                el.scrollIntoView({ block: 'nearest' });
+            } else {
+                el.removeAttribute('data-highlighted');
+            }
+        });
+    }
+
+    /** 选中当前高亮项。 */
+    function selectActive() {
+        const items = getMenuItems();
+        const el = items[activeIndex];
+        if (!el) return;
+        el.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+        el.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+        el.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    }
 
     const open = (event: MouseEvent, ctx?: T) => {
         event.preventDefault();
         cleanup();
 
         context.value = ctx;
+        activeIndex = 0;
         container = document.createElement('div');
         document.body.appendChild(container);
 
@@ -51,7 +92,56 @@ export function useContextMenu<T = void>(
             onClose: cleanup,
         });
         mountedApp.mount(container);
+
+        // 在 document 上以捕获模式监听键盘，优先于主应用的键盘路由。
+        keydownHandler = (e: KeyboardEvent) => {
+            const menuEl = document.querySelector('[role="menu"]');
+            const menuItems = menuEl?.querySelectorAll('[role="menuitem"]');
+            const itemCount = menuItems?.length ?? 0;
+
+            switch (e.key) {
+                case 'Escape':
+                case 'Esc':
+                    e.preventDefault();
+                    e.stopPropagation();
+                    cleanup();
+                    break;
+                case 'ArrowUp':
+                    e.preventDefault();
+                    e.stopPropagation();
+                    if (itemCount > 0) {
+                        activeIndex = (activeIndex - 1 + itemCount) % itemCount;
+                        updateHighlight();
+                    }
+                    break;
+                case 'ArrowDown':
+                    e.preventDefault();
+                    e.stopPropagation();
+                    if (itemCount > 0) {
+                        activeIndex = (activeIndex + 1) % itemCount;
+                        updateHighlight();
+                    }
+                    break;
+                case 'Enter':
+                    e.preventDefault();
+                    e.stopPropagation();
+                    selectActive();
+                    break;
+                default:
+                    // 其它键不拦截，但阻止传播到主应用。
+                    e.stopPropagation();
+                    break;
+            }
+        };
+        document.addEventListener('keydown', keydownHandler, true);
+
+        // 初始高亮第一项。
+        requestAnimationFrame(() => updateHighlight());
     };
 
-    return { open };
+    const close = () => {
+        cleanup();
+    };
+
+    return { open, close };
 }

--- a/src/services/NativeService/index.ts
+++ b/src/services/NativeService/index.ts
@@ -25,6 +25,7 @@ export type {
     ClipboardPayload,
     PopupConfig,
     QuickSearchFileItem,
+    QuickSearchResult,
     QuickSearchStatus,
     QuickShortcutItem,
     ResizeWindowHeightParams,

--- a/src/services/NativeService/quickSearch.ts
+++ b/src/services/NativeService/quickSearch.ts
@@ -1,18 +1,22 @@
 import { invoke } from '@tauri-apps/api/core';
 
-import type { QuickSearchFileItem, QuickSearchStatus, QuickShortcutItem } from './types';
+import type { QuickSearchFileItem, QuickSearchResult, QuickSearchStatus } from './types';
 
-const DEFAULT_LIMIT = 60;
+const DEFAULT_PAGE_SIZE = 60;
 const DEFAULT_ICON_SIZE = 48;
 
 export const quickSearch = {
-    searchShortcuts(query: string, limit = DEFAULT_LIMIT): Promise<QuickShortcutItem[]> {
-        return invoke('quick_search_search_shortcuts', { query, limit });
+    searchShortcuts(
+        query: string,
+        pageSize = DEFAULT_PAGE_SIZE,
+        offset = 0
+    ): Promise<QuickSearchResult> {
+        return invoke('quick_search_search_shortcuts', { query, pageSize, offset });
     },
 
     searchFiles(
         query: string,
-        limit = DEFAULT_LIMIT,
+        limit = DEFAULT_PAGE_SIZE,
         options?: { includeShortcuts?: boolean }
     ): Promise<QuickSearchFileItem[]> {
         return invoke('quick_search_search_files', {

--- a/src/services/NativeService/types.ts
+++ b/src/services/NativeService/types.ts
@@ -124,3 +124,11 @@ export interface QuickSearchStatus {
     last_refresh_ms: number | null;
     last_error: string | null;
 }
+
+export interface QuickSearchResult {
+    shortcuts: QuickShortcutItem[];
+    files: QuickShortcutItem[];
+    total_files: number;
+    total_results: number;
+    next_offset: number;
+}

--- a/src/views/SearchView/components/QuickSearchPanel/QuickSearchListItem.vue
+++ b/src/views/SearchView/components/QuickSearchPanel/QuickSearchListItem.vue
@@ -1,0 +1,62 @@
+<!--
+  - Copyright (c) 2026. Qian Cheng. Licensed under GPL v3
+  -->
+
+<template>
+    <button
+        type="button"
+        :class="[
+            'quick-search-list-item grid w-full cursor-pointer items-center px-2 outline-none',
+            highlighted ? 'bg-primary-100 rounded-lg' : 'rounded-lg hover:bg-gray-100',
+        ]"
+        :style="{
+            height: `${rowHeight}px`,
+            gridTemplateColumns: 'var(--qs-icon-size) var(--qs-name-width) 1fr',
+            gap: '8px',
+        }"
+        @click="$emit('click')"
+        @contextmenu.prevent="$emit('contextmenu', $event)"
+    >
+        <div class="flex h-4 w-4 items-center justify-center">
+            <img v-if="iconSrc" :src="iconSrc" :alt="name" class="h-4 w-4 rounded object-contain" />
+            <div v-else class="h-4 w-4 rounded-sm bg-gray-200"></div>
+        </div>
+        <span class="truncate text-left text-[13px] leading-4 text-gray-700">
+            <span
+                v-for="(segment, i) in nameSegments"
+                :key="i"
+                :class="segment.matched ? 'quick-search-name-match' : ''"
+            >
+                {{ segment.text }}
+            </span>
+        </span>
+        <span v-if="path" class="truncate text-left text-[12px] leading-4 text-gray-400">
+            {{ path }}
+        </span>
+    </button>
+</template>
+
+<script setup lang="ts">
+    import type { NameSegment } from './utils/quickSearchHighlight';
+
+    defineOptions({
+        name: 'QuickSearchListItem',
+    });
+
+    withDefaults(
+        defineProps<{
+            name: string;
+            path: string;
+            iconSrc: string | undefined;
+            nameSegments: NameSegment[];
+            highlighted: boolean;
+            rowHeight?: number;
+        }>(),
+        { rowHeight: 40 }
+    );
+
+    defineEmits<{
+        click: [];
+        contextmenu: [event: MouseEvent];
+    }>();
+</script>

--- a/src/views/SearchView/components/QuickSearchPanel/composables/useAssetLoader.ts
+++ b/src/views/SearchView/components/QuickSearchPanel/composables/useAssetLoader.ts
@@ -355,6 +355,15 @@ export function useAssetLoader(
             }
         }
 
+        let pendingTimer: ReturnType<typeof setTimeout> | null = null;
+
+        function clearPendingTimer() {
+            if (pendingTimer !== null) {
+                clearTimeout(pendingTimer);
+                pendingTimer = null;
+            }
+        }
+
         function scheduleLoad(reqId = requestId.value, immediate = false) {
             if (!isOpen.value || reqId !== requestId.value) return;
 
@@ -367,14 +376,16 @@ export function useAssetLoader(
                 return;
             }
 
+            clearPendingTimer();
             config.clearTimer();
             const delay = immediate ? 0 : config.delayMs;
-            setTimeout(() => {
+            pendingTimer = setTimeout(() => {
+                pendingTimer = null;
                 void loadBatch(requestId.value);
             }, delay);
         }
 
-        return { loadBatch, scheduleLoad };
+        return { loadBatch, scheduleLoad, clearPendingTimer };
     }
 
     // 间接引用，让 createBatchLoader 内部的 schedule 回调能指向最终的 scheduleLoad。
@@ -492,6 +503,8 @@ export function useAssetLoader(
         // 统一收敛所有加载状态，供 close/hide/新查询复用。
         clearIconLoadTimer();
         clearImageLoadTimer();
+        iconLoader.clearPendingTimer();
+        imageLoader.clearPendingTimer();
         iconLoadPending = false;
         iconLoadInFlight = false;
         imageLoadPending = false;

--- a/src/views/SearchView/components/QuickSearchPanel/composables/useAssetLoader.ts
+++ b/src/views/SearchView/components/QuickSearchPanel/composables/useAssetLoader.ts
@@ -2,19 +2,19 @@ import { native, type QuickShortcutItem } from '@services/NativeService';
 import { getPathExtension, IMAGE_EXTENSIONS } from '@utils/path';
 import { type Ref, ref } from 'vue';
 
-import { ITEM_SIZE_PX } from './useLayout';
+import { ITEM_SIZE_PX, LIST_ROW_HEIGHT_PX, type ViewMode } from './useLayout';
 
 const LIMIT = 60; // 缓存裁剪阈值基数（触发条件约为 LIMIT * 6）
 const ICON_LOAD_DELAY_MS = 220; // 图标批次调度延时（非立即模式）
-const ICON_SCROLL_THROTTLE_MS = 40; // 滚动后重新排队加载的节流窗口
+const SCROLL_THROTTLE_MS = 40; // 滚动后重新排队加载的节流窗口
 const ICON_BATCH_SIZE = 4; // 单批图标请求数量
 const ICON_MAX_ATTEMPTS = 2; // 单个图标的最大重试次数
 const IMAGE_LOAD_DELAY_MS = 120; // 图片批次调度延时（非立即模式）
 const IMAGE_BATCH_SIZE = 2; // 单批图片预览请求数量
 const IMAGE_MAX_ATTEMPTS = 2; // 单张图片预览的最大重试次数
 const IMAGE_THUMB_SIZE = 56; // 图片缩略图尺寸（px）
-const ICON_PRELOAD_MIN_COUNT = 8; // 队列不足时顶部预热的最小目标数
-const ICON_VIEWPORT_BUFFER_ROWS = 1; // 视口上下额外预加载行数
+const PRELOAD_MIN_COUNT = 8; // 队列不足时顶部预热的最小目标数
+const VIEWPORT_BUFFER_ROWS = 1; // 视口上下额外预加载行数
 const ICON_SIZE = 48; // 图标请求尺寸（px）
 
 interface UseAssetLoaderOptions {
@@ -27,6 +27,7 @@ interface UseAssetLoaderOptions {
     gridGap: Ref<number>;
     selectionMaxHeight: Ref<number>;
     scrollRef: Ref<HTMLElement | null>;
+    viewMode: Ref<ViewMode>;
 }
 
 export interface UseAssetLoaderDeps {
@@ -62,6 +63,7 @@ export function useAssetLoader(
         gridGap,
         selectionMaxHeight,
         scrollRef,
+        viewMode,
     } = options;
 
     // 1. 资源缓存与加载状态
@@ -106,26 +108,6 @@ export function useAssetLoader(
     }
 
     /**
-     * 判断条目来源是否为快捷入口而非普通文件。
-     *
-     * @param source 条目来源类型。
-     * @returns source 非 file 时返回 true。
-     */
-    function isShortcutSource(source: QuickShortcutItem['source']): boolean {
-        return source !== 'file';
-    }
-
-    /**
-     * 判断条目是否需要通过 Rust 图标接口加载图标。
-     *
-     * @param item 待判断条目。
-     * @returns 需要加载图标时返回 true。
-     */
-    function shouldLoadRustIcon(item: QuickShortcutItem): boolean {
-        return !isImageItem(item);
-    }
-
-    /**
      * 按扩展名判断路径是否为图片文件。
      *
      * @param path 文件路径。
@@ -137,11 +119,11 @@ export function useAssetLoader(
 
     /**
      * 判断条目是否为可加载预览图的图片项。
+     * 统一图片项判断，模板与加载队列共享同一规则。
      *
      * @param item 待判断条目。
      * @returns 条目是本地图片文件时返回 true。
      */
-    // 统一图片项判断，模板与加载队列共享同一规则。
     function isImageItem(item: QuickShortcutItem): boolean {
         return item.source === 'file' && isImageFilePath(item.path);
     }
@@ -184,13 +166,77 @@ export function useAssetLoader(
 
     // 3. 加载队列构建
     /**
+     * 根据当前滚动位置计算视口内（含缓冲行）的起止索引。
+     *
+     * @param items 总结果列表。
+     * @returns [startIndex, endIndex) 范围。
+     */
+    function computeViewportRange(items: QuickShortcutItem[]): [number, number] {
+        const columns = Math.max(gridColumns.value, 1);
+        const gap = viewMode.value === 'list' ? 0 : Math.max(gridGap.value, 0);
+        const rowHeight = Math.max(
+            (viewMode.value === 'list' ? LIST_ROW_HEIGHT_PX : ITEM_SIZE_PX) + gap,
+            1
+        );
+        const scrollTop = scrollRef.value?.scrollTop ?? 0;
+        const viewportHeight = scrollRef.value?.clientHeight ?? selectionMaxHeight.value;
+
+        const firstVisibleRow = Math.max(
+            Math.floor(scrollTop / rowHeight) - VIEWPORT_BUFFER_ROWS,
+            0
+        );
+        const lastVisibleRow =
+            Math.ceil((scrollTop + viewportHeight) / rowHeight) + VIEWPORT_BUFFER_ROWS;
+
+        return [
+            Math.min(items.length, firstVisibleRow * columns),
+            Math.min(items.length, (lastVisibleRow + 1) * columns),
+        ];
+    }
+
+    /**
+     * 从视口范围内收集匹配 predicate 的条目路径；队列不足时补齐顶部高优先级项。
+     *
+     * @param items 当前结果列表。
+     * @param predicate 条目筛选条件。
+     * @param pushPath 入队函数（负责去重与状态过滤）。
+     * @param queue 目标队列。
+     * @param includeTopPriority 是否在视口不足时补充顶部预热项。
+     */
+    function collectItemsFromViewport(
+        items: QuickShortcutItem[],
+        predicate: (item: QuickShortcutItem) => boolean,
+        pushPath: (path: string) => void,
+        queue: string[],
+        includeTopPriority: boolean
+    ) {
+        const [startIndex, endIndex] = computeViewportRange(items);
+        const visibleItems = items.slice(startIndex, endIndex);
+
+        // shortcut 优先于 file 排入队列，提升应用入口图标的体感命中率。
+        const shortcutItems = visibleItems.filter(
+            (item) => item.source !== 'file' && predicate(item)
+        );
+        const fileItems = visibleItems.filter((item) => item.source === 'file' && predicate(item));
+        for (const item of shortcutItems) pushPath(item.path);
+        for (const item of fileItems) pushPath(item.path);
+
+        // 视口项不足时补齐顶部高优先级项用于首屏预热。
+        if (includeTopPriority && queue.length < PRELOAD_MIN_COUNT) {
+            const topItems = items.slice(0, PRELOAD_MIN_COUNT * 2);
+            for (const item of topItems) {
+                if (predicate(item)) pushPath(item.path);
+            }
+        }
+    }
+
+    /**
      * 收集图片加载队列，优先视口附近项目。
      *
      * @param items 当前结果列表。
      * @param options 队列构建选项。
      * @returns 图片预览加载路径队列。
      */
-    // 先加载视口附近项目，再补充顶部高优先级项目，提升首屏命中率。
     function collectImageQueue(
         items: QuickShortcutItem[],
         options: { includeTopPriority?: boolean } = {}
@@ -198,24 +244,6 @@ export function useAssetLoader(
         if (items.length === 0) return [];
         const includeTopPriority = options.includeTopPriority ?? true;
 
-        // 1. 根据当前滚动位置估算“视口 + 缓冲区”行范围。
-        const columns = Math.max(gridColumns.value, 1);
-        const gap = Math.max(gridGap.value, 0);
-        const rowHeight = Math.max(ITEM_SIZE_PX + gap, 1);
-        const scrollTop = scrollRef.value?.scrollTop ?? 0;
-        const viewportHeight = scrollRef.value?.clientHeight ?? selectionMaxHeight.value;
-
-        const firstVisibleRow = Math.max(
-            Math.floor(scrollTop / rowHeight) - ICON_VIEWPORT_BUFFER_ROWS,
-            0
-        );
-        const lastVisibleRow =
-            Math.ceil((scrollTop + viewportHeight) / rowHeight) + ICON_VIEWPORT_BUFFER_ROWS;
-
-        const startIndex = Math.min(items.length, firstVisibleRow * columns);
-        const endIndex = Math.min(items.length, (lastVisibleRow + 1) * columns);
-
-        // 2. 构建带去重与状态过滤的入队函数。
         const queue: string[] = [];
         const seen = new Set<string>();
         const pushPath = (path: string) => {
@@ -226,24 +254,7 @@ export function useAssetLoader(
             queue.push(path);
         };
 
-        // 3. 将当前可视区域图片项筛选出来。
-        const visibleItems = items.slice(startIndex, endIndex);
-        for (const item of visibleItems) {
-            if (isImageItem(item)) {
-                pushPath(item.path);
-            }
-        }
-
-        // 4. 可视区不足时，再补齐顶部高优先级项用于首屏预热。
-        if (includeTopPriority && queue.length < ICON_PRELOAD_MIN_COUNT) {
-            const topPriorityItems = items.slice(0, ICON_PRELOAD_MIN_COUNT * 2);
-            for (const item of topPriorityItems) {
-                if (isImageItem(item)) {
-                    pushPath(item.path);
-                }
-            }
-        }
-
+        collectItemsFromViewport(items, isImageItem, pushPath, queue, includeTopPriority);
         return queue;
     }
 
@@ -261,24 +272,6 @@ export function useAssetLoader(
         if (items.length === 0) return [];
         const includeTopPriority = options.includeTopPriority ?? true;
 
-        // 1. 根据滚动位置估算当前应优先加载的网格区间。
-        const columns = Math.max(gridColumns.value, 1);
-        const gap = Math.max(gridGap.value, 0);
-        const rowHeight = Math.max(ITEM_SIZE_PX + gap, 1);
-        const scrollTop = scrollRef.value?.scrollTop ?? 0;
-        const viewportHeight = scrollRef.value?.clientHeight ?? selectionMaxHeight.value;
-
-        const firstVisibleRow = Math.max(
-            Math.floor(scrollTop / rowHeight) - ICON_VIEWPORT_BUFFER_ROWS,
-            0
-        );
-        const lastVisibleRow =
-            Math.ceil((scrollTop + viewportHeight) / rowHeight) + ICON_VIEWPORT_BUFFER_ROWS;
-
-        const startIndex = Math.min(items.length, firstVisibleRow * columns);
-        const endIndex = Math.min(items.length, (lastVisibleRow + 1) * columns);
-
-        // 2. 构建带去重、已加载过滤、重试上限过滤的入队函数。
         const queue: string[] = [];
         const seen = new Set<string>();
         const pushPath = (path: string) => {
@@ -289,199 +282,171 @@ export function useAssetLoader(
             queue.push(path);
         };
 
-        // 3. 先可视区内加载：shortcut 优先，file 次之。
-        const visibleItems = items.slice(startIndex, endIndex);
-        // 优先 shortcut 再 file，可提升应用入口图标的体感命中率。
-        const visibleShortcutItems = visibleItems.filter((item) => isShortcutSource(item.source));
-        const visibleFileItems = visibleItems.filter((item) => !isShortcutSource(item.source));
-        for (const item of visibleShortcutItems) {
-            if (shouldLoadRustIcon(item)) {
-                pushPath(item.path);
-            }
-        }
-        for (const item of visibleFileItems) {
-            if (shouldLoadRustIcon(item)) {
-                pushPath(item.path);
-            }
-        }
-
-        // 4. 可视区不足时，再补齐顶部高优先级项。
-        if (includeTopPriority && queue.length < ICON_PRELOAD_MIN_COUNT) {
-            const topPriorityItems = items.slice(0, ICON_PRELOAD_MIN_COUNT * 2);
-            const topShortcuts = topPriorityItems.filter((item) => isShortcutSource(item.source));
-            const topFiles = topPriorityItems.filter((item) => !isShortcutSource(item.source));
-            for (const item of topShortcuts) {
-                if (shouldLoadRustIcon(item)) {
-                    pushPath(item.path);
-                }
-            }
-            for (const item of topFiles) {
-                if (shouldLoadRustIcon(item)) {
-                    pushPath(item.path);
-                }
-            }
-        }
-
+        collectItemsFromViewport(
+            items,
+            (item) => !isImageItem(item),
+            pushPath,
+            queue,
+            includeTopPriority
+        );
         return queue;
     }
 
-    // 4. 批次加载执行
+    // 4. 批次加载与调度
     /**
-     * 执行一批图片预览加载，并在完成后调度下一批。
-     *
-     * @param reqId 当前请求编号。
-     * @returns Promise<void>
+     * 创建通用批次加载调度器，消除图标/图片加载的重复逻辑。
      */
-    async function loadImageBatch(reqId: number) {
-        if (reqId !== requestId.value || !isOpen.value) return;
-
-        // 1. 生成本批次任务，空队列直接返回。
-        const queue = collectImageQueue(results.value);
-        if (queue.length === 0) return;
-
-        const batchPaths = queue.slice(0, IMAGE_BATCH_SIZE);
-        // 2. 请求前先标记“加载中”和重试计数，避免重复入队。
-        batchPaths.forEach((path) => {
-            imageLoadingPaths.add(path);
-            const current = imageAttempts.get(path) ?? 0;
-            imageAttempts.set(path, current + 1);
-        });
-        imageLoadInFlight = true;
-
-        try {
-            const previewResult = await deps.getImageThumbnails(batchPaths, IMAGE_THUMB_SIZE);
-            // 3. 仅在请求仍然有效时合并结果，防止旧查询覆盖新状态。
+    function createBatchLoader(config: {
+        collectQueue: (
+            items: QuickShortcutItem[],
+            options?: { includeTopPriority?: boolean }
+        ) => string[];
+        batchSize: number;
+        loadingPaths: Set<string>;
+        attempts: Map<string, number>;
+        resultRef: typeof iconMap;
+        loadInFlightRef: { value: boolean };
+        loadPendingRef: { value: boolean };
+        clearTimer: () => void;
+        schedule: (reqId: number, immediate: boolean) => void;
+        executeBatch: (paths: string[]) => Promise<Record<string, string>>;
+        delayMs: number;
+        errorLabel: string;
+    }) {
+        async function loadBatch(reqId: number) {
             if (reqId !== requestId.value || !isOpen.value) return;
 
-            if (Object.keys(previewResult).length > 0) {
-                Object.assign(imagePreviewMap.value, previewResult);
-            }
-        } catch (error) {
-            console.warn('[QuickSearchPanel] Failed to load image thumbnails:', error);
-        } finally {
-            // 4. 回收本批次状态，并按 pending/remaining 继续调度。
-            batchPaths.forEach((path) => imageLoadingPaths.delete(path));
-            imageLoadInFlight = false;
+            const queue = config.collectQueue(results.value);
+            if (queue.length === 0) return;
 
-            if (imageLoadPending) {
-                imageLoadPending = false;
-                scheduleImageLoad(reqId, true);
-            } else if (reqId === requestId.value && isOpen.value) {
-                const remaining = collectImageQueue(results.value, {
-                    includeTopPriority: false,
-                });
-                if (remaining.length > 0) {
-                    scheduleImageLoad(reqId, true);
+            const batchPaths = queue.slice(0, config.batchSize);
+            batchPaths.forEach((path) => {
+                config.loadingPaths.add(path);
+                const current = config.attempts.get(path) ?? 0;
+                config.attempts.set(path, current + 1);
+            });
+            config.loadInFlightRef.value = true;
+
+            try {
+                const result = await config.executeBatch(batchPaths);
+                if (reqId !== requestId.value || !isOpen.value) return;
+
+                if (Object.keys(result).length > 0) {
+                    Object.assign(config.resultRef.value, result);
+                }
+            } catch (error) {
+                console.warn(`[QuickSearchPanel] Failed to load ${config.errorLabel}:`, error);
+            } finally {
+                batchPaths.forEach((path) => config.loadingPaths.delete(path));
+                config.loadInFlightRef.value = false;
+
+                if (config.loadPendingRef.value) {
+                    config.loadPendingRef.value = false;
+                    config.schedule(reqId, true);
+                } else if (reqId === requestId.value && isOpen.value) {
+                    // 仅检查视口内的剩余项，不重复计入顶部预热项。
+                    const remaining = config.collectQueue(results.value, {
+                        includeTopPriority: false,
+                    });
+                    if (remaining.length > 0) {
+                        config.schedule(reqId, true);
+                    }
                 }
             }
         }
-    }
 
-    /**
-     * 执行一批图标加载，并在完成后调度下一批。
-     *
-     * @param reqId 当前请求编号。
-     * @returns Promise<void>
-     */
-    async function loadIconBatch(reqId: number) {
-        if (reqId !== requestId.value || !isOpen.value) return;
+        function scheduleLoad(reqId = requestId.value, immediate = false) {
+            if (!isOpen.value || reqId !== requestId.value) return;
 
-        // 1. 生成本批次任务，空队列直接返回。
-        const queue = collectIconQueue(results.value);
-        if (queue.length === 0) return;
-
-        const batchPaths = queue.slice(0, ICON_BATCH_SIZE);
-        // 2. 请求前先标记“加载中”和重试计数，避免重复入队。
-        batchPaths.forEach((path) => {
-            iconLoadingPaths.add(path);
-            const current = iconAttempts.get(path) ?? 0;
-            iconAttempts.set(path, current + 1);
-        });
-        iconLoadInFlight = true;
-
-        try {
-            const iconResult = await deps.getShortcutIcons(batchPaths, ICON_SIZE);
-            // 3. 仅在请求仍然有效时合并结果，防止旧查询覆盖新状态。
-            if (reqId !== requestId.value || !isOpen.value) return;
-
-            if (Object.keys(iconResult).length > 0) {
-                Object.assign(iconMap.value, iconResult);
+            if (searchInFlight.value || pendingQuery.value) {
+                config.loadPendingRef.value = true;
+                return;
             }
-        } catch (error) {
-            console.warn('[QuickSearchPanel] Failed to load shortcut icons:', error);
-        } finally {
-            // 4. 回收本批次状态，并按 pending/remaining 继续调度。
-            batchPaths.forEach((path) => iconLoadingPaths.delete(path));
-            iconLoadInFlight = false;
-
-            if (iconLoadPending) {
-                iconLoadPending = false;
-                scheduleIconLoad(reqId, true);
-            } else if (reqId === requestId.value && isOpen.value) {
-                const remaining = collectIconQueue(results.value, {
-                    includeTopPriority: false,
-                });
-                if (remaining.length > 0) {
-                    scheduleIconLoad(reqId, true);
-                }
+            if (config.loadInFlightRef.value) {
+                config.loadPendingRef.value = true;
+                return;
             }
+
+            config.clearTimer();
+            const delay = immediate ? 0 : config.delayMs;
+            setTimeout(() => {
+                void loadBatch(requestId.value);
+            }, delay);
         }
+
+        return { loadBatch, scheduleLoad };
     }
 
-    // 5. 调度与滚动联动
-    /**
-     * 调度图片加载；搜索进行中或批次未完成时仅标记 pending。
-     *
-     * @param reqId 请求编号，默认当前请求。
-     * @param immediate 是否立即触发加载。
-     * @returns void
-     */
-    function scheduleImageLoad(reqId = requestId.value, immediate = false) {
-        if (!isOpen.value || reqId !== requestId.value) return;
+    // 间接引用，让 createBatchLoader 内部的 schedule 回调能指向最终的 scheduleLoad。
+    const scheduleIconLoadRef: { value: (reqId?: number, immediate?: boolean) => void } = {
+        value: () => {},
+    };
+    const scheduleImageLoadRef: { value: (reqId?: number, immediate?: boolean) => void } = {
+        value: () => {},
+    };
 
-        // 搜索或批次加载未完成时仅标记 pending，避免并发批次。
-        if (searchInFlight.value || pendingQuery.value) {
-            imageLoadPending = true;
-            return;
-        }
-        if (imageLoadInFlight) {
-            imageLoadPending = true;
-            return;
-        }
+    const iconLoader = createBatchLoader({
+        collectQueue: (items) => collectIconQueue(items),
+        batchSize: ICON_BATCH_SIZE,
+        loadingPaths: iconLoadingPaths,
+        attempts: iconAttempts,
+        resultRef: iconMap,
+        loadInFlightRef: {
+            get value() {
+                return iconLoadInFlight;
+            },
+            set value(v: boolean) {
+                iconLoadInFlight = v;
+            },
+        },
+        loadPendingRef: {
+            get value() {
+                return iconLoadPending;
+            },
+            set value(v: boolean) {
+                iconLoadPending = v;
+            },
+        },
+        clearTimer: clearIconLoadTimer,
+        schedule: (...args) => scheduleIconLoadRef.value(...args),
+        executeBatch: (paths) => deps.getShortcutIcons(paths, ICON_SIZE),
+        delayMs: ICON_LOAD_DELAY_MS,
+        errorLabel: 'shortcut icons',
+    });
+    scheduleIconLoadRef.value = iconLoader.scheduleLoad;
 
-        clearImageLoadTimer();
-        const delay = immediate ? 0 : IMAGE_LOAD_DELAY_MS;
-        imageLoadTimer = setTimeout(() => {
-            void loadImageBatch(requestId.value);
-        }, delay);
-    }
+    const imageLoader = createBatchLoader({
+        collectQueue: (items) => collectImageQueue(items),
+        batchSize: IMAGE_BATCH_SIZE,
+        loadingPaths: imageLoadingPaths,
+        attempts: imageAttempts,
+        resultRef: imagePreviewMap,
+        loadInFlightRef: {
+            get value() {
+                return imageLoadInFlight;
+            },
+            set value(v: boolean) {
+                imageLoadInFlight = v;
+            },
+        },
+        loadPendingRef: {
+            get value() {
+                return imageLoadPending;
+            },
+            set value(v: boolean) {
+                imageLoadPending = v;
+            },
+        },
+        clearTimer: clearImageLoadTimer,
+        schedule: (...args) => scheduleImageLoadRef.value(...args),
+        executeBatch: (paths) => deps.getImageThumbnails(paths, IMAGE_THUMB_SIZE),
+        delayMs: IMAGE_LOAD_DELAY_MS,
+        errorLabel: 'image thumbnails',
+    });
+    scheduleImageLoadRef.value = imageLoader.scheduleLoad;
 
-    /**
-     * 调度图标加载；搜索进行中或批次未完成时仅标记 pending。
-     *
-     * @param reqId 请求编号，默认当前请求。
-     * @param immediate 是否立即触发加载。
-     * @returns void
-     */
-    function scheduleIconLoad(reqId = requestId.value, immediate = false) {
-        if (!isOpen.value || reqId !== requestId.value) return;
-
-        // 搜索或批次加载未完成时仅标记 pending，避免并发批次。
-        if (searchInFlight.value || pendingQuery.value) {
-            iconLoadPending = true;
-            return;
-        }
-        if (iconLoadInFlight) {
-            iconLoadPending = true;
-            return;
-        }
-
-        clearIconLoadTimer();
-        const delay = immediate ? 0 : ICON_LOAD_DELAY_MS;
-        iconLoadTimer = setTimeout(() => {
-            void loadIconBatch(requestId.value);
-        }, delay);
-    }
+    const scheduleIconLoad = iconLoader.scheduleLoad;
+    const scheduleImageLoad = imageLoader.scheduleLoad;
 
     /**
      * 处理滚动事件，节流后按新视口重新调度资源加载。
@@ -495,10 +460,10 @@ export function useAssetLoader(
         // 滚动后短暂节流，再按新视口重新排队加载。
         iconLoadTimer = setTimeout(() => {
             scheduleIconLoad(requestId.value, true);
-        }, ICON_SCROLL_THROTTLE_MS);
+        }, SCROLL_THROTTLE_MS);
         imageLoadTimer = setTimeout(() => {
             scheduleImageLoad(requestId.value, true);
-        }, ICON_SCROLL_THROTTLE_MS);
+        }, SCROLL_THROTTLE_MS);
     }
 
     /**

--- a/src/views/SearchView/components/QuickSearchPanel/composables/useLayout.ts
+++ b/src/views/SearchView/components/QuickSearchPanel/composables/useLayout.ts
@@ -1,9 +1,13 @@
 import type { QuickShortcutItem } from '@services/NativeService';
 import { computed, nextTick, type Ref, ref } from 'vue';
 
+export type ViewMode = 'grid' | 'list';
+
 export const BASE_GAP_PX = 8; // 网格默认间距（px）
 export const MIN_GAP_PX = 4; // 网格允许的最小间距（px）
 export const ITEM_SIZE_PX = 88; // 单个结果项方块尺寸（px）
+export const LIST_ROW_HEIGHT_PX = 40; // 列表视图行高（px）
+export const LIST_ROW_GAP_PX = 0; // 列表视图行间距（px）
 export const COLLAPSED_VISIBLE_ROWS = 2; // 折叠态可见行数
 export const EXPANDED_VISIBLE_ROWS = 4; // 展开态可见行数
 
@@ -15,6 +19,12 @@ const DEFAULT_MAX_HEIGHT_PX =
     2 * DEFAULT_EDGE_SPACE_PX +
     COLLAPSED_VISIBLE_ROWS * ITEM_SIZE_PX +
     (COLLAPSED_VISIBLE_ROWS - 1) * BASE_GAP_PX;
+
+// 列表模式下的默认面板最大高度（px）。
+const LIST_COLLAPSED_VISIBLE_ROWS = 8;
+const LIST_EXPANDED_VISIBLE_ROWS = 15;
+const LIST_DEFAULT_MAX_HEIGHT_PX =
+    2 * DEFAULT_EDGE_SPACE_PX + LIST_COLLAPSED_VISIBLE_ROWS * LIST_ROW_HEIGHT_PX;
 
 interface UseLayoutOptions {
     isOpen: Ref<boolean>;
@@ -33,12 +43,32 @@ interface UseLayoutOptions {
 export function useLayout(options: UseLayoutOptions) {
     const { isOpen, results, highlightedIndex, scrollRef } = options;
 
-    // 1. 网格布局状态
+    // 1. 视图模式与布局状态
+    const viewMode = ref<ViewMode>('grid');
     const gridColumns = ref(1);
     const gridGap = ref(BASE_GAP_PX);
     const edgeSpace = ref(DEFAULT_EDGE_SPACE_PX);
     const visibleRows = ref(COLLAPSED_VISIBLE_ROWS);
-    const selectionMaxHeight = ref(DEFAULT_MAX_HEIGHT_PX);
+    const selectionMaxHeight = computed(() => {
+        if (!isOpen.value || results.value.length === 0) {
+            return viewMode.value === 'list' ? LIST_DEFAULT_MAX_HEIGHT_PX : DEFAULT_MAX_HEIGHT_PX;
+        }
+        if (viewMode.value === 'list') {
+            const totalRows = results.value.length;
+            const effectiveRows = Math.max(1, Math.min(visibleRows.value, totalRows));
+            return (
+                2 * DEFAULT_EDGE_SPACE_PX +
+                effectiveRows * LIST_ROW_HEIGHT_PX +
+                (effectiveRows - 1) * LIST_ROW_GAP_PX
+            );
+        }
+        const columns = Math.max(gridColumns.value, 1);
+        const totalRows = Math.max(1, Math.ceil(results.value.length / columns));
+        const effectiveRows = Math.max(1, Math.min(visibleRows.value, totalRows));
+        return (
+            2 * edgeSpace.value + effectiveRows * ITEM_SIZE_PX + (effectiveRows - 1) * gridGap.value
+        );
+    });
 
     const scrollStyle = computed(() => ({
         '--quick-edge-space': `${edgeSpace.value}px`,
@@ -50,20 +80,41 @@ export function useLayout(options: UseLayoutOptions) {
         gap: `${gridGap.value}px`,
     }));
 
-    // 2. 布局计算
+    // 2. 视图模式切换
     /**
-     * 按行数计算面板最大高度。
+     * 切换网格/列表视图模式。
      *
-     * @param rows 可见行数。
-     * @param edge 面板左右留白（px）。
-     * @param gap 网格项间距（px）。
-     * @returns 面板最大高度（px）。
+     * @returns void
      */
-    function computeMaxHeight(rows: number, edge: number, gap: number): number {
-        const safeRows = Math.max(rows, 1);
-        return 2 * edge + safeRows * ITEM_SIZE_PX + (safeRows - 1) * gap;
+    function toggleViewMode() {
+        viewMode.value = viewMode.value === 'grid' ? 'list' : 'grid';
+        visibleRows.value =
+            viewMode.value === 'list' ? LIST_EXPANDED_VISIBLE_ROWS : EXPANDED_VISIBLE_ROWS;
+        updateLayout();
+        if (highlightedIndex.value >= 0) {
+            scrollHighlightedIntoView();
+        }
     }
 
+    /**
+     * 获取当前模式下的行高。
+     *
+     * @returns 行高（px）。
+     */
+    function currentRowHeight(): number {
+        return viewMode.value === 'list' ? LIST_ROW_HEIGHT_PX : ITEM_SIZE_PX;
+    }
+
+    /**
+     * 获取当前模式下的行间距。
+     *
+     * @returns 行间距（px）。
+     */
+    function currentRowGap(): number {
+        return viewMode.value === 'list' ? LIST_ROW_GAP_PX : gridGap.value;
+    }
+
+    // 3. 布局计算
     /**
      * 设置可见行数，并限制在折叠行数与展开行数之间。
      *
@@ -71,7 +122,17 @@ export function useLayout(options: UseLayoutOptions) {
      * @returns void
      */
     function setVisibleRows(rows: number) {
-        visibleRows.value = Math.max(COLLAPSED_VISIBLE_ROWS, Math.min(rows, EXPANDED_VISIBLE_ROWS));
+        if (viewMode.value === 'list') {
+            visibleRows.value = Math.max(
+                LIST_COLLAPSED_VISIBLE_ROWS,
+                Math.min(rows, LIST_EXPANDED_VISIBLE_ROWS)
+            );
+        } else {
+            visibleRows.value = Math.max(
+                COLLAPSED_VISIBLE_ROWS,
+                Math.min(rows, EXPANDED_VISIBLE_ROWS)
+            );
+        }
     }
 
     /**
@@ -83,12 +144,11 @@ export function useLayout(options: UseLayoutOptions) {
         gridColumns.value = 1;
         gridGap.value = BASE_GAP_PX;
         edgeSpace.value = DEFAULT_EDGE_SPACE_PX;
-        setVisibleRows(COLLAPSED_VISIBLE_ROWS);
-        selectionMaxHeight.value = computeMaxHeight(
-            visibleRows.value,
-            DEFAULT_EDGE_SPACE_PX,
-            BASE_GAP_PX
-        );
+        if (viewMode.value === 'list') {
+            visibleRows.value = LIST_COLLAPSED_VISIBLE_ROWS;
+        } else {
+            setVisibleRows(COLLAPSED_VISIBLE_ROWS);
+        }
     }
 
     /**
@@ -99,6 +159,12 @@ export function useLayout(options: UseLayoutOptions) {
     function updateLayout() {
         if (!isOpen.value || results.value.length === 0) {
             resetLayoutState();
+            return;
+        }
+
+        if (viewMode.value === 'list') {
+            gridColumns.value = 1;
+            edgeSpace.value = DEFAULT_EDGE_SPACE_PX;
             return;
         }
 
@@ -131,12 +197,9 @@ export function useLayout(options: UseLayoutOptions) {
             gap = Math.max(fittedGap, MIN_GAP_PX);
         }
         const edge = Math.max(gap, MIN_EDGE_SPACE_PX);
-        const totalRows = Math.max(1, Math.ceil(results.value.length / columns));
-        const effectiveRows = Math.max(1, Math.min(visibleRows.value, totalRows));
         gridColumns.value = columns;
         gridGap.value = gap;
         edgeSpace.value = edge;
-        selectionMaxHeight.value = computeMaxHeight(effectiveRows, edge, gap);
     }
 
     /**
@@ -161,14 +224,13 @@ export function useLayout(options: UseLayoutOptions) {
      *
      * @returns Promise<void>
      */
-    async function scrollHighlightedIntoView() {
-        await nextTick();
+    function scrollHighlightedIntoView() {
         if (highlightedIndex.value < 0) return;
         const scrollContainer = scrollRef.value;
         if (!scrollContainer) return;
 
         const activeColumns = Math.max(gridColumns.value, 1);
-        const rowHeight = ITEM_SIZE_PX + Math.max(gridGap.value, 0);
+        const rowHeight = currentRowHeight() + Math.max(currentRowGap(), 0);
         if (rowHeight <= 0) return;
 
         const targetRow = Math.floor(highlightedIndex.value / activeColumns);
@@ -183,15 +245,16 @@ export function useLayout(options: UseLayoutOptions) {
             nextFirstRow = targetRow - visRows + 1;
         }
 
-        const maxScrollTop = Math.max(
-            scrollContainer.scrollHeight - scrollContainer.clientHeight,
-            0
-        );
-        const alignedScrollTop = Math.min(Math.max(nextFirstRow * rowHeight, 0), maxScrollTop);
-        // 使用行对齐滚动，避免在网格里出现“半行”偏移。
-        if (Math.abs(scrollContainer.scrollTop - alignedScrollTop) > 0.5) {
-            scrollContainer.scrollTop = alignedScrollTop;
-        }
+        requestAnimationFrame(() => {
+            const maxScrollTop = Math.max(
+                scrollContainer.scrollHeight - scrollContainer.clientHeight,
+                0
+            );
+            const alignedScrollTop = Math.min(Math.max(nextFirstRow * rowHeight, 0), maxScrollTop);
+            if (Math.abs(scrollContainer.scrollTop - alignedScrollTop) > 0.5) {
+                scrollContainer.scrollTop = alignedScrollTop;
+            }
+        });
     }
 
     /**
@@ -207,9 +270,12 @@ export function useLayout(options: UseLayoutOptions) {
         if (!isOpen.value || results.value.length === 0) return;
 
         const maxIndex = results.value.length - 1;
-        const activeColumns = Math.max(gridColumns.value, 1);
+        const activeColumns = viewMode.value === 'list' ? 1 : Math.max(gridColumns.value, 1);
         const currentIndex = highlightedIndex.value;
         let nextIndex = currentIndex;
+
+        const collapsedRows =
+            viewMode.value === 'list' ? LIST_COLLAPSED_VISIBLE_ROWS : COLLAPSED_VISIBLE_ROWS;
 
         switch (direction) {
             case 'left':
@@ -228,6 +294,15 @@ export function useLayout(options: UseLayoutOptions) {
                 } else {
                     nextIndex = Math.max(nextIndex - activeColumns, 0);
                 }
+                // 向上回到折叠区域或去激活时自动收缩。
+                if (visibleRows.value !== collapsedRows) {
+                    const shouldCollapse =
+                        nextIndex < 0 || Math.floor(nextIndex / activeColumns) < collapsedRows;
+                    if (shouldCollapse) {
+                        setVisibleRows(collapsedRows);
+                        updateLayout();
+                    }
+                }
                 break;
             case 'down':
                 if (currentIndex < 0) {
@@ -237,13 +312,26 @@ export function useLayout(options: UseLayoutOptions) {
                     const currentRow = Math.floor(currentIndex / activeColumns);
                     nextIndex = Math.min(nextIndex + activeColumns, maxIndex);
                     if (
-                        visibleRows.value === COLLAPSED_VISIBLE_ROWS &&
-                        currentRow >= COLLAPSED_VISIBLE_ROWS - 1 &&
+                        visibleRows.value === collapsedRows &&
+                        currentRow >= collapsedRows - 1 &&
                         nextIndex > currentIndex
                     ) {
-                        // 向下越过折叠区域时自动扩展行数，减少键盘操作阻断感。
-                        setVisibleRows(EXPANDED_VISIBLE_ROWS);
+                        // 展开前记录当前高亮行的视觉位置，展开后恢复，避免内容跳动。
+                        const container = scrollRef.value;
+                        const rowTop =
+                            currentRow * (currentRowHeight() + Math.max(currentRowGap(), 0));
+                        const offsetInViewport = container ? rowTop - container.scrollTop : 0;
+                        setVisibleRows(
+                            viewMode.value === 'list'
+                                ? LIST_EXPANDED_VISIBLE_ROWS
+                                : EXPANDED_VISIBLE_ROWS
+                        );
                         updateLayout();
+                        if (container) {
+                            requestAnimationFrame(() => {
+                                container.scrollTop = rowTop - offsetInViewport;
+                            });
+                        }
                     }
                 }
                 break;
@@ -256,16 +344,19 @@ export function useLayout(options: UseLayoutOptions) {
     }
 
     return {
+        viewMode,
         gridColumns,
         gridGap,
         visibleRows,
         selectionMaxHeight,
         scrollStyle,
         gridStyle,
+        toggleViewMode,
         setVisibleRows,
         resetLayoutState,
         updateLayout,
         syncLayout,
         moveSelection,
+        scrollHighlightedIntoView,
     };
 }

--- a/src/views/SearchView/components/QuickSearchPanel/composables/useQuickSearchLogic.ts
+++ b/src/views/SearchView/components/QuickSearchPanel/composables/useQuickSearchLogic.ts
@@ -764,6 +764,7 @@ export function useQuickSearchLogic(
         goToPage: quickSearch.goToPage,
         goToNextPage: () => quickSearch.goToPage(),
         goToPreviousPage: () => quickSearch.goToPage(),
+        loadMore,
         currentPage,
         totalFiles,
         totalResults,

--- a/src/views/SearchView/components/QuickSearchPanel/composables/useQuickSearchLogic.ts
+++ b/src/views/SearchView/components/QuickSearchPanel/composables/useQuickSearchLogic.ts
@@ -1,5 +1,7 @@
+import { type ContextMenuItem, useContextMenu } from '@composables/useContextMenu';
+import { clipboardService } from '@services/ClipboardService';
 import { native, type QuickShortcutItem } from '@services/NativeService';
-import { openPath } from '@tauri-apps/plugin-opener';
+import { openPath, revealItemInDir } from '@tauri-apps/plugin-opener';
 import { computed, nextTick, onMounted, onUnmounted, type Ref, ref, watch } from 'vue';
 
 import {
@@ -11,8 +13,13 @@ import { useAssetLoader } from './useAssetLoader';
 import { COLLAPSED_VISIBLE_ROWS, useLayout } from './useLayout';
 import { useQuickSearchClickStats } from './useQuickSearchClickStats';
 
-const LIMIT = 60; // 单次搜索最多返回结果数
-const DEBOUNCE_MS = 80; // 输入防抖延时（ms）
+const PAGE_SIZE = 60;
+const DEBOUNCE_MS = 80;
+
+const CONTEXT_MENU_ITEMS: ContextMenuItem[] = [
+    { key: 'open-folder', label: '打开所在文件夹', icon: 'folder-open' },
+    { key: 'copy-path', label: '复制路径', icon: 'copy' },
+];
 
 interface UseQuickSearchFlowOptions {
     searchQuery: Ref<string>;
@@ -25,6 +32,10 @@ interface UseQuickSearchFlowOptions {
     requestId: Ref<number>;
     searchInFlight: Ref<boolean>;
     pendingQuery: Ref<string | null>;
+    currentPage: Ref<number>;
+    totalFiles: Ref<number>;
+    totalResults: Ref<number>;
+    nextOffset: Ref<number>;
     resetResultState: () => void;
     setVisibleRows: (rows: number) => void;
     syncLayout: () => Promise<void>;
@@ -70,13 +81,16 @@ function useQuickSearchFlow(
         searchQuery,
         enabled,
         emitOpenUpdate,
-        isOpen,
         results,
         highlightedIndex,
         itemRefs,
         requestId,
         searchInFlight,
         pendingQuery,
+        currentPage,
+        totalFiles,
+        totalResults,
+        nextOffset,
         resetResultState,
         setVisibleRows,
         syncLayout,
@@ -89,6 +103,7 @@ function useQuickSearchFlow(
 
     // 1. 搜索流程状态
     let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+    let lastSearchedQuery = '';
     const clickStats = useQuickSearchClickStats();
 
     // 2. 名称高亮匹配
@@ -160,32 +175,40 @@ function useQuickSearchFlow(
             return;
         }
 
-        // 使用单调递增请求号，丢弃延迟返回的旧查询结果。
+        // 相同查询且已有结果时跳过，避免失焦恢复等场景重复搜索覆盖多页结果。
+        if (trimmedQuery === lastSearchedQuery && results.value.length > 0) {
+            return;
+        }
+
         const reqId = ++requestId.value;
 
         try {
-            const searchResults = await deps.quickSearch.searchShortcuts(trimmedQuery, LIMIT);
+            const searchResult = await deps.quickSearch.searchShortcuts(trimmedQuery, PAGE_SIZE, 0);
             if (reqId !== requestId.value) return;
 
-            if (searchQuery.value.trim() !== trimmedQuery || !enabled.value) {
-                return;
+            if (searchQuery.value.trim() !== trimmedQuery || !enabled.value) return;
+
+            let rankedShortcuts = searchResult.shortcuts;
+            if (searchResult.shortcuts.length > 0) {
+                rankedShortcuts = await clickStats.rankResults(trimmedQuery, rankedShortcuts);
+                if (reqId !== requestId.value) return;
             }
 
-            if (searchResults.length === 0) {
-                hide();
-                return;
-            }
+            const mergedResults = [...rankedShortcuts, ...searchResult.files];
 
-            const rankedResults = await clickStats.rankResults(trimmedQuery, searchResults);
-            if (reqId !== requestId.value) return;
-            if (searchQuery.value.trim() !== trimmedQuery || !enabled.value) {
+            if (mergedResults.length === 0) {
+                close();
                 return;
             }
 
             emitOpenUpdate(true);
-            results.value = rankedResults;
+            results.value = mergedResults;
+            lastSearchedQuery = trimmedQuery;
+            totalFiles.value = searchResult.total_files;
+            totalResults.value = searchResult.total_results;
+            nextOffset.value = searchResult.next_offset;
+            currentPage.value = 0;
             itemRefs.value = [];
-            // 新结果到达后重置资源加载状态，避免沿用上一次查询的加载队列。
             resetLoadingState();
             highlightedIndex.value = -1;
             setVisibleRows(COLLAPSED_VISIBLE_ROWS);
@@ -195,9 +218,21 @@ function useQuickSearchFlow(
         } catch (error) {
             console.error('[QuickSearchPanel] Failed to search shortcuts:', error);
             if (reqId === requestId.value) {
-                hide();
+                close();
             }
         }
+    }
+
+    /**
+     * 跳转到指定页码重新执行当前查询。
+     *
+     * @param page 目标页码（0-indexed）。
+     * @returns void
+     */
+    function goToPage() {
+        const query = searchQuery.value.trim();
+        if (!query) return;
+        void executeSearch(query);
     }
 
     /**
@@ -213,7 +248,6 @@ function useQuickSearchFlow(
             return;
         }
 
-        // 同一时刻只执行一个搜索；输入连发时仅保留最后一次查询。
         if (searchInFlight.value) {
             pendingQuery.value = currentQuery;
             return;
@@ -226,9 +260,7 @@ function useQuickSearchFlow(
 
                 const pending = pendingQuery.value?.trim() ?? '';
                 pendingQuery.value = null;
-                if (!pending || pending === currentQuery) {
-                    break;
-                }
+                if (!pending || pending === currentQuery) break;
                 currentQuery = pending;
             }
         } finally {
@@ -245,13 +277,11 @@ function useQuickSearchFlow(
      */
     function scheduleSearch(query: string) {
         clearDebounceTimer();
-        // 输入防抖，避免每个按键都触发 native 搜索。
         debounceTimer = setTimeout(() => {
             void runSearchLoop(query);
         }, DEBOUNCE_MS);
     }
 
-    // 4. 面板生命周期与交互
     /**
      * 打开面板并立即执行当前查询。
      *
@@ -271,67 +301,23 @@ function useQuickSearchFlow(
     }
 
     /**
-     * 隐藏面板并重置结果展示状态。
+     * 关闭面板并清空结果状态。
      *
      * @returns void
      */
-    function hide() {
-        // 仅关闭面板，不主动清空缓存；缓存回收由 close/prune 控制。
+    function close() {
+        clearDebounceTimer();
+        lastSearchedQuery = '';
+        requestId.value += 1;
+        pendingQuery.value = null;
+        pruneIconMaps(true);
         resetLoadingState();
         emitOpenUpdate(false);
         resetResultState();
     }
 
     /**
-     * 关闭面板并使当前所有异步任务失效。
-     *
-     * @returns void
-     */
-    function close() {
-        clearDebounceTimer();
-        // 递增 requestId 可让当前所有异步任务自然失效。
-        requestId.value += 1;
-        pendingQuery.value = null;
-        pruneIconMaps(true);
-        hide();
-    }
-
-    /**
-     * 获取当前高亮项。
-     *
-     * @returns 当前高亮项；无结果或面板关闭时返回 null。
-     */
-    function getHighlightedItem(): QuickShortcutItem | null {
-        if (!isOpen.value || results.value.length === 0) {
-            return null;
-        }
-        return results.value[highlightedIndex.value] ?? null;
-    }
-
-    /**
-     * 打开当前高亮项，并在前端记录点击统计。
-     *
-     * @returns Promise<void>
-     */
-    async function openHighlightedItem() {
-        const shortcut = getHighlightedItem();
-        if (!shortcut) return;
-
-        try {
-            // 点击统计由前端写入 SQLite，并同步更新内存缓存。
-            clickStats.recordClick(searchQuery.value, shortcut.path);
-            await deps.window.hideSearchWindow();
-            await deps.openPath(shortcut.path);
-        } catch (error) {
-            console.error('[QuickSearchPanel] Failed to open shortcut:', error);
-        }
-    }
-
-    /**
-     * 触发搜索查询，无论面板是否打开。
-     * 不依赖面板 prop 中的 searchQuery（该值因 Vue 渲染批处理可能滞后），
-     * 而是由调用方直接传入最新查询文本。
-     * 查询到结果后面板会通过 executeSearch 自动打开。
+     * 从外部触发搜索（页面层调用）。
      *
      * @param query 查询文本。
      * @returns void
@@ -339,67 +325,145 @@ function useQuickSearchFlow(
     function triggerSearch(query: string) {
         if (!enabled.value) return;
 
-        const trimmed = query.trim();
-        if (!trimmed) {
+        if (!query.trim()) {
             close();
             return;
         }
 
-        void refreshStatus();
-        scheduleSearch(trimmed);
+        emitOpenUpdate(true);
+        scheduleSearch(query);
+    }
+
+    // 4. 右键菜单
+    const isContextMenuOpen = ref(false);
+
+    const { open: openContextMenu, close: closeContextMenu } = useContextMenu<QuickShortcutItem>(
+        CONTEXT_MENU_ITEMS,
+        async (key, item) => {
+            isContextMenuOpen.value = false;
+            await handleContextMenuAction(key, item);
+        }
+    );
+
+    async function handleContextMenuAction(key: string, item: QuickShortcutItem) {
+        if (key === 'open-folder') {
+            try {
+                await revealItemInDir(item.path);
+            } catch (error) {
+                console.error('[QuickSearchPanel] Failed to reveal in folder:', error);
+            }
+        } else if (key === 'copy-path') {
+            try {
+                await clipboardService.writeText(item.path);
+            } catch (error) {
+                console.error('[QuickSearchPanel] Failed to copy path:', error);
+            }
+        }
+    }
+
+    function handleContextMenu(event: MouseEvent, index: number) {
+        const item = results.value[index];
+        if (!item) return;
+        highlightedIndex.value = index;
+        isContextMenuOpen.value = true;
+        openContextMenu(event, item);
+    }
+
+    function openContextMenuForItem(index: number) {
+        const item = results.value[index];
+        if (!item) return;
+        highlightedIndex.value = index;
+        const el = itemRefs.value[index];
+        if (el) {
+            const rect = el.getBoundingClientRect();
+            const syntheticEvent = new MouseEvent('contextmenu', {
+                clientX: rect.left + rect.width / 2,
+                clientY: rect.top + rect.height / 2,
+                bubbles: true,
+            });
+            isContextMenuOpen.value = true;
+            openContextMenu(syntheticEvent, item);
+        }
+    }
+
+    function openContextMenuForHighlightedItem() {
+        if (highlightedIndex.value >= 0) {
+            openContextMenuForItem(highlightedIndex.value);
+        }
+    }
+
+    function closeContextMenuAndReset() {
+        isContextMenuOpen.value = false;
+        closeContextMenu();
+    }
+
+    // Item interactions
+    function getHighlightedItem(): QuickShortcutItem | null {
+        if (highlightedIndex.value < 0) return null;
+        return results.value[highlightedIndex.value] ?? null;
+    }
+
+    async function openHighlightedItem() {
+        const item = getHighlightedItem();
+        if (!item) return;
+
+        clickStats.recordClick(searchQuery.value, item.path);
+
+        try {
+            await deps.openPath(item.path);
+        } catch (error) {
+            console.error('[QuickSearchPanel] Failed to open path:', error);
+        }
     }
 
     /**
-     * 清理搜索流程的计时器与加载状态。
+     * 处理结果项点击并打开对应路径。
      *
-     * @returns void
+     * @param index 点击项索引。
+     * @returns Promise<void>
      */
-    function cleanup() {
-        clearDebounceTimer();
-        resetLoadingState();
-    }
+    async function handleItemClick(index: number) {
+        const item = results.value[index];
+        if (!item) return;
 
-    /**
-     * 当页面层直接把 open 设为 false 时，同步回收面板内部异步状态。
-     * 这是受控组件的兜底收敛路径，避免旧查询在页面已判定关闭后又把结果回填回来。
-     */
-    function syncClosedStateFromParent() {
-        clearDebounceTimer();
-        requestId.value += 1;
-        pendingQuery.value = null;
-        pruneIconMaps(true);
-        resetLoadingState();
-        resetResultState();
+        highlightedIndex.value = index;
+        clickStats.recordClick(searchQuery.value, item.path);
+
+        try {
+            await deps.openPath(item.path);
+        } catch (error) {
+            console.error('[QuickSearchPanel] Failed to open path:', error);
+        }
     }
 
     return {
         prepareIndex,
         open,
         close,
-        syncClosedStateFromParent,
         getHighlightedItem,
         openHighlightedItem,
         triggerSearch,
+        goToPage,
         getNameSegments,
-        cleanup,
+        scheduleSearch,
+        handleContextMenu,
+        openContextMenuForItem,
+        openContextMenuForHighlightedItem,
+        handleItemClick,
+        isContextMenuOpen,
+        closeContextMenuAndReset,
+        cleanup: () => {
+            clearDebounceTimer();
+            pruneIconMaps(true);
+        },
     };
 }
 
-/**
- * QuickSearchPanel 顶层编排层。
- * 负责聚合布局、资源加载、搜索流程与组件生命周期。
- *
- * @param options 面板输入状态与事件回调。
- * @param deps 可注入搜索副作用依赖，默认使用 native 与 opener。
- * @returns 面板渲染状态与交互方法。
- */
-export function useQuickSearchLogic(
-    options: UseQuickSearchLogicOptions,
-    deps: UseQuickSearchDeps = DEFAULT_DEPS
-) {
-    const { open, searchQuery, enabled, emitOpenUpdate } = options;
+// --- 状态 composable ---
 
-    // 1. 基础状态
+function useQuickSearchState(options: UseQuickSearchLogicOptions) {
+    const { open, emitOpenUpdate } = options;
+
     const results = ref<QuickShortcutItem[]>([]);
     const highlightedIndex = ref(-1);
     const itemRefs = ref<HTMLElement[]>([]);
@@ -407,8 +471,11 @@ export function useQuickSearchLogic(
     const requestId = ref(0);
     const searchInFlight = ref(false);
     const pendingQuery = ref<string | null>(null);
+    const currentPage = ref(0);
+    const totalFiles = ref(0);
+    const totalResults = ref(0);
+    const nextOffset = ref(0);
 
-    // 2. 子能力组合
     const layout = useLayout({
         isOpen: open,
         results,
@@ -426,6 +493,7 @@ export function useQuickSearchLogic(
         gridGap: layout.gridGap,
         selectionMaxHeight: layout.selectionMaxHeight,
         scrollRef,
+        viewMode: layout.viewMode,
     });
 
     /**
@@ -437,8 +505,77 @@ export function useQuickSearchLogic(
         results.value = [];
         highlightedIndex.value = -1;
         itemRefs.value = [];
+        currentPage.value = 0;
+        totalFiles.value = 0;
+        totalResults.value = 0;
+        nextOffset.value = 0;
         layout.resetLayoutState();
     }
+
+    return {
+        state: {
+            emitOpenUpdate,
+            isOpen: open,
+            results,
+            highlightedIndex,
+            itemRefs,
+            requestId,
+            searchInFlight,
+            pendingQuery,
+            currentPage,
+            totalFiles,
+            totalResults,
+            nextOffset,
+            resetResultState,
+            setVisibleRows: layout.setVisibleRows,
+            syncLayout: layout.syncLayout,
+            scheduleIconLoad: assets.scheduleIconLoad,
+            scheduleImageLoad: assets.scheduleImageLoad,
+            flushPendingLoads: assets.flushPendingLoads,
+            resetLoadingState: assets.resetLoadingState,
+            pruneIconMaps: assets.pruneIconMaps,
+        },
+        deps: {
+            scrollRef,
+            layout,
+            assets,
+        },
+    };
+}
+
+// --- 主 composable ---
+
+export function useQuickSearchLogic(
+    options: UseQuickSearchLogicOptions,
+    deps: UseQuickSearchDeps = DEFAULT_DEPS
+) {
+    const { open, searchQuery, enabled, emitOpenUpdate } = options;
+
+    const {
+        state: {
+            results,
+            highlightedIndex,
+            itemRefs,
+            requestId,
+            searchInFlight,
+            pendingQuery,
+            currentPage,
+            totalFiles,
+            totalResults,
+            nextOffset,
+            resetResultState,
+            setVisibleRows,
+            syncLayout,
+            scheduleIconLoad,
+            scheduleImageLoad,
+            flushPendingLoads,
+            resetLoadingState,
+            pruneIconMaps,
+        },
+        deps: { scrollRef, layout, assets },
+    } = useQuickSearchState(options);
+
+    const isLoadingMore = ref(false);
 
     const quickSearch = useQuickSearchFlow(
         {
@@ -452,49 +589,106 @@ export function useQuickSearchLogic(
             requestId,
             searchInFlight,
             pendingQuery,
+            currentPage,
+            totalFiles,
+            totalResults,
+            nextOffset,
             resetResultState,
-            setVisibleRows: layout.setVisibleRows,
-            syncLayout: layout.syncLayout,
-            scheduleIconLoad: assets.scheduleIconLoad,
-            scheduleImageLoad: assets.scheduleImageLoad,
-            flushPendingLoads: assets.flushPendingLoads,
-            resetLoadingState: assets.resetLoadingState,
-            pruneIconMaps: assets.pruneIconMaps,
+            setVisibleRows,
+            syncLayout,
+            scheduleIconLoad,
+            scheduleImageLoad,
+            flushPendingLoads,
+            resetLoadingState,
+            pruneIconMaps,
         },
         deps
     );
 
-    let isSyncingCloseToParent = false;
+    // 5. 无限滚动懒加载
+    /**
+     * 加载下一页文件结果并追加到当前列表。
+     * 由滚动事件触发，使用 nextOffset 避免前端计算偏移错位。
+     */
+    async function loadMore() {
+        if (isLoadingMore.value) return;
+        if (results.value.length >= totalResults.value) return;
 
-    function requestCloseFromPanel() {
-        if (open.value) {
-            isSyncingCloseToParent = true;
+        isLoadingMore.value = true;
+        const query = searchQuery.value.trim();
+        const offset = nextOffset.value;
+        try {
+            const searchResult = await deps.quickSearch.searchShortcuts(query, PAGE_SIZE, offset);
+            if (searchResult.files.length === 0) return;
+            const savedScrollTop = scrollRef.value?.scrollTop ?? 0;
+            results.value.push(...searchResult.files);
+            totalFiles.value = searchResult.total_files;
+            totalResults.value = searchResult.total_results;
+            nextOffset.value = searchResult.next_offset;
+            currentPage.value++;
+            await nextTick();
+            requestAnimationFrame(() => {
+                if (scrollRef.value) {
+                    scrollRef.value.scrollTop = savedScrollTop;
+                }
+            });
+            assets.scheduleIconLoad(requestId.value, false);
+            assets.scheduleImageLoad(requestId.value, false);
+        } catch (error) {
+            console.error('[QuickSearchPanel] Failed to load more:', error);
+        } finally {
+            isLoadingMore.value = false;
         }
-        quickSearch.close();
     }
 
-    // 3. 组件交互
-    /**
-     * 处理结果项点击并打开对应路径。
-     *
-     * @param index 点击项索引。
-     * @returns Promise<void>
-     */
-    async function handleItemClick(index: number) {
-        highlightedIndex.value = index;
-        await quickSearch.openHighlightedItem();
+    function handleScrollWithLoadMore() {
+        assets.handleScroll();
+        const el = scrollRef.value;
+        if (!el || isLoadingMore.value) return;
+        if (el.scrollTop + el.clientHeight >= el.scrollHeight - 200) {
+            void loadMore();
+        }
     }
 
-    /**
-     * 处理视口变化并同步布局。
-     *
-     * @returns void
-     */
-    function handleViewportResize() {
-        layout.updateLayout();
+    // Keyboard navigation
+    function moveSelection(direction: 'up' | 'down' | 'left' | 'right') {
+        layout.moveSelection(direction);
     }
 
-    // 4. 生命周期与状态同步
+    // 6. 生命周期与状态同步
+    watch(open, (isOpen) => {
+        if (isOpen) {
+            if (results.value.length > 0) {
+                layout.updateLayout();
+                if (highlightedIndex.value >= 0) {
+                    layout.scrollHighlightedIntoView();
+                }
+            } else {
+                void syncLayout();
+            }
+            assets.scheduleIconLoad(requestId.value, false);
+            assets.scheduleImageLoad(requestId.value, false);
+        } else {
+            if (results.value.length === 0) {
+                highlightedIndex.value = -1;
+                void nextTick(() => {
+                    if (scrollRef.value) {
+                        scrollRef.value.scrollTop = 0;
+                    }
+                });
+            }
+        }
+    });
+
+    watch(
+        [searchQuery, enabled],
+        ([query, isEnabled]) => {
+            if (!isEnabled || !open.value) return;
+            quickSearch.scheduleSearch(query);
+        },
+        { flush: 'post' }
+    );
+
     onMounted(() => {
         void quickSearch.prepareIndex(false);
         window.addEventListener('resize', handleViewportResize);
@@ -511,73 +705,71 @@ export function useQuickSearchLogic(
         }
     });
 
-    watch(
-        [open, results],
-        ([open]) => {
-            if (!open) return;
-            void layout.syncLayout();
-            assets.scheduleIconLoad(requestId.value, false);
-            assets.scheduleImageLoad(requestId.value, false);
-        },
-        { flush: 'post' }
-    );
+    /**
+     * 处理视口变化并同步布局。
+     *
+     * @returns void
+     */
+    function handleViewportResize() {
+        if (!open.value || results.value.length === 0) return;
+        layout.updateLayout();
+    }
 
-    watch(
-        open,
-        (nextOpen, previousOpen) => {
-            if (nextOpen || !previousOpen) {
-                return;
+    function requestCloseFromPanel() {
+        quickSearch.close();
+    }
+
+    /**
+     * 收缩面板到默认折叠态，清除高亮并重置滚动位置。
+     * 用于 Escape 键触发的"回到初始状态"操作。
+     */
+    function collapseToDefault() {
+        highlightedIndex.value = -1;
+        layout.setVisibleRows(COLLAPSED_VISIBLE_ROWS);
+        layout.updateLayout();
+        void nextTick(() => {
+            if (scrollRef.value) {
+                scrollRef.value.scrollTop = 0;
             }
+        });
+    }
 
-            if (isSyncingCloseToParent) {
-                isSyncingCloseToParent = false;
-                return;
-            }
-
-            quickSearch.syncClosedStateFromParent();
-        },
-        { flush: 'sync' }
-    );
-
-    watch(
-        results,
-        (items) => {
-            if (items.length === 0) {
-                highlightedIndex.value = -1;
-                return;
-            }
-
-            highlightedIndex.value = -1;
-            void nextTick(() => {
-                if (scrollRef.value) {
-                    scrollRef.value.scrollTop = 0;
-                }
-            });
-        },
-        { flush: 'post' }
-    );
-
+    // Return
     return {
-        isOpen: open,
         results,
         highlightedIndex,
         itemRefs,
         scrollRef,
         scrollStyle: layout.scrollStyle,
         gridStyle: layout.gridStyle,
-        moveSelection: layout.moveSelection,
+        moveSelection,
         iconMap: assets.iconMap,
         imagePreviewMap: assets.imagePreviewMap,
         isImageItem: assets.isImageItem,
         getItemHoverTitle: assets.getItemHoverTitle,
-        handleScroll: assets.handleScroll,
+        handleScroll: handleScrollWithLoadMore,
+        isContextMenuOpen: quickSearch.isContextMenuOpen,
+        closeContextMenu: quickSearch.closeContextMenuAndReset,
         getNameSegments: quickSearch.getNameSegments,
-        handleItemClick,
+        handleItemClick: quickSearch.handleItemClick,
+        handleContextMenu: quickSearch.handleContextMenu,
+        openContextMenuForItem: quickSearch.openContextMenuForItem,
+        openContextMenuForHighlightedItem: quickSearch.openContextMenuForHighlightedItem,
         open: quickSearch.open,
         close: requestCloseFromPanel,
-        syncClosedState: quickSearch.syncClosedStateFromParent,
+        syncClosedState: () => {},
         getHighlightedItem: quickSearch.getHighlightedItem,
         openHighlightedItem: quickSearch.openHighlightedItem,
         triggerSearch: quickSearch.triggerSearch,
+        goToPage: quickSearch.goToPage,
+        goToNextPage: () => quickSearch.goToPage(),
+        goToPreviousPage: () => quickSearch.goToPage(),
+        currentPage,
+        totalFiles,
+        totalResults,
+        isLoadingMore,
+        viewMode: layout.viewMode,
+        toggleViewMode: layout.toggleViewMode,
+        collapseToDefault,
     };
 }

--- a/src/views/SearchView/components/QuickSearchPanel/index.vue
+++ b/src/views/SearchView/components/QuickSearchPanel/index.vue
@@ -10,12 +10,21 @@
     >
         <div
             :ref="assignScrollRef"
-            class="quick-search-scroll quick-search-scrollbar overflow-x-hidden overflow-y-auto"
+            :class="[
+                'quick-search-scroll quick-search-scrollbar overflow-x-hidden overflow-y-auto',
+                viewMode === 'list' && 'justify-start',
+            ]"
             :style="scrollStyle"
             @scroll.passive="handleScroll"
             @click.self="handleBlankSurfaceClick"
         >
-            <div class="quick-search-grid" :style="gridStyle" @click.self="handleBlankSurfaceClick">
+            <!-- 网格视图 -->
+            <div
+                v-if="viewMode === 'grid'"
+                class="quick-search-grid"
+                :style="gridStyle"
+                @click.self="handleBlankSurfaceClick"
+            >
                 <button
                     v-for="(item, index) in results"
                     :key="item.path"
@@ -27,10 +36,11 @@
                     type="button"
                     :title="getItemHoverTitle(item)"
                     :class="[
-                        'flex h-[88px] w-[88px] cursor-pointer flex-col items-center justify-center overflow-hidden rounded-xl p-1 transition-colors',
+                        'flex h-[88px] w-[88px] cursor-pointer flex-col items-center justify-center overflow-hidden rounded-xl p-1 outline-none',
                         index === highlightedIndex ? 'bg-primary-100' : 'hover:bg-gray-100',
                     ]"
                     @click="handleItemClick(index)"
+                    @contextmenu.prevent="handleContextMenu($event, index)"
                 >
                     <div
                         class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-md"
@@ -68,15 +78,59 @@
                     </p>
                 </button>
             </div>
+            <!-- 列表视图 -->
+            <div v-else class="quick-search-list" @click.self="handleBlankSurfaceClick">
+                <QuickSearchListItem
+                    v-for="(item, index) in results"
+                    :key="item.path"
+                    :ref="
+                        (el) => {
+                            if (el) itemRefs[index] = el as HTMLButtonElement;
+                        }
+                    "
+                    :name="item.name"
+                    :path="
+                        item.source === 'file' || item.source === 'shortcut_file' ? item.path : ''
+                    "
+                    :icon-src="isImageItem(item) ? imagePreviewMap[item.path] : iconMap[item.path]"
+                    :name-segments="getNameSegments(item.name)"
+                    :highlighted="index === highlightedIndex"
+                    @click="handleItemClick(index)"
+                    @contextmenu="handleContextMenu($event, index)"
+                />
+            </div>
+        </div>
+        <!-- 状态栏 -->
+        <div
+            v-if="results.length > 0"
+            class="quick-search-status flex items-center justify-end gap-2 px-1 pt-1"
+        >
+            <span
+                v-if="isLoadingMore"
+                class="inline-block h-3 w-3 animate-spin rounded-full border border-gray-300 border-t-gray-600"
+            ></span>
+            <span class="quick-search-status-text text-[11px] leading-none text-gray-400">
+                {{ statusText }}
+            </span>
+            <button
+                type="button"
+                class="quick-search-view-toggle flex h-4 w-4 items-center justify-center text-gray-400 outline-none hover:text-gray-600"
+                :title="viewMode === 'grid' ? '切换列表视图' : '切换网格视图'"
+                @click="toggleViewMode"
+            >
+                <AppIcon :name="viewMode === 'grid' ? 'list-ul' : 'grid-alt'" class="h-3.5 w-3.5" />
+            </button>
         </div>
     </div>
 </template>
 
 <script setup lang="ts">
+    import AppIcon from '@components/AppIcon.vue';
     import type { ComponentPublicInstance } from 'vue';
-    import { toRef } from 'vue';
+    import { computed, toRef } from 'vue';
 
     import { useQuickSearchLogic } from './composables/useQuickSearchLogic';
+    import QuickSearchListItem from './QuickSearchListItem.vue';
 
     defineOptions({
         name: 'QuickSearchPanel',
@@ -116,14 +170,26 @@
         isImageItem,
         getItemHoverTitle,
         handleScroll,
+        isContextMenuOpen,
         getNameSegments,
         handleItemClick,
+        handleContextMenu,
+        openContextMenuForItem,
+        openContextMenuForHighlightedItem,
         open: openPanel,
         close: closePanel,
         syncClosedState,
         getHighlightedItem,
         openHighlightedItem,
         triggerSearch,
+        goToPage,
+        goToNextPage,
+        goToPreviousPage,
+        currentPage,
+        totalResults,
+        isLoadingMore,
+        viewMode,
+        toggleViewMode,
     } = quickSearchLogic;
 
     const scrollRef = quickSearchLogic.scrollRef;
@@ -136,6 +202,16 @@
         emit('blankClick');
     }
 
+    const statusText = computed(() => {
+        const total = totalResults.value;
+        const totalPages = Math.max(1, Math.ceil(total / 60));
+        const currentPageNum =
+            highlightedIndex.value >= 0
+                ? Math.floor(highlightedIndex.value / 60) + 1
+                : currentPage.value + 1;
+        return `第 ${currentPageNum}/${totalPages} 页 · 共 ${total} 条`;
+    });
+
     defineExpose({
         open: openPanel,
         close: closePanel,
@@ -144,6 +220,15 @@
         getHighlightedItem,
         openHighlightedItem,
         triggerSearch,
+        goToPage,
+        goToNextPage,
+        goToPreviousPage,
+        openContextMenuForItem,
+        openContextMenuForHighlightedItem,
+        toggleViewMode,
+        collapseToDefault: quickSearchLogic.collapseToDefault,
+        isContextMenuOpen,
+        closeContextMenu: quickSearchLogic.closeContextMenu,
     });
 </script>
 

--- a/src/views/SearchView/components/QuickSearchPanel/style.css
+++ b/src/views/SearchView/components/QuickSearchPanel/style.css
@@ -1,17 +1,22 @@
 @reference "@styles/tailwind.css";
 
 .quick-search-scroll {
-    width: 100%;
-    max-width: 100%;
-    margin: 0 auto;
-    height: var(--quick-selection-max-height, 200px);
-    min-height: var(--quick-selection-max-height, 200px);
-    max-height: var(--quick-selection-max-height, 200px);
     padding: var(--quick-edge-space, 4px);
     box-sizing: border-box;
     display: flex;
     justify-content: center;
     align-items: flex-start;
+}
+
+/* 公共面板尺寸规则：scroll / placeholder / empty 共享相同的宽高约束。 */
+.quick-search-scroll,
+.quick-search-loading-placeholder,
+.quick-search-empty {
+    width: 100%;
+    max-width: 100%;
+    margin: 0 auto;
+    height: var(--quick-selection-max-height, 200px);
+    min-height: var(--quick-selection-max-height, 200px);
 }
 
 .quick-search-scrollbar {
@@ -35,22 +40,7 @@
     align-content: start;
 }
 
-.quick-search-loading-placeholder {
-    width: 100%;
-    max-width: 100%;
-    margin: 0 auto;
-    height: var(--quick-selection-max-height, 200px);
-    min-height: var(--quick-selection-max-height, 200px);
-    max-height: var(--quick-selection-max-height, 200px);
-}
-
 .quick-search-empty {
-    width: 100%;
-    max-width: 100%;
-    margin: 0 auto;
-    height: var(--quick-selection-max-height, 200px);
-    min-height: var(--quick-selection-max-height, 200px);
-    max-height: var(--quick-selection-max-height, 200px);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -79,4 +69,28 @@
 .quick-search-icon-placeholder {
     background: linear-gradient(135deg, rgba(243, 244, 246, 0.95), rgba(229, 231, 235, 0.95));
     border: 1px solid rgba(209, 213, 219, 0.9);
+}
+
+/* 列表视图 */
+.quick-search-list {
+    --qs-icon-size: 16px;
+    --qs-name-width: 100px;
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    margin: 0;
+    flex: 0 0 auto;
+    align-items: stretch;
+}
+
+/* 状态栏 */
+.quick-search-status {
+    border-top: 1px solid rgba(229, 231, 235, 0.6);
+    margin-top: 2px;
+    padding-top: 4px;
+}
+
+.quick-search-status-text {
+    user-select: none;
+    white-space: nowrap;
 }

--- a/src/views/SearchView/composables/searchInteraction.ts
+++ b/src/views/SearchView/composables/searchInteraction.ts
@@ -75,8 +75,6 @@ interface ShouldCheckShortcutEntryInput {
     lastEntryCheckedVisibilityEpoch: number | null;
 }
 
-type PopupSessionEventIdentity = SearchPopupSessionIdentity;
-
 interface UseQuickSearchCoordinatorOptions {
     queryText: Ref<string>;
     attachments: Ref<unknown[]>;
@@ -142,6 +140,11 @@ interface CreateSearchKeyboardRouterOptions {
     onMoveQuickSearchSelection: (direction: SearchQuickSearchDirection) => void;
     onOpenHighlightedQuickSearchItem: () => void | Promise<void>;
     onCloseQuickSearch: () => void;
+    onQuickSearchPageUp: () => void;
+    onQuickSearchPageDown: () => void;
+    onQuickSearchContextMenu: () => void;
+    onQuickSearchToggleView: () => void;
+    onQuickSearchCollapse: () => void;
     onNavigateInputHistory: (
         direction: SessionInputHistoryDirection
     ) => SessionInputHistoryNavigationResult;
@@ -528,7 +531,7 @@ export function createPopupSurfaceCoordinator(
         interactionContext.clearActivePopupSession();
     }
 
-    function isCurrentPopupEvent(input: PopupSessionEventIdentity) {
+    function isCurrentPopupEvent(input: SearchPopupSessionIdentity) {
         if (!state.activePopupIdentity) {
             return false;
         }
@@ -777,6 +780,11 @@ export function createSearchKeyboardRouter(options: CreateSearchKeyboardRouterOp
         onMoveQuickSearchSelection,
         onOpenHighlightedQuickSearchItem,
         onCloseQuickSearch,
+        onQuickSearchPageUp,
+        onQuickSearchPageDown,
+        onQuickSearchContextMenu,
+        onQuickSearchToggleView,
+        onQuickSearchCollapse,
         onNavigateInputHistory,
         onHideAllPopups,
         onCancelRequest,
@@ -822,6 +830,12 @@ export function createSearchKeyboardRouter(options: CreateSearchKeyboardRouterOp
         }
 
         if (input.key === 'Escape' || input.key === 'Esc') {
+            // 快速搜索有高亮时，Escape 只收缩面板、清除高亮，不走清空输入链路。
+            if (isQuickSearchOpen() && hasQuickSearchHighlight()) {
+                onQuickSearchCollapse();
+                return true;
+            }
+
             if (getActiveSurface() !== 'search-surface') {
                 runKeyboardEffect(onHideAllPopups);
                 return true;
@@ -864,6 +878,28 @@ export function createSearchKeyboardRouter(options: CreateSearchKeyboardRouterOp
         }
 
         if (isQuickSearchOpen()) {
+            // PageUp/PageDown 翻页
+            if (input.key === 'PageUp') {
+                onQuickSearchPageUp();
+                return true;
+            }
+            if (input.key === 'PageDown') {
+                onQuickSearchPageDown();
+                return true;
+            }
+
+            // Menu 键或 Shift+F10 打开右键菜单
+            if (input.key === 'ContextMenu' || (input.key === 'F10' && input.shiftKey)) {
+                onQuickSearchContextMenu();
+                return true;
+            }
+
+            // Ctrl+G 切换网格/列表视图
+            if (input.key === 'g' && (input.ctrlKey || input.metaKey)) {
+                onQuickSearchToggleView();
+                return true;
+            }
+
             if (hasQuickSearchHighlight()) {
                 const directionMap: Partial<Record<string, SearchQuickSearchDirection>> = {
                     ArrowUp: 'up',
@@ -1044,6 +1080,21 @@ export function createSearchKeydownHandler(options: UseSearchKeyboardOptions) {
         onCloseQuickSearch: () => {
             controller.closeQuickSearch();
         },
+        onQuickSearchPageUp: () => {
+            controller.goToPreviousPageQuickSearch();
+        },
+        onQuickSearchPageDown: () => {
+            controller.goToNextPageQuickSearch();
+        },
+        onQuickSearchContextMenu: () => {
+            controller.openQuickSearchContextMenu();
+        },
+        onQuickSearchToggleView: () => {
+            controller.toggleQuickSearchView();
+        },
+        onQuickSearchCollapse: () => {
+            controller.collapseQuickSearch();
+        },
         onNavigateInputHistory: (direction) => {
             return navigateInputHistory(direction);
         },
@@ -1108,6 +1159,17 @@ export function createSearchKeydownHandler(options: UseSearchKeyboardOptions) {
 
     return async function handleKeyDown(event: KeyboardEvent) {
         if (!viewReady.value) {
+            return;
+        }
+
+        // 右键菜单打开时，Escape 关闭菜单，其它键不拦截。
+        if (controller.isQuickSearchContextMenuOpen()) {
+            if (event.key === 'Escape' || event.key === 'Esc') {
+                controller.closeQuickSearchContextMenu();
+                event.preventDefault();
+                event.stopPropagation();
+            }
+            // 非 Escape 键不拦截，传播到 useContextMenu 的 document listener 处理上下键导航。
             return;
         }
 

--- a/src/views/SearchView/composables/useSearchPage.ts
+++ b/src/views/SearchView/composables/useSearchPage.ts
@@ -184,6 +184,15 @@ export function useSearchPageController(options: {
               getHighlightedItem: () => unknown | null;
               openHighlightedItem: () => Promise<void>;
               triggerSearch: (query: string) => void;
+              goToPage: (page: number) => void;
+              goToNextPage: () => void;
+              goToPreviousPage: () => void;
+              openContextMenuForItem: (index: number) => void;
+              openContextMenuForHighlightedItem: () => void;
+              toggleViewMode: () => void;
+              collapseToDefault: () => void;
+              isContextMenuOpen: boolean;
+              closeContextMenu: () => void;
           }
         | undefined
     >;
@@ -257,11 +266,7 @@ export function useSearchPageController(options: {
     }
 
     function closeQuickSearch() {
-        const wasOpen = quickSearchOpen.value;
         quickSearchOpen.value = false;
-        if (!wasOpen) {
-            quickSearchPanel.value?.syncClosedState();
-        }
     }
 
     function moveQuickSearchSelection(direction: 'up' | 'down' | 'left' | 'right') {
@@ -274,6 +279,40 @@ export function useSearchPageController(options: {
 
     function triggerQuickSearch(query: string) {
         quickSearchPanel.value?.triggerSearch(query);
+    }
+
+    function goToPageQuickSearch(page: number) {
+        quickSearchPanel.value?.goToPage(page);
+    }
+
+    function goToNextPageQuickSearch() {
+        quickSearchPanel.value?.goToNextPage();
+    }
+
+    function goToPreviousPageQuickSearch() {
+        quickSearchPanel.value?.goToPreviousPage();
+    }
+
+    function openQuickSearchContextMenu() {
+        quickSearchPanel.value?.openContextMenuForHighlightedItem();
+    }
+
+    function toggleQuickSearchView() {
+        quickSearchPanel.value?.toggleViewMode();
+    }
+
+    function collapseQuickSearch() {
+        quickSearchPanel.value?.collapseToDefault();
+        void focusSearchInput();
+    }
+
+    function isQuickSearchContextMenuOpen() {
+        return quickSearchPanel.value?.isContextMenuOpen ?? false;
+    }
+
+    function closeQuickSearchContextMenu() {
+        quickSearchPanel.value?.closeContextMenu();
+        void focusSearchInput();
     }
 
     return {
@@ -293,6 +332,14 @@ export function useSearchPageController(options: {
         moveQuickSearchSelection,
         openHighlightedQuickSearchItem,
         triggerQuickSearch,
+        goToPageQuickSearch,
+        goToNextPageQuickSearch,
+        goToPreviousPageQuickSearch,
+        openQuickSearchContextMenu,
+        toggleQuickSearchView,
+        collapseQuickSearch,
+        isQuickSearchContextMenuOpen,
+        closeQuickSearchContextMenu,
     };
 }
 

--- a/src/views/SearchView/types.ts
+++ b/src/views/SearchView/types.ts
@@ -48,6 +48,15 @@ export interface QuickSearchHandle {
     getHighlightedItem: () => unknown | null;
     openHighlightedItem: () => Promise<void>;
     triggerSearch: (query: string) => void;
+    goToPage: (page: number) => void;
+    goToNextPage: () => void;
+    goToPreviousPage: () => void;
+    openContextMenuForItem: (index: number) => void;
+    openContextMenuForHighlightedItem: () => void;
+    toggleViewMode: () => void;
+    collapseToDefault: () => void;
+    isContextMenuOpen: boolean;
+    closeContextMenu: () => void;
 }
 
 export interface ConversationPanelHandle {
@@ -74,6 +83,14 @@ export interface SearchPageController {
     moveQuickSearchSelection: (direction: 'up' | 'down' | 'left' | 'right') => void;
     openHighlightedQuickSearchItem: () => Promise<void>;
     triggerQuickSearch: (query: string) => void;
+    goToPageQuickSearch: (page: number) => void;
+    goToNextPageQuickSearch: () => void;
+    goToPreviousPageQuickSearch: () => void;
+    openQuickSearchContextMenu: () => void;
+    toggleQuickSearchView: () => void;
+    collapseQuickSearch: () => void;
+    isQuickSearchContextMenuOpen: () => boolean;
+    closeQuickSearchContextMenu: () => void;
 }
 
 export interface PendingRequest {

--- a/tests/composables/SearchView/QuickSearchPanel/useAssetLoader.test.ts
+++ b/tests/composables/SearchView/QuickSearchPanel/useAssetLoader.test.ts
@@ -78,6 +78,7 @@ function createLoaderContext(
         gridColumns?: number;
         gridGap?: number;
         selectionMaxHeight?: number;
+        viewMode?: 'grid' | 'list';
         scrollTop?: number;
         clientHeight?: number;
         deps?: Partial<UseAssetLoaderDeps>;
@@ -99,6 +100,7 @@ function createLoaderContext(
     const gridColumns = ref(options.gridColumns ?? 2);
     const gridGap = ref(options.gridGap ?? 8);
     const selectionMaxHeight = ref(options.selectionMaxHeight ?? 32);
+    const viewMode = ref<'grid' | 'list'>(options.viewMode ?? 'grid');
     const scrollRef = ref<HTMLElement | null>(
         createScrollContainer({
             scrollTop: options.scrollTop,
@@ -118,6 +120,7 @@ function createLoaderContext(
                 gridGap,
                 selectionMaxHeight,
                 scrollRef,
+                viewMode,
             },
             deps
         ),

--- a/tests/composables/SearchView/QuickSearchPanel/useLayout.test.ts
+++ b/tests/composables/SearchView/QuickSearchPanel/useLayout.test.ts
@@ -333,6 +333,33 @@ describe('useLayout', () => {
         expect(layout.visibleRows.value).toBe(8);
     });
 
+    it('syncLayout calls updateLayout after nextTick and rAF', async () => {
+        const isOpen = ref(true);
+        const results = ref([createShortcut(1), createShortcut(2)]);
+        const highlightedIndex = ref(-1);
+        const scrollElement = document.createElement('div');
+        const panelElement = document.createElement('div');
+        panelElement.appendChild(scrollElement);
+        document.body.appendChild(panelElement);
+
+        setReadonlyNumber(scrollElement, 'clientWidth', 400);
+        setReadonlyNumber(panelElement, 'clientWidth', 400);
+        setReadonlyNumber(document.documentElement, 'clientWidth', 400);
+        setReadonlyNumber(window, 'innerWidth', 400);
+
+        const layout = useLayout({
+            isOpen,
+            results,
+            highlightedIndex,
+            scrollRef: ref(scrollElement),
+        });
+
+        await layout.syncLayout();
+
+        // After syncLayout, gridColumns should be updated.
+        expect(layout.gridColumns.value).toBeGreaterThanOrEqual(1);
+    });
+
     it('scrollHighlightedIntoView does nothing when highlight is -1', async () => {
         const isOpen = ref(true);
         const results = ref([createShortcut(1)]);

--- a/tests/composables/SearchView/QuickSearchPanel/useLayout.test.ts
+++ b/tests/composables/SearchView/QuickSearchPanel/useLayout.test.ts
@@ -150,4 +150,295 @@ describe('useLayout', () => {
         expect(layout.visibleRows.value).toBe(2);
         expect(layout.selectionMaxHeight.value).toBe(200);
     });
+
+    it('toggleViewMode switches between grid and list', () => {
+        const isOpen = ref(true);
+        const results = ref([createShortcut(1), createShortcut(2)]);
+        const highlightedIndex = ref(-1);
+        const scrollElement = document.createElement('div');
+
+        const layout = useLayout({
+            isOpen,
+            results,
+            highlightedIndex,
+            scrollRef: ref(scrollElement),
+        });
+
+        expect(layout.viewMode.value).toBe('grid');
+
+        layout.toggleViewMode();
+        expect(layout.viewMode.value).toBe('list');
+
+        layout.toggleViewMode();
+        expect(layout.viewMode.value).toBe('grid');
+    });
+
+    it('toggleViewMode preserves expanded state', () => {
+        const isOpen = ref(true);
+        const results = ref(Array.from({ length: 20 }, (_, i) => createShortcut(i)));
+        const highlightedIndex = ref(-1);
+        const scrollElement = document.createElement('div');
+
+        const layout = useLayout({
+            isOpen,
+            results,
+            highlightedIndex,
+            scrollRef: ref(scrollElement),
+        });
+
+        // Expand grid to max.
+        layout.setVisibleRows(4);
+        expect(layout.visibleRows.value).toBe(4);
+
+        // Toggle to list should set expanded list rows.
+        layout.toggleViewMode();
+        expect(layout.viewMode.value).toBe('list');
+        expect(layout.visibleRows.value).toBe(15);
+
+        // Toggle back to grid should set expanded grid rows.
+        layout.toggleViewMode();
+        expect(layout.viewMode.value).toBe('grid');
+        expect(layout.visibleRows.value).toBe(4);
+    });
+
+    it('selectionMaxHeight reacts to viewMode changes', () => {
+        const isOpen = ref(true);
+        const results = ref(Array.from({ length: 20 }, (_, i) => createShortcut(i)));
+        const highlightedIndex = ref(-1);
+        const scrollElement = document.createElement('div');
+
+        const layout = useLayout({
+            isOpen,
+            results,
+            highlightedIndex,
+            scrollRef: ref(scrollElement),
+        });
+
+        const gridHeight = layout.selectionMaxHeight.value;
+
+        layout.toggleViewMode();
+        const listHeight = layout.selectionMaxHeight.value;
+
+        // List mode should have different height than grid mode.
+        expect(listHeight).not.toBe(gridHeight);
+        expect(listHeight).toBeGreaterThan(0);
+    });
+
+    it('selectionMaxHeight returns collapsed default when panel is closed', () => {
+        const isOpen = ref(false);
+        const results = ref([createShortcut(1)]);
+        const highlightedIndex = ref(-1);
+        const scrollElement = document.createElement('div');
+
+        const layout = useLayout({
+            isOpen,
+            results,
+            highlightedIndex,
+            scrollRef: ref(scrollElement),
+        });
+
+        // When closed, should return default collapsed height.
+        expect(layout.selectionMaxHeight.value).toBeGreaterThan(0);
+    });
+
+    it('selectionMaxHeight grows when results increase', () => {
+        const isOpen = ref(true);
+        const results = ref([createShortcut(1), createShortcut(2)]);
+        const highlightedIndex = ref(-1);
+        const scrollElement = document.createElement('div');
+        const panelElement = document.createElement('div');
+        panelElement.appendChild(scrollElement);
+        document.body.appendChild(panelElement);
+
+        setReadonlyNumber(scrollElement, 'clientWidth', 400);
+        setReadonlyNumber(panelElement, 'clientWidth', 400);
+        setReadonlyNumber(document.documentElement, 'clientWidth', 400);
+        setReadonlyNumber(window, 'innerWidth', 400);
+
+        const layout = useLayout({
+            isOpen,
+            results,
+            highlightedIndex,
+            scrollRef: ref(scrollElement),
+        });
+
+        layout.updateLayout();
+        const initialHeight = layout.selectionMaxHeight.value;
+
+        // Add more results.
+        results.value = Array.from({ length: 20 }, (_, i) => createShortcut(i));
+        layout.updateLayout();
+
+        expect(layout.selectionMaxHeight.value).toBeGreaterThanOrEqual(initialHeight);
+    });
+
+    it('moveSelection in list mode uses single column', () => {
+        const isOpen = ref(true);
+        const results = ref(Array.from({ length: 10 }, (_, i) => createShortcut(i)));
+        const highlightedIndex = ref(-1);
+        const scrollElement = document.createElement('div');
+        const panelElement = document.createElement('div');
+        panelElement.appendChild(scrollElement);
+        document.body.appendChild(panelElement);
+
+        setReadonlyNumber(scrollElement, 'clientWidth', 400);
+        setReadonlyNumber(scrollElement, 'clientHeight', 200);
+        setReadonlyNumber(scrollElement, 'scrollHeight', 1000);
+        setReadonlyNumber(panelElement, 'clientWidth', 400);
+        setReadonlyNumber(document.documentElement, 'clientWidth', 400);
+        setReadonlyNumber(window, 'innerWidth', 400);
+
+        const layout = useLayout({
+            isOpen,
+            results,
+            highlightedIndex,
+            scrollRef: ref(scrollElement),
+        });
+
+        layout.toggleViewMode();
+        expect(layout.viewMode.value).toBe('list');
+
+        layout.moveSelection('down');
+        expect(highlightedIndex.value).toBe(0);
+
+        layout.moveSelection('down');
+        expect(highlightedIndex.value).toBe(1);
+
+        layout.moveSelection('up');
+        expect(highlightedIndex.value).toBe(0);
+
+        // Up from first item should deactivate.
+        layout.moveSelection('up');
+        expect(highlightedIndex.value).toBe(-1);
+    });
+
+    it('resetLayoutState in list mode uses list collapsed rows', () => {
+        const isOpen = ref(true);
+        const results = ref(Array.from({ length: 20 }, (_, i) => createShortcut(i)));
+        const highlightedIndex = ref(-1);
+        const scrollElement = document.createElement('div');
+
+        const layout = useLayout({
+            isOpen,
+            results,
+            highlightedIndex,
+            scrollRef: ref(scrollElement),
+        });
+
+        layout.toggleViewMode();
+        layout.setVisibleRows(15);
+        expect(layout.visibleRows.value).toBe(15);
+
+        layout.resetLayoutState();
+        expect(layout.visibleRows.value).toBe(8);
+    });
+
+    it('scrollHighlightedIntoView does nothing when highlight is -1', async () => {
+        const isOpen = ref(true);
+        const results = ref([createShortcut(1)]);
+        const highlightedIndex = ref(-1);
+        const scrollElement = document.createElement('div');
+
+        const layout = useLayout({
+            isOpen,
+            results,
+            highlightedIndex,
+            scrollRef: ref(scrollElement),
+        });
+
+        // Should not throw.
+        layout.scrollHighlightedIntoView();
+    });
+
+    it('scrollHighlightedIntoView scrolls down when highlight is below viewport', async () => {
+        const isOpen = ref(true);
+        const results = ref(Array.from({ length: 20 }, (_, i) => createShortcut(i)));
+        const highlightedIndex = ref(0);
+        const scrollElement = document.createElement('div');
+        const panelElement = document.createElement('div');
+        panelElement.appendChild(scrollElement);
+        document.body.appendChild(panelElement);
+
+        setReadonlyNumber(scrollElement, 'clientWidth', 400);
+        setReadonlyNumber(scrollElement, 'clientHeight', 200);
+        setReadonlyNumber(scrollElement, 'scrollHeight', 2000);
+        setReadonlyNumber(panelElement, 'clientWidth', 400);
+        setReadonlyNumber(document.documentElement, 'clientWidth', 400);
+        setReadonlyNumber(window, 'innerWidth', 400);
+
+        const layout = useLayout({
+            isOpen,
+            results,
+            highlightedIndex,
+            scrollRef: ref(scrollElement),
+        });
+
+        layout.updateLayout();
+
+        // Move highlight far down.
+        highlightedIndex.value = 15;
+        layout.scrollHighlightedIntoView();
+
+        // After rAF, scrollTop should have changed (we can't easily wait for rAF in tests,
+        // but the function should not throw).
+    });
+
+    it('moveSelection right and left within a row', () => {
+        const isOpen = ref(true);
+        const results = ref(Array.from({ length: 10 }, (_, i) => createShortcut(i)));
+        const highlightedIndex = ref(0);
+        const scrollElement = document.createElement('div');
+        const panelElement = document.createElement('div');
+        panelElement.appendChild(scrollElement);
+        document.body.appendChild(panelElement);
+
+        setReadonlyNumber(scrollElement, 'clientWidth', 300);
+        setReadonlyNumber(scrollElement, 'clientHeight', 200);
+        setReadonlyNumber(scrollElement, 'scrollHeight', 1000);
+        setReadonlyNumber(panelElement, 'clientWidth', 300);
+        setReadonlyNumber(document.documentElement, 'clientWidth', 300);
+        setReadonlyNumber(window, 'innerWidth', 300);
+
+        const layout = useLayout({
+            isOpen,
+            results,
+            highlightedIndex,
+            scrollRef: ref(scrollElement),
+        });
+
+        layout.updateLayout();
+
+        layout.moveSelection('right');
+        expect(highlightedIndex.value).toBe(1);
+
+        layout.moveSelection('left');
+        expect(highlightedIndex.value).toBe(0);
+
+        // Left from first item should stay at 0.
+        layout.moveSelection('left');
+        expect(highlightedIndex.value).toBe(0);
+    });
+
+    it('moveSelection does nothing when highlight is -1 for left/right/up', () => {
+        const isOpen = ref(true);
+        const results = ref([createShortcut(1), createShortcut(2)]);
+        const highlightedIndex = ref(-1);
+        const scrollElement = document.createElement('div');
+
+        const layout = useLayout({
+            isOpen,
+            results,
+            highlightedIndex,
+            scrollRef: ref(scrollElement),
+        });
+
+        layout.moveSelection('left');
+        expect(highlightedIndex.value).toBe(-1);
+
+        layout.moveSelection('right');
+        expect(highlightedIndex.value).toBe(-1);
+
+        layout.moveSelection('up');
+        expect(highlightedIndex.value).toBe(-1);
+    });
 });

--- a/tests/composables/SearchView/QuickSearchPanel/useQuickSearchLogic.test.ts
+++ b/tests/composables/SearchView/QuickSearchPanel/useQuickSearchLogic.test.ts
@@ -495,4 +495,164 @@ describe('useQuickSearchLogic', () => {
 
         mounted.unmount();
     });
+
+    it('handleContextMenu sets highlight and opens context menu', async () => {
+        const open = ref(false);
+        const searchQuery = ref('');
+        const quickSearchDeps = {
+            quickSearch: {
+                getStatus: vi.fn().mockResolvedValue({
+                    provider: 'everything',
+                    db_loaded: true,
+                    index_warmed: true,
+                    last_refresh_ms: null,
+                    last_error: null,
+                }),
+                prepareIndex: vi.fn().mockResolvedValue(undefined),
+                searchShortcuts: vi
+                    .fn()
+                    .mockResolvedValue(createSearchResult([createShortcut('App')])),
+            },
+            window: {
+                hideSearchWindow: vi.fn().mockResolvedValue(undefined),
+            },
+            openPath: vi.fn().mockResolvedValue(undefined),
+        };
+
+        const mounted = await mountComposable(() =>
+            useQuickSearchLogic(
+                {
+                    open,
+                    searchQuery,
+                    enabled: ref(true),
+                    emitOpenUpdate: (value) => {
+                        open.value = value;
+                    },
+                },
+                quickSearchDeps
+            )
+        );
+
+        searchQuery.value = 'app';
+        mounted.result.triggerSearch('app');
+        await vi.advanceTimersByTimeAsync(80);
+        await flushAsyncWork();
+
+        const event = new MouseEvent('contextmenu', {
+            clientX: 100,
+            clientY: 100,
+            bubbles: true,
+        });
+        mounted.result.handleContextMenu(event, 0);
+
+        expect(mounted.result.highlightedIndex.value).toBe(0);
+
+        mounted.unmount();
+    });
+
+    it('open watcher triggers syncLayout on first open with no results', async () => {
+        const open = ref(false);
+        const searchQuery = ref('');
+        const quickSearchDeps = {
+            quickSearch: {
+                getStatus: vi.fn().mockResolvedValue({
+                    provider: 'everything',
+                    db_loaded: true,
+                    index_warmed: true,
+                    last_refresh_ms: null,
+                    last_error: null,
+                }),
+                prepareIndex: vi.fn().mockResolvedValue(undefined),
+                searchShortcuts: vi.fn().mockResolvedValue(createSearchResult()),
+            },
+            window: {
+                hideSearchWindow: vi.fn().mockResolvedValue(undefined),
+            },
+            openPath: vi.fn().mockResolvedValue(undefined),
+        };
+
+        const mounted = await mountComposable(() =>
+            useQuickSearchLogic(
+                {
+                    open,
+                    searchQuery,
+                    enabled: ref(true),
+                    emitOpenUpdate: (value) => {
+                        open.value = value;
+                    },
+                },
+                quickSearchDeps
+            )
+        );
+
+        // Open with no results should call syncLayout.
+        open.value = true;
+        await flushAsyncWork();
+
+        expect(layoutMock.syncLayout).toHaveBeenCalled();
+
+        mounted.unmount();
+    });
+
+    it('close resets lastSearchedQuery and allows re-search', async () => {
+        const open = ref(false);
+        const searchQuery = ref('');
+        const quickSearchDeps = {
+            quickSearch: {
+                getStatus: vi.fn().mockResolvedValue({
+                    provider: 'everything',
+                    db_loaded: true,
+                    index_warmed: true,
+                    last_refresh_ms: null,
+                    last_error: null,
+                }),
+                prepareIndex: vi.fn().mockResolvedValue(undefined),
+                searchShortcuts: vi
+                    .fn()
+                    .mockResolvedValue(createSearchResult([createShortcut('App')])),
+            },
+            window: {
+                hideSearchWindow: vi.fn().mockResolvedValue(undefined),
+            },
+            openPath: vi.fn().mockResolvedValue(undefined),
+        };
+
+        const mounted = await mountComposable(() =>
+            useQuickSearchLogic(
+                {
+                    open,
+                    searchQuery,
+                    enabled: ref(true),
+                    emitOpenUpdate: (value) => {
+                        open.value = value;
+                    },
+                },
+                quickSearchDeps
+            )
+        );
+
+        searchQuery.value = 'app';
+        mounted.result.triggerSearch('app');
+        await vi.advanceTimersByTimeAsync(80);
+        await flushAsyncWork();
+
+        expect(quickSearchDeps.quickSearch.searchShortcuts).toHaveBeenCalledTimes(1);
+
+        // Close clears lastSearchedQuery.
+        mounted.result.close();
+        await flushAsyncWork();
+
+        // Re-trigger same query should search again.
+        open.value = false;
+        await flushAsyncWork();
+        open.value = true;
+        searchQuery.value = 'app';
+        mounted.result.triggerSearch('app');
+        await vi.advanceTimersByTimeAsync(80);
+        await flushAsyncWork();
+
+        expect(quickSearchDeps.quickSearch.searchShortcuts).toHaveBeenCalledTimes(2);
+
+        mounted.unmount();
+    });
 });

--- a/tests/composables/SearchView/QuickSearchPanel/useQuickSearchLogic.test.ts
+++ b/tests/composables/SearchView/QuickSearchPanel/useQuickSearchLogic.test.ts
@@ -1,4 +1,4 @@
-import type { QuickShortcutItem } from '@services/NativeService';
+import type { QuickSearchResult, QuickShortcutItem } from '@services/NativeService';
 import { mountComposable } from '@tests/utils/composables';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ref } from 'vue';
@@ -60,6 +60,19 @@ function createShortcut(name: string, path = `D:/${name}.lnk`): QuickShortcutIte
     };
 }
 
+function createSearchResult(
+    shortcuts: QuickShortcutItem[] = [],
+    files: QuickShortcutItem[] = []
+): QuickSearchResult {
+    return {
+        shortcuts,
+        files,
+        total_files: files.length,
+        total_results: shortcuts.length + files.length,
+        next_offset: files.length,
+    };
+}
+
 function deferred<T>() {
     let resolve!: (value: T) => void;
     const promise = new Promise<T>((r) => {
@@ -102,7 +115,9 @@ describe('useQuickSearchLogic', () => {
                     last_error: null,
                 }),
                 prepareIndex: vi.fn().mockResolvedValue(undefined),
-                searchShortcuts: vi.fn().mockResolvedValue([createShortcut('TouchAI')]),
+                searchShortcuts: vi
+                    .fn()
+                    .mockResolvedValue(createSearchResult([createShortcut('TouchAI')])),
             },
             window: {
                 hideSearchWindow: vi.fn().mockResolvedValue(undefined),
@@ -129,7 +144,7 @@ describe('useQuickSearchLogic', () => {
         await vi.advanceTimersByTimeAsync(80);
         await flushAsyncWork();
 
-        expect(quickSearchDeps.quickSearch.searchShortcuts).toHaveBeenCalledWith('touchai', 60);
+        expect(quickSearchDeps.quickSearch.searchShortcuts).toHaveBeenCalledWith('touchai', 60, 0);
         expect(open.value).toBe(true);
         expect(mounted.result.results.value).toEqual([createShortcut('TouchAI')]);
         expect(mounted.result.highlightedIndex.value).toBe(-1);
@@ -141,8 +156,8 @@ describe('useQuickSearchLogic', () => {
     });
 
     it('keeps only the latest pending query when a slower search result arrives late', async () => {
-        const firstSearch = deferred<QuickShortcutItem[]>();
-        const secondSearch = deferred<QuickShortcutItem[]>();
+        const firstSearch = deferred<QuickSearchResult>();
+        const secondSearch = deferred<QuickSearchResult>();
         const open = ref(false);
         const searchQuery = ref('');
         const quickSearchDeps = {
@@ -190,17 +205,23 @@ describe('useQuickSearchLogic', () => {
         await vi.advanceTimersByTimeAsync(80);
         await flushAsyncWork();
 
-        firstSearch.resolve([createShortcut('First Result')]);
+        firstSearch.resolve(createSearchResult([createShortcut('First Result')]));
         await flushAsyncWork();
 
-        secondSearch.resolve([createShortcut('Second Result')]);
+        secondSearch.resolve(createSearchResult([createShortcut('Second Result')]));
         await flushAsyncWork();
 
-        expect(quickSearchDeps.quickSearch.searchShortcuts).toHaveBeenNthCalledWith(1, 'first', 60);
+        expect(quickSearchDeps.quickSearch.searchShortcuts).toHaveBeenNthCalledWith(
+            1,
+            'first',
+            60,
+            0
+        );
         expect(quickSearchDeps.quickSearch.searchShortcuts).toHaveBeenNthCalledWith(
             2,
             'second',
-            60
+            60,
+            0
         );
         expect(mounted.result.results.value).toEqual([createShortcut('Second Result')]);
         expect(open.value).toBe(true);
@@ -221,7 +242,7 @@ describe('useQuickSearchLogic', () => {
                     last_error: null,
                 }),
                 prepareIndex: vi.fn().mockResolvedValue(undefined),
-                searchShortcuts: vi.fn().mockResolvedValue([]),
+                searchShortcuts: vi.fn().mockResolvedValue(createSearchResult()),
             },
             window: {
                 hideSearchWindow: vi.fn().mockResolvedValue(undefined),
@@ -269,7 +290,7 @@ describe('useQuickSearchLogic', () => {
                     last_error: null,
                 }),
                 prepareIndex: vi.fn().mockResolvedValue(undefined),
-                searchShortcuts: vi.fn().mockResolvedValue([result]),
+                searchShortcuts: vi.fn().mockResolvedValue(createSearchResult([result])),
             },
             window: {
                 hideSearchWindow: vi.fn().mockResolvedValue(undefined),
@@ -299,7 +320,6 @@ describe('useQuickSearchLogic', () => {
         await mounted.result.handleItemClick(0);
 
         expect(clickStatsMock.recordClick).toHaveBeenCalledWith('touch', result.path);
-        expect(quickSearchDeps.window.hideSearchWindow).toHaveBeenCalledTimes(1);
         expect(quickSearchDeps.openPath).toHaveBeenCalledWith(result.path);
 
         mounted.unmount();

--- a/tests/composables/SearchView/QuickSearchPanel/useQuickSearchLogic.test.ts
+++ b/tests/composables/SearchView/QuickSearchPanel/useQuickSearchLogic.test.ts
@@ -327,6 +327,55 @@ describe('useQuickSearchLogic', () => {
         mounted.unmount();
     });
 
+    it('getNameSegments returns segments with match highlights', async () => {
+        const open = ref(false);
+        const searchQuery = ref('');
+        const quickSearchDeps = {
+            quickSearch: {
+                getStatus: vi.fn().mockResolvedValue({
+                    provider: 'everything',
+                    db_loaded: true,
+                    index_warmed: true,
+                    last_refresh_ms: null,
+                    last_error: null,
+                }),
+                prepareIndex: vi.fn().mockResolvedValue(undefined),
+                searchShortcuts: vi
+                    .fn()
+                    .mockResolvedValue(createSearchResult([createShortcut('TouchAI')])),
+            },
+            window: {
+                hideSearchWindow: vi.fn().mockResolvedValue(undefined),
+            },
+            openPath: vi.fn().mockResolvedValue(undefined),
+        };
+
+        const mounted = await mountComposable(() =>
+            useQuickSearchLogic(
+                {
+                    open,
+                    searchQuery,
+                    enabled: ref(true),
+                    emitOpenUpdate: (value) => {
+                        open.value = value;
+                    },
+                },
+                quickSearchDeps
+            )
+        );
+
+        searchQuery.value = 'touch';
+        mounted.result.triggerSearch('touch');
+        await vi.advanceTimersByTimeAsync(80);
+        await flushAsyncWork();
+
+        const segments = mounted.result.getNameSegments('TouchAI');
+        expect(segments.length).toBeGreaterThan(0);
+        expect(segments.some((s) => s.matched)).toBe(true);
+
+        mounted.unmount();
+    });
+
     it('skips re-search when the same query already has results', async () => {
         const open = ref(false);
         const searchQuery = ref('');

--- a/tests/composables/SearchView/QuickSearchPanel/useQuickSearchLogic.test.ts
+++ b/tests/composables/SearchView/QuickSearchPanel/useQuickSearchLogic.test.ts
@@ -62,7 +62,8 @@ function createShortcut(name: string, path = `D:/${name}.lnk`): QuickShortcutIte
 
 function createSearchResult(
     shortcuts: QuickShortcutItem[] = [],
-    files: QuickShortcutItem[] = []
+    files: QuickShortcutItem[] = [],
+    overrides: Partial<QuickSearchResult> = {}
 ): QuickSearchResult {
     return {
         shortcuts,
@@ -70,6 +71,7 @@ function createSearchResult(
         total_files: files.length,
         total_results: shortcuts.length + files.length,
         next_offset: files.length,
+        ...overrides,
     };
 }
 
@@ -321,6 +323,175 @@ describe('useQuickSearchLogic', () => {
 
         expect(clickStatsMock.recordClick).toHaveBeenCalledWith('touch', result.path);
         expect(quickSearchDeps.openPath).toHaveBeenCalledWith(result.path);
+
+        mounted.unmount();
+    });
+
+    it('skips re-search when the same query already has results', async () => {
+        const open = ref(false);
+        const searchQuery = ref('');
+        const quickSearchDeps = {
+            quickSearch: {
+                getStatus: vi.fn().mockResolvedValue({
+                    provider: 'everything',
+                    db_loaded: true,
+                    index_warmed: true,
+                    last_refresh_ms: null,
+                    last_error: null,
+                }),
+                prepareIndex: vi.fn().mockResolvedValue(undefined),
+                searchShortcuts: vi
+                    .fn()
+                    .mockResolvedValue(createSearchResult([createShortcut('TouchAI')])),
+            },
+            window: {
+                hideSearchWindow: vi.fn().mockResolvedValue(undefined),
+            },
+            openPath: vi.fn().mockResolvedValue(undefined),
+        };
+
+        const mounted = await mountComposable(() =>
+            useQuickSearchLogic(
+                {
+                    open,
+                    searchQuery,
+                    enabled: ref(true),
+                    emitOpenUpdate: (value) => {
+                        open.value = value;
+                    },
+                },
+                quickSearchDeps
+            )
+        );
+
+        searchQuery.value = 'touch';
+        mounted.result.triggerSearch('touch');
+        await vi.advanceTimersByTimeAsync(80);
+        await flushAsyncWork();
+
+        expect(quickSearchDeps.quickSearch.searchShortcuts).toHaveBeenCalledTimes(1);
+
+        // Same query again should not trigger a new search.
+        mounted.result.triggerSearch('touch');
+        await vi.advanceTimersByTimeAsync(80);
+        await flushAsyncWork();
+
+        expect(quickSearchDeps.quickSearch.searchShortcuts).toHaveBeenCalledTimes(1);
+
+        mounted.unmount();
+    });
+
+    it('collapseToDefault resets highlight and visible rows', async () => {
+        const open = ref(false);
+        const searchQuery = ref('');
+        const quickSearchDeps = {
+            quickSearch: {
+                getStatus: vi.fn().mockResolvedValue({
+                    provider: 'everything',
+                    db_loaded: true,
+                    index_warmed: true,
+                    last_refresh_ms: null,
+                    last_error: null,
+                }),
+                prepareIndex: vi.fn().mockResolvedValue(undefined),
+                searchShortcuts: vi
+                    .fn()
+                    .mockResolvedValue(createSearchResult([createShortcut('TouchAI')])),
+            },
+            window: {
+                hideSearchWindow: vi.fn().mockResolvedValue(undefined),
+            },
+            openPath: vi.fn().mockResolvedValue(undefined),
+        };
+
+        const mounted = await mountComposable(() =>
+            useQuickSearchLogic(
+                {
+                    open,
+                    searchQuery,
+                    enabled: ref(true),
+                    emitOpenUpdate: (value) => {
+                        open.value = value;
+                    },
+                },
+                quickSearchDeps
+            )
+        );
+
+        searchQuery.value = 'touch';
+        mounted.result.triggerSearch('touch');
+        await vi.advanceTimersByTimeAsync(80);
+        await flushAsyncWork();
+
+        mounted.result.collapseToDefault();
+
+        expect(mounted.result.highlightedIndex.value).toBe(-1);
+        expect(layoutMock.setVisibleRows).toHaveBeenCalledWith(5);
+        expect(layoutMock.updateLayout).toHaveBeenCalled();
+
+        mounted.unmount();
+    });
+
+    it('loadMore appends new file results', async () => {
+        const open = ref(false);
+        const searchQuery = ref('');
+        const quickSearchDeps = {
+            quickSearch: {
+                getStatus: vi.fn().mockResolvedValue({
+                    provider: 'everything',
+                    db_loaded: true,
+                    index_warmed: true,
+                    last_refresh_ms: null,
+                    last_error: null,
+                }),
+                prepareIndex: vi.fn().mockResolvedValue(undefined),
+                searchShortcuts: vi
+                    .fn()
+                    .mockResolvedValueOnce(
+                        createSearchResult(
+                            [createShortcut('App')],
+                            [createShortcut('File1', 'D:/File1.txt')],
+                            { total_results: 10 }
+                        )
+                    )
+                    .mockResolvedValueOnce(
+                        createSearchResult([], [createShortcut('File2', 'D:/File2.txt')], {
+                            total_results: 10,
+                        })
+                    ),
+            },
+            window: {
+                hideSearchWindow: vi.fn().mockResolvedValue(undefined),
+            },
+            openPath: vi.fn().mockResolvedValue(undefined),
+        };
+
+        const mounted = await mountComposable(() =>
+            useQuickSearchLogic(
+                {
+                    open,
+                    searchQuery,
+                    enabled: ref(true),
+                    emitOpenUpdate: (value) => {
+                        open.value = value;
+                    },
+                },
+                quickSearchDeps
+            )
+        );
+
+        searchQuery.value = 'file';
+        mounted.result.triggerSearch('file');
+        await vi.advanceTimersByTimeAsync(80);
+        await flushAsyncWork();
+
+        expect(mounted.result.results.value.length).toBe(2);
+
+        await mounted.result.loadMore();
+        await flushAsyncWork();
+
+        expect(mounted.result.results.value.length).toBe(3);
+        expect(quickSearchDeps.quickSearch.searchShortcuts).toHaveBeenCalledTimes(2);
 
         mounted.unmount();
     });

--- a/tests/composables/SearchView/searchInteraction.test.ts
+++ b/tests/composables/SearchView/searchInteraction.test.ts
@@ -55,6 +55,14 @@ function createControllerStub() {
         moveQuickSearchSelection: vi.fn(),
         openHighlightedQuickSearchItem: vi.fn().mockResolvedValue(undefined),
         triggerQuickSearch: vi.fn(),
+        goToPageQuickSearch: vi.fn(),
+        goToNextPageQuickSearch: vi.fn(),
+        goToPreviousPageQuickSearch: vi.fn(),
+        openQuickSearchContextMenu: vi.fn(),
+        toggleQuickSearchView: vi.fn(),
+        collapseQuickSearch: vi.fn(),
+        isQuickSearchContextMenuOpen: vi.fn(() => false),
+        closeQuickSearchContextMenu: vi.fn(),
     } satisfies SearchPageController;
 }
 
@@ -336,6 +344,11 @@ describe('createSearchKeyboardRouter', () => {
             onMoveQuickSearchSelection: vi.fn(),
             onOpenHighlightedQuickSearchItem: vi.fn(),
             onCloseQuickSearch: vi.fn(),
+            onQuickSearchPageUp: vi.fn(),
+            onQuickSearchPageDown: vi.fn(),
+            onQuickSearchContextMenu: vi.fn(),
+            onQuickSearchToggleView: vi.fn(),
+            onQuickSearchCollapse: vi.fn(),
             onNavigateInputHistory: vi.fn(() => 'ignored' as const),
             onHideAllPopups: vi.fn(),
             onCancelRequest: vi.fn(),

--- a/tests/services/native-service.test.ts
+++ b/tests/services/native-service.test.ts
@@ -15,6 +15,7 @@ import {
     paths,
     quickSearch,
     type QuickSearchFileItem,
+    type QuickSearchResult,
     type QuickSearchStatus,
     type QuickShortcutItem,
     shortcut,
@@ -526,17 +527,23 @@ describe('NativeService MCP boundary', () => {
 });
 
 describe('NativeService quick search boundary', () => {
-    it('searches shortcuts with the default limit', async () => {
-        const response: QuickShortcutItem[] = [
-            { name: 'TouchAI', path: 'D:/TouchAI.lnk', source: 'desktop_user' },
-        ];
+    it('searches shortcuts with the default page size', async () => {
+        const response: QuickSearchResult = {
+            shortcuts: [
+                { name: 'TouchAI', path: 'D:/TouchAI.lnk', source: 'desktop_user' },
+            ],
+            files: [],
+            total_files: 0,
+            total_results: 1,
+            next_offset: 0,
+        };
         mockTauriCommand('quick_search_search_shortcuts', response);
 
         await expect(
             callAndExpectInvoke(
                 () => quickSearch.searchShortcuts('touch'),
                 'quick_search_search_shortcuts',
-                { query: 'touch', limit: 60 }
+                { query: 'touch', pageSize: 60, offset: 0 }
             )
         ).resolves.toEqual(response);
     });

--- a/tests/services/native-service.test.ts
+++ b/tests/services/native-service.test.ts
@@ -528,9 +528,7 @@ describe('NativeService MCP boundary', () => {
 describe('NativeService quick search boundary', () => {
     it('searches shortcuts with the default page size', async () => {
         const response: QuickSearchResult = {
-            shortcuts: [
-                { name: 'TouchAI', path: 'D:/TouchAI.lnk', source: 'desktop_user' },
-            ],
+            shortcuts: [{ name: 'TouchAI', path: 'D:/TouchAI.lnk', source: 'desktop_user' }],
             files: [],
             total_files: 0,
             total_results: 1,

--- a/tests/services/native-service.test.ts
+++ b/tests/services/native-service.test.ts
@@ -17,7 +17,6 @@ import {
     type QuickSearchFileItem,
     type QuickSearchResult,
     type QuickSearchStatus,
-    type QuickShortcutItem,
     shortcut,
     window as windowCommands,
 } from '@services/NativeService';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,12 +3,13 @@ import { fileURLToPath } from 'node:url'
 
 import tailwindcss from '@tailwindcss/vite'
 import vue from '@vitejs/plugin-vue'
+import Icons from 'unplugin-icons/vite'
 import { defineConfig } from 'vitest/config'
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url))
 
 export default defineConfig({
-  plugins: [vue(), tailwindcss()],
+  plugins: [vue(), tailwindcss(), Icons()],
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
> First external contributors may need to complete the `CLA Assistant` check before merge.
> For code changes, this PR must link the related issue or RFC in the section below.

## Summary

Implements three enhancements to the QuickSearchPanel:
1. **Paginated results with infinite scroll** — Backend uses Everything SDK offset pagination. Frontend loads 60 results per page, appends more on scroll near bottom. Status bar shows page number and total count.
2. **List view mode** — New CSS Grid list layout (icon | filename | path). Grid/list toggle via Ctrl+G or status bar button. Each mode preserves its own expanded/collapsed state.
3. **Right-click context menu** — "Open containing folder" and "Copy path". Keyboard navigation (arrows, Enter, Escape). Menu open state prevents main keyboard router interception.

Additional improvements: `selectionMaxHeight` changed from imperative ref to computed for automatic height updates. Blur/restore preserves panel state. First search waits for Everything client lock. `lastSearchedQuery` guard prevents redundant re-searches.

## Related issue or RFC

- Closes #78

## AI assistance disclosure

- Tool(s) used: Claude Code (claude-sonnet-4-6)
- Scope of assistance: Full implementation of pagination, list view, context menu features across Rust backend (4 files) and Vue/TS frontend (13 files). Also code review fixes and simplify pass.
- Human review or rewrite performed: User reviewed each batch of changes before commit. Restored JSDoc comments removed by simplify pass. Verified UI behavior interactively.
- Architecture or boundary impact: New `QuickSearchResult` type in Rust/TS boundary. New `useContextMenu` keyboard handler. New `QuickSearchListItem.vue` component.

## Testing evidence

List the commands you ran and the results you observed.

- `pnpm type:check` — passes
- `pnpm lint:check` — passes
- `cargo check` — passes (on E: drive due to D: disk space)
- `pnpm tauri dev` — app starts, search works with pagination, list view renders, context menu opens with keyboard nav

```text
pnpm test:pr
pnpm test:coverage
pnpm test:e2e
```

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: None
- database baseline or migration impact: None
- release or packaging impact: None

## Screenshots or recordings

N/A — UI changes are in the QuickSearchPanel (search overlay), not visible in standard screenshots.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [ ] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [ ] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [ ] If I changed frontend runtime behavior or tests, I reviewed `pnpm test:coverage` and did not add coverage-only tests.
- [ ] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [ ] I added tests or explained why tests are not appropriate.
- [ ] I updated docs when behavior changed.