### PR TITLE
fix: keep SearchView auto-height in sync

### DIFF
--- a/apps/desktop/src/views/SearchView/composables/useSearchWindowResize.ts
+++ b/apps/desktop/src/views/SearchView/composables/useSearchWindowResize.ts
@@ -191,6 +191,7 @@ export function useSearchWindowResize(options: UseSearchWindowResizeOptions) {
         await native.window.resizeWindowHeight({
             targetHeight: newHeight,
             center: true,
+            animate: false,
             respectManualOverride: searchWindowHeightPolicy.value.respectManualOverride,
         });
         currentHeight.value = newHeight;

--- a/apps/desktop/tests/composables/SearchView/useSearchWindowResize.test.ts
+++ b/apps/desktop/tests/composables/SearchView/useSearchWindowResize.test.ts
@@ -182,6 +182,7 @@ describe('useSearchWindowResize', () => {
         expect(nativeMock.window.resizeWindowHeight).toHaveBeenCalledWith({
             targetHeight: 180,
             center: true,
+            animate: false,
             respectManualOverride: true,
         });
         expect(nativeMock.window.setSearchWindowMinSize).toHaveBeenLastCalledWith({


### PR DESCRIPTION
> First external contributors may need to complete the `CLA Assistant` check before merge.
> For code changes, this PR must link the related issue or RFC in the section below.

## Summary

Disable native animation for SearchView content-driven auto-height updates so the window can track multiline input growth immediately. This keeps the existing centering and manual-override policy intact, and updates the composable test expectation for the immediate resize contract.

## Related issue or RFC

- Related to #220

## AI assistance disclosure

- Tool(s) used: OpenAI Codex
- Scope of assistance: source inspection, minimal patch, PR preparation
- Human review or rewrite performed: reviewed the two-line diff and repository contribution requirements before push
- Architecture or boundary impact: none; this uses the existing `animate` IPC parameter already supported by the native resize command

## Testing evidence

```text
git diff --check
# passed

pnpm install --frozen-lockfile
# attempted twice in a fresh Windows clone; dependency linking did not complete before local timeout, so workspace binaries were unavailable

node ../../node_modules/.pnpm/vitest@4.1.6_*/node_modules/vitest/vitest.mjs run --configLoader runner --passWithNoTests tests/composables/SearchView/useSearchWindowResize.test.ts
# blocked by incomplete pnpm workspace links / missing local package resolution after the timed-out install
```

Did you follow TDD? The regression expectation was updated with the behavior change; local execution was blocked by dependency linking timeout, so CI is the first complete proof for this clone.

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: none
- database baseline or migration impact: none
- release or packaging impact: none

## Screenshots or recordings

Not included. This is a resize timing contract change with a focused test expectation.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [x] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [x] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.