### PR TITLE
fix(ci): update pr-template-check script path after monorepo move

### DIFF
--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -26,4 +26,4 @@ jobs:
             - name: Validate PR body structure and linkage
               env:
                   PR_BODY: ${{ github.event.pull_request.body || '' }}
-              run: node scripts/ci/pr-template-check.js
+              run: node apps/desktop/scripts/ci/pr-template-check.js


### PR DESCRIPTION
## Summary
- Fix the "Cannot find module" error in the PR Template Check CI workflow
- Update the script path from `scripts/ci/pr-template-check.js` to `apps/desktop/scripts/ci/pr-template-check.js` to match the monorepo layout from #216

## Related issue or RFC
Fixes CI failures on all new PRs caused by #216 path migration

## AI assistance disclosure
AI-assisted (Claude Code)

## Testing evidence
- Verified the file exists at the new path on origin/main
- Confirmed the old path does not exist on origin/main
- The workflow uses `pull_request_target` which checks out the base branch, so this fix must be merged to main to take effect

## Risk notes
Low risk - single line path update in CI workflow

## Screenshots or recordings
N/A

## Checklist
- [x] Path matches monorepo structure
- [x] Workflow syntax verified