### PR TITLE
ci(actions): harden workflow execution controls

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# Repository automation and release controls require explicit maintainer review.
+/.github/CODEOWNERS @hiqiancheng
+/.github/workflows/ @hiqiancheng
+/.github/actions/ @hiqiancheng
+/.github/dependabot.yml @hiqiancheng
+/.github/labeler.yml @hiqiancheng
+/.github/labels.yml @hiqiancheng
+/.github/pull_request_template.md @hiqiancheng
+
+# Release automation and update metadata can publish artifacts or change channels.
+/release-please-config.json @hiqiancheng
+/.release-please-manifest.json @hiqiancheng
+/apps/desktop/product.json @hiqiancheng
+/apps/desktop/scripts/ci/ @hiqiancheng

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         steps:
             - id: classify
               name: Detect docs-only pull requests
-              uses: actions/github-script@v9
+              uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
               with:
                   script: |
                       if (context.eventName !== 'pull_request' && context.eventName !== 'push') {
@@ -135,13 +135,13 @@ jobs:
         if: github.event_name == 'pull_request'
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
               with:
                   fetch-depth: 0
 
-            - uses: pnpm/action-setup@v6
+            - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
 
-            - uses: actions/setup-node@v6
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
                   node-version: 22
                   cache: pnpm
@@ -174,7 +174,7 @@ jobs:
 
             - name: Dependency review
               if: needs.changes.outputs.docs_only != 'true'
-              uses: actions/dependency-review-action@v5
+              uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5
               with:
                   # Tauri/Wry currently pulls the vulnerable GTK3 glib 0.18 chain on Linux,
                   # and upstream has no non-vulnerable GTK3 release path yet.
@@ -192,13 +192,13 @@ jobs:
               if: needs.changes.outputs.docs_only == 'true'
               run: echo 'Frontend quality checks are skipped for docs-only changes.'
 
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
               if: needs.changes.outputs.docs_only != 'true'
 
-            - uses: pnpm/action-setup@v6
+            - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
               if: needs.changes.outputs.docs_only != 'true'
 
-            - uses: actions/setup-node@v6
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               if: needs.changes.outputs.docs_only != 'true'
               with:
                   node-version: 22
@@ -234,13 +234,13 @@ jobs:
               if: needs.changes.outputs.docs_only == 'true'
               run: echo 'Frontend tests are skipped for docs-only changes.'
 
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
               if: needs.changes.outputs.docs_only != 'true'
 
-            - uses: pnpm/action-setup@v6
+            - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
               if: needs.changes.outputs.docs_only != 'true'
 
-            - uses: actions/setup-node@v6
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               if: needs.changes.outputs.docs_only != 'true'
               with:
                   node-version: 22
@@ -261,7 +261,7 @@ jobs:
 
             - name: Upload coverage artifact
               if: needs.changes.outputs.docs_only != 'true'
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
               with:
                   name: frontend-coverage-report
                   path: apps/desktop/.coverage/unit
@@ -273,11 +273,11 @@ jobs:
         if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.site_changed == 'true'
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-            - uses: pnpm/action-setup@v6
+            - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
 
-            - uses: actions/setup-node@v6
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
                   node-version: 22
                   cache: pnpm
@@ -298,13 +298,13 @@ jobs:
               if: needs.changes.outputs.docs_only == 'true'
               run: echo 'Rust checks are skipped for docs-only changes.'
 
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
               if: needs.changes.outputs.docs_only != 'true'
 
-            - uses: pnpm/action-setup@v6
+            - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
               if: needs.changes.outputs.docs_only != 'true'
 
-            - uses: actions/setup-node@v6
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               if: needs.changes.outputs.docs_only != 'true'
               with:
                   node-version: 22
@@ -329,11 +329,11 @@ jobs:
 
             - name: Install Rust stable
               if: needs.changes.outputs.docs_only != 'true'
-              uses: dtolnay/rust-toolchain@stable
+              uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
             - name: Rust cache
               if: needs.changes.outputs.docs_only != 'true'
-              uses: swatinem/rust-cache@v2
+              uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
               with:
                   workspaces: apps/desktop/src-tauri -> ../../../rust-target/ci-check
 
@@ -359,20 +359,20 @@ jobs:
             - rust-checks
         runs-on: windows-latest
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-            - uses: pnpm/action-setup@v6
+            - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
 
-            - uses: actions/setup-node@v6
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
                   node-version: 22
                   cache: pnpm
 
             - name: Install Rust stable
-              uses: dtolnay/rust-toolchain@stable
+              uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
             - name: Rust cache
-              uses: swatinem/rust-cache@v2
+              uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
               with:
                   workspaces: apps/desktop/src-tauri -> target
 
@@ -394,14 +394,14 @@ jobs:
               run: pnpm install --frozen-lockfile
 
             - name: Build Tauri app
-              uses: tauri-apps/tauri-action@v0.6.2
+              uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0.6.2
               with:
                   projectPath: apps/desktop
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Upload installers
-              uses: actions/upload-artifact@v7.0.1
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   name: touchai-installers-windows-${{ steps.sha.outputs.short }}
                   path: |
@@ -410,7 +410,7 @@ jobs:
                   if-no-files-found: warn
 
             - name: Upload portable
-              uses: actions/upload-artifact@v7.0.1
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   name: touchai-portable-windows-${{ steps.sha.outputs.short }}
                   path: apps/desktop/src-tauri/target/release/${{ steps.product.outputs.main_exe }}

--- a/.github/workflows/community.yml
+++ b/.github/workflows/community.yml
@@ -40,8 +40,8 @@ jobs:
         permissions:
             issues: write
         steps:
-            - uses: actions/checkout@v6
-            - uses: EndBug/label-sync@v2
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+            - uses: EndBug/label-sync@52074158190acb45f3077f9099fea818aa43f97a # v2
               with:
                   config-file: .github/labels.yml
                   delete-other-labels: false
@@ -54,7 +54,7 @@ jobs:
             issues: write
         steps:
             - name: Add triage label
-              uses: actions/github-script@v9
+              uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
               with:
                   script: |
                       const issue_number = context.payload.issue.number;
@@ -75,7 +75,7 @@ jobs:
             contents: read
             pull-requests: write
         steps:
-            - uses: actions/labeler@v6
+            - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6
               with:
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
                   configuration-path: .github/labeler.yml
@@ -88,7 +88,7 @@ jobs:
             issues: write
         steps:
             - name: Process /assign and /unassign
-              uses: actions/github-script@v9
+              uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
               with:
                   script: |
                       const body = context.payload.comment.body.trim();
@@ -204,7 +204,7 @@ jobs:
             issues: write
         steps:
             - name: Remind or release stale claims
-              uses: actions/github-script@v9
+              uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
               with:
                   script: |
                       const owner = context.repo.owner;
@@ -306,7 +306,7 @@ jobs:
             issues: write
             pull-requests: write
         steps:
-            - uses: actions/stale@v10
+            - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10
               with:
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
                   days-before-stale: 14
@@ -324,7 +324,7 @@ jobs:
             issues: write
             pull-requests: write
         steps:
-            - uses: actions/stale@v10
+            - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10
               with:
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
                   days-before-pr-stale: 21

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -25,7 +25,7 @@ jobs:
         steps:
             - id: classify
               name: Detect docs-only pull requests
-              uses: actions/github-script@v9
+              uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
               with:
                   script: |
                       if (context.eventName !== 'pull_request' && context.eventName !== 'push') {
@@ -118,20 +118,20 @@ jobs:
             TOUCHAI_CARGO_TARGET_DIR: apps/desktop/src-tauri/target/e2e
             TOUCHAI_E2E_CARGO_PROFILE: ci-check
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-            - uses: pnpm/action-setup@v6
+            - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
 
-            - uses: actions/setup-node@v6
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
                   node-version: 22
                   cache: pnpm
 
             - name: Install Rust stable
-              uses: dtolnay/rust-toolchain@stable
+              uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
             - name: Rust cache
-              uses: swatinem/rust-cache@v2
+              uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
               with:
                   workspaces: apps/desktop/src-tauri -> target/e2e
 

--- a/.github/workflows/first-interaction.yml
+++ b/.github/workflows/first-interaction.yml
@@ -20,7 +20,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Welcome first-time issue author
-              uses: actions/github-script@v9
+              uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
               with:
                   script: |
                       const association = context.payload.issue.author_association;
@@ -95,7 +95,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Welcome first-time PR author
-              uses: actions/github-script@v9
+              uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
               with:
                   script: |
                       const association = context.payload.pull_request.author_association;

--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -18,7 +18,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out base branch workflow files
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
               with:
                   ref: ${{ github.event.pull_request.base.sha }}
                   persist-credentials: false

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,10 +8,7 @@ on:
             - main
 
 permissions:
-    contents: write
-    deployments: write
-    issues: write
-    pull-requests: write
+    contents: read
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
@@ -21,13 +18,17 @@ jobs:
     release-please:
         name: Release Please
         runs-on: ubuntu-latest
+        permissions:
+            contents: write
+            issues: write
+            pull-requests: write
         outputs:
             release_created: ${{ steps.release.outputs['apps/desktop--release_created'] }}
             version: ${{ steps.release.outputs['apps/desktop--version'] }}
             tag_name: ${{ steps.release.outputs['apps/desktop--tag_name'] }}
             sha: ${{ steps.release.outputs['apps/desktop--sha'] }}
         steps:
-            - uses: googleapis/release-please-action@v4
+            - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
               id: release
               with:
                   token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
@@ -38,6 +39,9 @@ jobs:
         name: Publish Windows stable release
         needs: release-please
         if: ${{ needs.release-please.outputs.release_created == 'true' }}
+        permissions:
+            contents: write
+            deployments: write
         uses: ./.github/workflows/velopack-build.yml
         with:
             channel: stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,7 @@ on:
         - cron: '0 18 * * *'
 
 permissions:
-    contents: write
-    deployments: write
+    contents: read
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
@@ -37,11 +36,11 @@ jobs:
             prerelease: ${{ steps.release.outputs.prerelease }}
             release_name: ${{ steps.release.outputs.release_name }}
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
               with:
                   fetch-depth: 0
 
-            - uses: actions/setup-node@v6
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
                   node-version: 22
 
@@ -56,6 +55,9 @@ jobs:
     publish-windows:
         name: Publish Windows prerelease
         needs: resolve
+        permissions:
+            contents: write
+            deployments: write
         uses: ./.github/workflows/velopack-build.yml
         with:
             channel: ${{ needs.resolve.outputs.channel }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,7 +26,7 @@ jobs:
         steps:
             - id: classify
               name: Detect docs-only pull requests
-              uses: actions/github-script@v9
+              uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
               with:
                   script: |
                       if (context.eventName !== 'pull_request' && context.eventName !== 'push') {
@@ -110,28 +110,28 @@ jobs:
               if: needs.changes.outputs.docs_only == 'true'
               run: echo "CodeQL is not required for docs-only pull requests (${{ matrix.language }})."
 
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
               if: needs.changes.outputs.docs_only != 'true'
 
             - name: Initialize CodeQL
               if: needs.changes.outputs.docs_only != 'true'
-              uses: github/codeql-action/init@v4
+              uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
               with:
                   languages: ${{ matrix.language }}
 
             - name: Set up Node
               if: needs.changes.outputs.docs_only != 'true' && matrix.language == 'rust'
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
                   node-version: 22
 
             - name: Set up pnpm
               if: needs.changes.outputs.docs_only != 'true' && matrix.language == 'rust'
-              uses: pnpm/action-setup@v6
+              uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
 
             - name: Install Rust stable
               if: needs.changes.outputs.docs_only != 'true' && matrix.language == 'rust'
-              uses: dtolnay/rust-toolchain@stable
+              uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
             - name: Install dependencies
               if: needs.changes.outputs.docs_only != 'true' && matrix.language == 'rust'
@@ -139,7 +139,7 @@ jobs:
 
             - name: Rust cache
               if: needs.changes.outputs.docs_only != 'true' && matrix.language == 'rust'
-              uses: swatinem/rust-cache@v2
+              uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
               with:
                   workspaces: apps/desktop/src-tauri -> target
                   shared-key: codeql
@@ -150,24 +150,24 @@ jobs:
 
             - name: Analyze
               if: needs.changes.outputs.docs_only != 'true'
-              uses: github/codeql-action/analyze@v4
+              uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
 
     audits:
         name: Dependency audits
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-            - uses: actions/setup-node@v6
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
                   node-version: 22
                   cache: pnpm
 
-            - uses: pnpm/action-setup@v6
+            - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
 
             - name: Install Rust stable
-              uses: dtolnay/rust-toolchain@stable
+              uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
             - name: Install dependencies
               run: pnpm install --frozen-lockfile

--- a/.github/workflows/thanks-on-merge.yml
+++ b/.github/workflows/thanks-on-merge.yml
@@ -17,7 +17,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Post merge thank-you comment
-              uses: actions/github-script@v9
+              uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
               with:
                   script: |
                       const association = context.payload.pull_request.author_association;

--- a/.github/workflows/velopack-build.yml
+++ b/.github/workflows/velopack-build.yml
@@ -27,29 +27,30 @@ jobs:
     build-windows:
         name: Build Windows Velopack release
         runs-on: windows-latest
+        environment: release
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
               with:
                   ref: ${{ inputs.target-commitish }}
                   fetch-depth: 0
 
-            - uses: pnpm/action-setup@v6
+            - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
 
-            - uses: actions/setup-node@v6
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
                   node-version: 22
                   cache: pnpm
 
             - name: Install Rust stable
-              uses: dtolnay/rust-toolchain@stable
+              uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
             - name: Install .NET SDK
-              uses: actions/setup-dotnet@v5
+              uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
               with:
                   dotnet-version: 8.0.x
 
             - name: Rust cache
-              uses: swatinem/rust-cache@v2
+              uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
               with:
                   workspaces: apps/desktop/src-tauri -> target
 
@@ -247,7 +248,7 @@ jobs:
                     --notes-file "$env:RELEASE_NOTES_PATH"
 
             - name: Upload update channel JSON artifact
-              uses: actions/upload-artifact@v7.0.1
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   name: touchai-update-channels
                   path: ${{ runner.temp }}/touchai-update-dist
@@ -267,7 +268,7 @@ jobs:
                     --branch="$env:CLOUDFLARE_PAGES_BRANCH"
 
             - name: Upload Velopack diagnostics artifact
-              uses: actions/upload-artifact@v7.0.1
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   name: touchai-velopack-windows-${{ inputs.channel }}-${{ inputs.version }}
                   path: ${{ env.VELOPACK_RELEASE }}


### PR DESCRIPTION
## Summary

Harden GitHub Actions execution controls for open-source contribution and release workflows.

This PR:

- adds CODEOWNERS for workflow, repository automation, release configuration, and update-channel metadata changes
- pins external workflow actions to full commit SHAs while keeping the prior tag in comments for reviewability
- scopes release workflow write permissions to the jobs that need them
- gates Velopack publishing and Cloudflare update-channel deployment behind the `release` GitHub Environment

Repository settings already updated outside this PR:

- created the `release` environment with required reviewer hiqiancheng
- changed Actions policy from all to selected
- kept GitHub-owned actions allowed and explicitly allowed the current third-party action owners used by this repo
- changed default workflow token setting so Actions cannot approve pull request reviews

## Related issue or RFC

Closes #238

## AI assistance disclosure

- Tool(s) used: Codex
- Scope of assistance: repository security review, workflow hardening edits, GitHub API setting updates, validation commands
- Human review or rewrite performed: maintainer review required before merge through CODEOWNERS/ruleset
- Architecture or boundary impact: CI/release automation only; no app runtime or product behavior change

## Testing evidence

```text
python YAML parse over .github/workflows/*.yml
Result: parsed all 10 workflow files

python external action pinning check
Result: all external actions are pinned to full SHA

git diff --check HEAD~1 HEAD
Result: no whitespace errors

gh api repos/TouchAI-org/TouchAI/environments/release
Result: release environment exists with required reviewer and protected-branch deployment policy

gh api repos/TouchAI-org/TouchAI/actions/permissions
Result: allowed_actions=selected, sha_pinning_required=false

gh api repos/TouchAI-org/TouchAI/actions/permissions/selected-actions
Result: GitHub-owned actions allowed; current third-party action patterns explicitly allowed
```

pnpm test:pr was not run because this PR changes repository workflow configuration only and the working copy is a sparse CI/security checkout used to avoid the main workspace disk-full state.

## Risk notes

- AgentService, runtime, MCP, or schema impact: none
- database baseline or migration impact: none
- release or packaging impact: release jobs now require the protected `release` environment before publishing artifacts or deploying update metadata
- follow-up after merge: enable repository-level SHA pinning once this SHA-pinned workflow set is on the default branch

## Screenshots or recordings

Not applicable.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use [WIP] or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches AgentService, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran pnpm test:pr for this code PR, or this is a docs-only change.
- [ ] If I changed Rust behavior or tests, I reviewed pnpm test:coverage:rust or relied on CI coverage evidence.
- [ ] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran pnpm test:e2e locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [ ] I updated docs when behavior changed.