### PR TITLE
fix(release): include update notes and downloads

### DIFF
--- a/.github/workflows/velopack-build.yml
+++ b/.github/workflows/velopack-build.yml
@@ -248,7 +248,9 @@ jobs:
                     --channel "${{ inputs.channel }}" `
                     --version "${{ inputs.version }}" `
                     --tag "${{ inputs.tag }}" `
-                    --prerelease "${{ inputs.prerelease }}"
+                    --prerelease "${{ inputs.prerelease }}" `
+                    --release-notes-file "$env:RELEASE_NOTES_PATH" `
+                    --release-dir "$env:VELOPACK_RELEASE"
 
             - name: Upload update channel JSON artifact
               uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/apps/desktop/scripts/ci/build-update-channels.d.mts
+++ b/apps/desktop/scripts/ci/build-update-channels.d.mts
@@ -4,6 +4,13 @@ export type BuildUpdateChannelsLatest = {
     releaseUrl: string;
     publishedAt: string | null;
     prerelease: boolean;
+    releaseNotes?: string | null;
+    downloads?: Array<{
+        kind: 'installer' | 'portable' | 'fullPackage' | 'deltaPackage' | 'asset';
+        name: string;
+        url: string;
+        sizeBytes: number | null;
+    }>;
 };
 
 export type BuildUpdateChannelsOptions = {
@@ -15,6 +22,10 @@ export type BuildUpdateChannelsOptions = {
         tag: string;
         publishedAt?: string | null;
         prerelease: boolean;
+        releaseNotes?: string | null;
+        releaseNotesFile?: string | null;
+        releaseDir?: string | null;
+        downloads?: BuildUpdateChannelsLatest['downloads'];
     } | null;
     latestByChannel?: Record<string, BuildUpdateChannelsLatest | null>;
 };

--- a/apps/desktop/scripts/ci/build-update-channels.mjs
+++ b/apps/desktop/scripts/ci/build-update-channels.mjs
@@ -1,8 +1,9 @@
-import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, readdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 const REQUIRED_SEVERITIES = ['critical', 'security', 'recommended'];
+const DOWNLOAD_KINDS = ['installer', 'portable', 'fullPackage', 'deltaPackage', 'asset'];
 const SEMVER_PATTERN =
     /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
 const SEMVER_CAPTURE_PATTERN =
@@ -38,6 +39,12 @@ function assertAbsoluteHttpsUrl(value, label) {
 
     if (url.protocol !== 'https:') {
         throw new Error(`${label} must use https.`);
+    }
+}
+
+function assertNullableNonNegativeInteger(value, label) {
+    if (value !== null && (!Number.isInteger(value) || value < 0)) {
+        throw new Error(`${label} must be a non-negative integer or null.`);
     }
 }
 
@@ -81,6 +88,47 @@ function normalizePolicy(policy, channel) {
     };
 }
 
+function normalizeReleaseNotes(value, label) {
+    assertNullableString(value, label);
+    if (value === null) {
+        return null;
+    }
+
+    const notes = value.trim();
+    return notes ? notes : null;
+}
+
+function normalizeDownload(value, label) {
+    assertObject(value, label);
+    assertNonEmptyString(value.kind, `${label}.kind`);
+    if (!DOWNLOAD_KINDS.includes(value.kind)) {
+        throw new Error(`${label}.kind must be one of ${DOWNLOAD_KINDS.join(', ')}.`);
+    }
+    assertNonEmptyString(value.name, `${label}.name`);
+    assertAbsoluteHttpsUrl(value.url, `${label}.url`);
+
+    const sizeBytes = value.sizeBytes ?? null;
+    assertNullableNonNegativeInteger(sizeBytes, `${label}.sizeBytes`);
+
+    return {
+        kind: value.kind,
+        name: value.name,
+        url: value.url,
+        sizeBytes,
+    };
+}
+
+function normalizeDownloads(value, channel) {
+    const downloads = value ?? [];
+    if (!Array.isArray(downloads)) {
+        throw new Error(`${channel}.latest.downloads must be an array.`);
+    }
+
+    return downloads.map((download, index) =>
+        normalizeDownload(download, `${channel}.latest.downloads[${index}]`)
+    );
+}
+
 function normalizeLatestRelease(value, channel) {
     if (value === undefined || value === null) {
         return null;
@@ -104,6 +152,11 @@ function normalizeLatestRelease(value, channel) {
         releaseUrl: value.releaseUrl,
         publishedAt,
         prerelease: value.prerelease,
+        releaseNotes: normalizeReleaseNotes(
+            value.releaseNotes ?? null,
+            `${channel}.latest.releaseNotes`
+        ),
+        downloads: normalizeDownloads(value.downloads, channel),
     };
 }
 
@@ -205,6 +258,118 @@ async function readProduct(projectRoot) {
 
 function releaseUrl(product, tag) {
     return `${product.repository.releasesUrl.replace(/\/+$/g, '')}/tag/${tag}`;
+}
+
+function releaseDownloadUrl(product, tag, fileName) {
+    return `${product.repository.url.replace(/\/+$/g, '')}/releases/download/${encodeURIComponent(
+        tag
+    )}/${encodeURIComponent(fileName)}`;
+}
+
+function downloadKindFromFileName(fileName) {
+    const lowerName = fileName.toLowerCase();
+    if (lowerName.endsWith('-setup.exe')) {
+        return 'installer';
+    }
+    if (lowerName.endsWith('-portable.zip')) {
+        return 'portable';
+    }
+    if (lowerName.endsWith('-full.nupkg')) {
+        return 'fullPackage';
+    }
+    if (lowerName.endsWith('-delta.nupkg')) {
+        return 'deltaPackage';
+    }
+    return null;
+}
+
+function sortDownloads(downloads) {
+    const order = new Map(DOWNLOAD_KINDS.map((kind, index) => [kind, index]));
+    return [...downloads].sort(
+        (left, right) =>
+            (order.get(left.kind) ?? DOWNLOAD_KINDS.length) -
+                (order.get(right.kind) ?? DOWNLOAD_KINDS.length) ||
+            left.name.localeCompare(right.name)
+    );
+}
+
+function mergeDownloads(...downloadLists) {
+    const merged = new Map();
+    for (const downloads of downloadLists) {
+        for (const download of downloads ?? []) {
+            const key = `${download.kind}:${download.name}`;
+            if (!merged.has(key)) {
+                merged.set(key, download);
+            }
+        }
+    }
+    return sortDownloads([...merged.values()]);
+}
+
+function releaseDownloadsFromGithubAssets(assets, version) {
+    if (!Array.isArray(assets)) {
+        return [];
+    }
+
+    const downloads = [];
+    for (const asset of assets) {
+        const name = asset?.name;
+        const url = asset?.browser_download_url;
+        if (typeof name !== 'string' || typeof url !== 'string') {
+            continue;
+        }
+
+        if (version && !name.includes(version)) {
+            continue;
+        }
+
+        const kind = downloadKindFromFileName(name);
+        if (!kind) {
+            continue;
+        }
+
+        downloads.push({
+            kind,
+            name,
+            url,
+            sizeBytes: Number.isInteger(asset.size) && asset.size >= 0 ? asset.size : null,
+        });
+    }
+
+    return sortDownloads(downloads);
+}
+
+async function releaseDownloadsFromDirectory(product, tag, releaseDir, version) {
+    if (!releaseDir) {
+        return [];
+    }
+
+    const entries = await readdir(releaseDir, { withFileTypes: true });
+    const downloads = [];
+    for (const entry of entries) {
+        if (!entry.isFile()) {
+            continue;
+        }
+
+        if (version && !entry.name.includes(version)) {
+            continue;
+        }
+
+        const kind = downloadKindFromFileName(entry.name);
+        if (!kind) {
+            continue;
+        }
+
+        const fileStat = await stat(join(releaseDir, entry.name));
+        downloads.push({
+            kind,
+            name: entry.name,
+            url: releaseDownloadUrl(product, tag, entry.name),
+            sizeBytes: fileStat.size,
+        });
+    }
+
+    return sortDownloads(downloads);
 }
 
 function parseVersion(value) {
@@ -319,6 +484,8 @@ function releaseCandidateFromGithubRelease(product, release) {
             releaseUrl: release.html_url ?? releaseUrl(product, tag),
             publishedAt: release.published_at ?? null,
             prerelease: Boolean(release.prerelease),
+            releaseNotes: normalizeReleaseNotes(release.body ?? null, `${tag}.releaseNotes`),
+            downloads: releaseDownloadsFromGithubAssets(release.assets, parsedVersion.version),
         },
         parsedVersion,
     };
@@ -349,7 +516,11 @@ function latestByChannelFromGithubReleases(product, releases) {
     );
 }
 
-function latestByChannelFromRelease(product, release, fallbackPublishedAt) {
+function releaseByTag(releases, tag) {
+    return releases.find((release) => release?.tag_name === tag) ?? null;
+}
+
+function latestByChannelFromRelease(product, release, fallbackPublishedAt, releases) {
     if (!release) {
         return {};
     }
@@ -363,13 +534,23 @@ function latestByChannelFromRelease(product, release, fallbackPublishedAt) {
         throw new Error('release prerelease must be a boolean.');
     }
 
+    const githubRelease = releaseByTag(releases, tag);
+    const githubLatest = githubRelease
+        ? releaseCandidateFromGithubRelease(product, githubRelease)?.latest
+        : null;
+
     return {
         [channel]: {
             version,
             tag,
-            releaseUrl: releaseUrl(product, tag),
-            publishedAt: publishedAt ?? fallbackPublishedAt,
+            releaseUrl: githubLatest?.releaseUrl ?? releaseUrl(product, tag),
+            publishedAt: publishedAt ?? githubLatest?.publishedAt ?? fallbackPublishedAt,
             prerelease,
+            releaseNotes: normalizeReleaseNotes(
+                release.releaseNotes ?? githubLatest?.releaseNotes ?? null,
+                `${channel}.latest.releaseNotes`
+            ),
+            downloads: mergeDownloads(release.downloads, githubLatest?.downloads),
         },
     };
 }
@@ -406,9 +587,28 @@ export async function buildUpdateChannels(projectRoot, outputRoot, now = new Dat
     const updates = product.services.updates;
     const outputDir = join(outputRoot, relativeUpdatePath(updates.baseUrl), 'channels');
     const releases = await githubReleases(options.githubRepository, options.githubToken);
+    const release = options.release
+        ? {
+              ...options.release,
+              releaseNotes:
+                  options.release.releaseNotes ??
+                  (options.release.releaseNotesFile
+                      ? await readFile(options.release.releaseNotesFile, 'utf8')
+                      : null),
+              downloads: mergeDownloads(
+                  await releaseDownloadsFromDirectory(
+                      product,
+                      options.release.tag,
+                      options.release.releaseDir,
+                      options.release.version
+                  ),
+                  options.release.downloads
+              ),
+          }
+        : null;
     const latestByChannel = {
         ...latestByChannelFromGithubReleases(product, releases),
-        ...latestByChannelFromRelease(product, options.release, generatedAt),
+        ...latestByChannelFromRelease(product, release, generatedAt, releases),
         ...(options.latestByChannel ?? {}),
     };
 
@@ -470,6 +670,8 @@ function parseCliOptions(argv) {
             tag: options.tag,
             prerelease: booleanArg(options.prerelease, '--prerelease'),
             publishedAt: options['published-at'] ?? null,
+            releaseNotesFile: options['release-notes-file'] ?? null,
+            releaseDir: options['release-dir'] ?? null,
         };
     }
 

--- a/apps/desktop/src-tauri/src/core/updater/mod.rs
+++ b/apps/desktop/src-tauri/src/core/updater/mod.rs
@@ -102,6 +102,19 @@ pub struct AppUpdateChannelLatest {
     pub release_url: String,
     pub published_at: Option<String>,
     pub prerelease: bool,
+    #[serde(default)]
+    pub release_notes: Option<String>,
+    #[serde(default)]
+    pub downloads: Vec<AppUpdateDownload>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AppUpdateDownload {
+    pub kind: String,
+    pub name: String,
+    pub url: String,
+    pub size_bytes: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -685,6 +698,13 @@ mod tests {
                 .to_string(),
             published_at: Some("2026-05-24T00:00:00.000Z".to_string()),
             prerelease: true,
+            release_notes: Some("Security fixes".to_string()),
+            downloads: vec![AppUpdateDownload {
+                kind: "installer".to_string(),
+                name: "TouchAI-beta-0.2.1-beta.1-Setup.exe".to_string(),
+                url: "https://github.com/TouchAI-org/TouchAI/releases/download/v0.2.1-beta.1/TouchAI-beta-0.2.1-beta.1-Setup.exe".to_string(),
+                size_bytes: Some(12_000_000),
+            }],
         });
         let result = map_manager_init_error(
             AppUpdateChannel::Beta,
@@ -756,7 +776,16 @@ mod tests {
             "tag": "v0.2.1",
             "releaseUrl": format!("{}/releases/tag/v0.2.1", config.repository.url),
             "publishedAt": "2026-05-24T00:00:00.000Z",
-            "prerelease": false
+            "prerelease": false,
+            "releaseNotes": "Bug fixes",
+            "downloads": [
+                {
+                    "kind": "installer",
+                    "name": "TouchAI-0.2.1-Setup.exe",
+                    "url": format!("{}/releases/download/v0.2.1/TouchAI-0.2.1-Setup.exe", config.repository.url),
+                    "sizeBytes": 12000000
+                }
+            ]
         });
         let body = serde_json::json!({
             "schemaVersion": 1,
@@ -786,6 +815,16 @@ mod tests {
                 release_url: format!("{}/releases/tag/v0.2.1", config.repository.url),
                 published_at: Some("2026-05-24T00:00:00.000Z".to_string()),
                 prerelease: false,
+                release_notes: Some("Bug fixes".to_string()),
+                downloads: vec![AppUpdateDownload {
+                    kind: "installer".to_string(),
+                    name: "TouchAI-0.2.1-Setup.exe".to_string(),
+                    url: format!(
+                        "{}/releases/download/v0.2.1/TouchAI-0.2.1-Setup.exe",
+                        config.repository.url
+                    ),
+                    size_bytes: Some(12_000_000),
+                }],
             })
         );
         assert_eq!(policy.minimum_supported_version.as_deref(), Some("0.2.1"));

--- a/apps/desktop/src-tauri/tests/updater_commands.rs
+++ b/apps/desktop/src-tauri/tests/updater_commands.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use common::{build_test_app, invoke_command_ok, TestAppOptions};
-use serde_json::json;
+use serde_json::{json, Value};
 
 #[test]
 fn updater_check_reports_unsupported_when_app_is_not_velopack_installed() {
@@ -13,22 +13,47 @@ fn updater_check_reports_unsupported_when_app_is_not_velopack_installed() {
         json!({ "channel": "beta" }),
     );
 
+    assert_eq!(response["status"], json!("unsupported"));
+    assert_eq!(response["channel"], json!("beta"));
+    assert_eq!(response["currentVersion"], Value::Null);
+    assert_eq!(response["reason"], json!("not_installed"));
     assert_eq!(
-        response,
+        response["message"],
+        json!("应用通过正式安装包安装后才能使用自动更新。")
+    );
+    assert_eq!(
+        response["requirement"],
         json!({
-            "status": "unsupported",
-            "channel": "beta",
-            "currentVersion": null,
-            "latest": null,
-            "reason": "not_installed",
-            "message": "应用通过正式安装包安装后才能使用自动更新。",
-            "requirement": {
-                "required": false,
-                "minimumSupportedVersion": null,
-                "requiredSeverity": null,
-                "requiredReason": null,
-                "targetSatisfiesRequirement": true
-            }
+            "required": false,
+            "minimumSupportedVersion": null,
+            "requiredSeverity": null,
+            "requiredReason": null,
+            "targetSatisfiesRequirement": true
         })
     );
+
+    if let Some(latest) = response["latest"].as_object() {
+        assert!(latest
+            .get("version")
+            .and_then(Value::as_str)
+            .is_some_and(|version| !version.is_empty()));
+        assert!(latest
+            .get("tag")
+            .and_then(Value::as_str)
+            .is_some_and(|tag| !tag.is_empty()));
+        assert!(latest
+            .get("releaseUrl")
+            .and_then(Value::as_str)
+            .is_some_and(|url| url.starts_with("https://")));
+        assert!(latest
+            .get("publishedAt")
+            .is_some_and(|value| value.is_null() || value.is_string()));
+        assert!(latest.get("prerelease").and_then(Value::as_bool).is_some());
+        assert!(latest
+            .get("releaseNotes")
+            .is_some_and(|value| value.is_null() || value.is_string()));
+        assert!(latest.get("downloads").and_then(Value::as_array).is_some());
+    } else {
+        assert_eq!(response["latest"], Value::Null);
+    }
 }

--- a/apps/desktop/src/components/AppUpdateRequiredGate.vue
+++ b/apps/desktop/src/components/AppUpdateRequiredGate.vue
@@ -30,9 +30,22 @@
             (requirement.value?.targetSatisfiesRequirement ?? false)
     );
     const canInstall = computed(() => updateState.value.status === 'downloaded');
-    const releaseNotes = computed(() => visibleUpdate.value?.notes?.trim() ?? '');
-    const releasePageUrl = computed(
-        () => latestUpdate.value?.releaseUrl ?? APP_PRODUCT_CONFIG.repository.releasesUrl
+    const releaseNotes = computed(
+        () => visibleUpdate.value?.notes?.trim() || latestUpdate.value?.releaseNotes?.trim() || ''
+    );
+    const directDownloadUrl = computed(() => {
+        const downloads = latestUpdate.value?.downloads ?? [];
+        return (
+            downloads.find((download) => download.kind === 'installer')?.url ??
+            downloads.find((download) => download.kind === 'portable')?.url ??
+            null
+        );
+    });
+    const releaseDownloadUrl = computed(
+        () =>
+            directDownloadUrl.value ??
+            latestUpdate.value?.releaseUrl ??
+            APP_PRODUCT_CONFIG.repository.releasesUrl
     );
     const targetVersionText = computed(() => {
         if (visibleUpdate.value?.version) {
@@ -80,7 +93,7 @@
             return '下载更新';
         }
 
-        return '打开下载页';
+        return directDownloadUrl.value ? '下载安装包' : '打开下载页';
     });
 
     onMounted(async () => {
@@ -115,7 +128,7 @@
             return;
         }
 
-        await openUrl(releasePageUrl.value);
+        await openUrl(releaseDownloadUrl.value);
     }
 
     async function checkAgain() {
@@ -217,7 +230,9 @@
                                 ? 'check-circle'
                                 : canUseInAppUpdate
                                   ? 'arrow-down'
-                                  : 'folder-open'
+                                  : directDownloadUrl
+                                    ? 'arrow-down'
+                                    : 'folder-open'
                         "
                         class="h-4 w-4"
                     />

--- a/apps/desktop/src/services/AppUpdateService/types.ts
+++ b/apps/desktop/src/services/AppUpdateService/types.ts
@@ -2,6 +2,7 @@ import type {
     AppUpdateChannel,
     AppUpdateChannelLatest,
     AppUpdateCheckResult,
+    AppUpdateDownload,
     AppUpdateInfo,
     AppUpdateRequirement,
 } from '@services/NativeService/types';
@@ -10,6 +11,7 @@ export type {
     AppUpdateChannel,
     AppUpdateChannelLatest,
     AppUpdateCheckResult,
+    AppUpdateDownload,
     AppUpdateInfo,
     AppUpdateRequirement,
 };

--- a/apps/desktop/src/services/NativeService/index.ts
+++ b/apps/desktop/src/services/NativeService/index.ts
@@ -24,6 +24,7 @@ export type {
     AppUpdateChannel,
     AppUpdateChannelLatest,
     AppUpdateCheckResult,
+    AppUpdateDownload,
     AppUpdateInfo,
     AppUpdateRequirement,
     BuiltInBashExecutionRequest,

--- a/apps/desktop/src/services/NativeService/types.ts
+++ b/apps/desktop/src/services/NativeService/types.ts
@@ -90,12 +90,21 @@ export interface AppUpdateRequirement {
     targetSatisfiesRequirement: boolean;
 }
 
+export interface AppUpdateDownload {
+    kind: 'installer' | 'portable' | 'fullPackage' | 'deltaPackage' | 'asset' | string;
+    name: string;
+    url: string;
+    sizeBytes: number | null;
+}
+
 export interface AppUpdateChannelLatest {
     version: string;
     tag: string;
     releaseUrl: string;
     publishedAt: string | null;
     prerelease: boolean;
+    releaseNotes: string | null;
+    downloads: AppUpdateDownload[];
 }
 
 export type AppUpdateCheckResult =

--- a/apps/desktop/src/views/SettingsView/components/About/index.vue
+++ b/apps/desktop/src/views/SettingsView/components/About/index.vue
@@ -43,6 +43,17 @@
     );
     const latestUpdate = computed(() => updateState.value.latestUpdate);
     const updateRequirement = computed(() => updateState.value.updateRequirement);
+    const directDownloadUrl = computed(() => {
+        const downloads = latestUpdate.value?.downloads ?? [];
+        return (
+            downloads.find((download) => download.kind === 'installer')?.url ??
+            downloads.find((download) => download.kind === 'portable')?.url ??
+            null
+        );
+    });
+    const updateDownloadUrl = computed(
+        () => directDownloadUrl.value ?? latestUpdate.value?.releaseUrl ?? links.releasesUrl
+    );
     const currentChannelLabel = computed(
         () =>
             updateChannelOptions.find((option) => option.value === updateState.value.channel)
@@ -144,6 +155,10 @@
 
         if (visibleUpdate.value?.notes) {
             return visibleUpdate.value.notes;
+        }
+
+        if (latestUpdate.value?.releaseNotes) {
+            return latestUpdate.value.releaseNotes;
         }
 
         if (latestUpdate.value?.version) {
@@ -280,7 +295,7 @@
     };
 
     const openUpdateDownloadPage = async () => {
-        await openLink(latestUpdate.value?.releaseUrl ?? links.releasesUrl);
+        await openLink(updateDownloadUrl.value);
     };
 
     const toggleAutoCheck = async () => {
@@ -459,7 +474,7 @@
                             @click="openUpdateDownloadPage"
                         >
                             <AppIcon name="arrow-down" class="h-4 w-4" />
-                            下载页
+                            {{ directDownloadUrl ? '安装包' : '下载页' }}
                         </button>
                         <button
                             v-if="updateState.status === 'downloaded'"

--- a/apps/desktop/tests/ci/build-update-channels.test.ts
+++ b/apps/desktop/tests/ci/build-update-channels.test.ts
@@ -12,12 +12,31 @@ type ChannelLatestFixture = {
     releaseUrl: string;
     publishedAt: string | null;
     prerelease: boolean;
+    releaseNotes?: string | null;
+    downloads?: ChannelDownloadFixture[];
+};
+type ChannelDownloadFixture = {
+    kind: 'installer' | 'portable' | 'fullPackage' | 'deltaPackage' | 'asset';
+    name: string;
+    url: string;
+    sizeBytes: number | null;
 };
 type BuildUpdateChannels = (
     projectRoot: string,
     outputRoot: string,
     now?: Date,
-    options?: { latestByChannel?: Record<string, ChannelLatestFixture | null> }
+    options?: {
+        release?: {
+            channel: string;
+            version: string;
+            tag: string;
+            publishedAt?: string | null;
+            prerelease: boolean;
+            releaseNotesFile?: string | null;
+            releaseDir?: string | null;
+        } | null;
+        latestByChannel?: Record<string, ChannelLatestFixture | null>;
+    }
 ) => Promise<void>;
 type ProductConfigFixture = {
     schemaVersion: number;
@@ -208,19 +227,29 @@ describe('buildUpdateChannels', () => {
         const productFixture = cloneProductConfig();
         const root = await createFixture(productFixture);
         const outputRoot = join(root, 'dist');
+        const releaseDir = join(root, 'release');
+        const releaseNotesPath = join(root, 'release-notes.md');
+        const installerName = 'TouchAI-beta-0.1.1-beta.1-Setup.exe';
+        const portableName = 'TouchAI-beta-0.1.1-beta.1-Portable.zip';
+        const releaseTag = 'v0.1.1-beta.1';
+        const expectedReleaseUrl = `${productFixture.repository.releasesUrl}/tag/${releaseTag}`;
+        const expectedDownloadBaseUrl = `${productFixture.repository.url}/releases/download/${releaseTag}`;
+        await mkdir(releaseDir, { recursive: true });
+        await writeFile(releaseNotesPath, '## Changes\n\n- Beta fixes\n', 'utf8');
+        await writeFile(join(releaseDir, installerName), 'installer');
+        await writeFile(join(releaseDir, portableName), 'portable');
 
         try {
             expect(buildUpdateChannels).toBeTypeOf('function');
             await buildUpdateChannels?.(root, outputRoot, new Date('2026-05-24T00:00:00Z'), {
-                latestByChannel: {
-                    beta: {
-                        version: '0.1.1-beta.1',
-                        tag: 'v0.1.1-beta.1',
-                        releaseUrl:
-                            'https://github.com/TouchAI-org/TouchAI/releases/tag/v0.1.1-beta.1',
-                        publishedAt: '2026-05-24T16:37:32.103Z',
-                        prerelease: true,
-                    },
+                release: {
+                    channel: 'beta',
+                    version: '0.1.1-beta.1',
+                    tag: releaseTag,
+                    publishedAt: '2026-05-24T16:37:32.103Z',
+                    prerelease: true,
+                    releaseNotesFile: releaseNotesPath,
+                    releaseDir,
                 },
             });
 
@@ -233,10 +262,25 @@ describe('buildUpdateChannels', () => {
 
             expect(beta.latest).toEqual({
                 version: '0.1.1-beta.1',
-                tag: 'v0.1.1-beta.1',
-                releaseUrl: 'https://github.com/TouchAI-org/TouchAI/releases/tag/v0.1.1-beta.1',
+                tag: releaseTag,
+                releaseUrl: expectedReleaseUrl,
                 publishedAt: '2026-05-24T16:37:32.103Z',
                 prerelease: true,
+                releaseNotes: '## Changes\n\n- Beta fixes',
+                downloads: [
+                    {
+                        kind: 'installer',
+                        name: installerName,
+                        url: `${expectedDownloadBaseUrl}/${installerName}`,
+                        sizeBytes: 9,
+                    },
+                    {
+                        kind: 'portable',
+                        name: portableName,
+                        url: `${expectedDownloadBaseUrl}/${portableName}`,
+                        sizeBytes: 8,
+                    },
+                ],
             });
             expect(stable.latest).toBeNull();
         } finally {

--- a/apps/desktop/tests/components/AppUpdateRequiredGate.test.ts
+++ b/apps/desktop/tests/components/AppUpdateRequiredGate.test.ts
@@ -28,6 +28,15 @@ const latestUpdate = {
     releaseUrl: `${APP_PRODUCT_CONFIG.repository.releasesUrl}/tag/v0.2.1`,
     publishedAt: '2026-05-22T09:00:00.000Z',
     prerelease: false,
+    releaseNotes: 'Release notes from GitHub',
+    downloads: [
+        {
+            kind: 'installer',
+            name: 'TouchAI-0.2.1-Setup.exe',
+            url: `${APP_PRODUCT_CONFIG.repository.url}/releases/download/v0.2.1/TouchAI-0.2.1-Setup.exe`,
+            sizeBytes: 12_000_000,
+        },
+    ],
 };
 
 const baseState: AppUpdateState = {
@@ -118,7 +127,7 @@ describe('AppUpdateRequiredGate', () => {
         expect(appUpdateServiceMock.download).toHaveBeenCalledTimes(1);
     });
 
-    it('opens the release page when the channel has no satisfying update', async () => {
+    it('opens the direct installer when the channel has no satisfying update', async () => {
         appUpdateServiceMock.state = {
             ...baseState,
             status: 'not_available',
@@ -133,8 +142,9 @@ describe('AppUpdateRequiredGate', () => {
         const wrapper = mount(AppUpdateRequiredGate);
         await nextTick();
         expect(wrapper.text()).toContain('可更新到 0.2.1');
+        expect(wrapper.text()).toContain('Release notes from GitHub');
         await wrapper.get('[data-testid="app-update-required-primary"]').trigger('click');
 
-        expect(openUrl).toHaveBeenCalledWith(latestUpdate.releaseUrl);
+        expect(openUrl).toHaveBeenCalledWith(latestUpdate.downloads[0]!.url);
     });
 });

--- a/apps/desktop/tests/services/AppUpdateService/service.test.ts
+++ b/apps/desktop/tests/services/AppUpdateService/service.test.ts
@@ -21,6 +21,15 @@ const latestUpdate = {
     releaseUrl: `${APP_PRODUCT_CONFIG.repository.releasesUrl}/tag/v0.2.0`,
     publishedAt: '2026-05-22T09:00:00.000Z',
     prerelease: false,
+    releaseNotes: 'Release notes from GitHub',
+    downloads: [
+        {
+            kind: 'installer',
+            name: 'TouchAI-0.2.0-Setup.exe',
+            url: `${APP_PRODUCT_CONFIG.repository.url}/releases/download/v0.2.0/TouchAI-0.2.0-Setup.exe`,
+            sizeBytes: 12_000_000,
+        },
+    ],
 };
 
 const neutralRequirement = {

--- a/apps/desktop/tests/services/AppUpdateService/state.test.ts
+++ b/apps/desktop/tests/services/AppUpdateService/state.test.ts
@@ -21,6 +21,15 @@ const latestUpdate = {
     releaseUrl: `${APP_PRODUCT_CONFIG.repository.releasesUrl}/tag/v0.2.0`,
     publishedAt: '2026-05-22T09:00:00.000Z',
     prerelease: false,
+    releaseNotes: 'Release notes from GitHub',
+    downloads: [
+        {
+            kind: 'installer',
+            name: 'TouchAI-0.2.0-Setup.exe',
+            url: `${APP_PRODUCT_CONFIG.repository.url}/releases/download/v0.2.0/TouchAI-0.2.0-Setup.exe`,
+            sizeBytes: 12_000_000,
+        },
+    ],
 };
 
 const availableUpdate: AppUpdateCheckResult = {

--- a/apps/desktop/tests/services/native-service.test.ts
+++ b/apps/desktop/tests/services/native-service.test.ts
@@ -656,6 +656,15 @@ describe('NativeService supporting boundaries', () => {
                 releaseUrl: `${APP_PRODUCT_CONFIG.repository.releasesUrl}/tag/v0.2.0`,
                 publishedAt: '2026-05-22T09:00:00.000Z',
                 prerelease: false,
+                releaseNotes: 'Release notes from GitHub',
+                downloads: [
+                    {
+                        kind: 'installer',
+                        name: 'TouchAI-0.2.0-Setup.exe',
+                        url: `${APP_PRODUCT_CONFIG.repository.url}/releases/download/v0.2.0/TouchAI-0.2.0-Setup.exe`,
+                        sizeBytes: 12_000_000,
+                    },
+                ],
             },
             update,
             requirement: {

--- a/apps/desktop/tests/views/SettingsView/About.test.ts
+++ b/apps/desktop/tests/views/SettingsView/About.test.ts
@@ -20,6 +20,15 @@ const latestUpdate = {
     releaseUrl: `${APP_PRODUCT_CONFIG.repository.releasesUrl}/tag/v0.2.0`,
     publishedAt: '2026-05-22T09:00:00.000Z',
     prerelease: false,
+    releaseNotes: 'Release notes from GitHub',
+    downloads: [
+        {
+            kind: 'installer',
+            name: 'TouchAI-0.2.0-Setup.exe',
+            url: `${APP_PRODUCT_CONFIG.repository.url}/releases/download/v0.2.0/TouchAI-0.2.0-Setup.exe`,
+            sizeBytes: 12_000_000,
+        },
+    ],
 };
 
 const updateState: AppUpdateState = {


### PR DESCRIPTION
## Summary

- Add release notes and direct download metadata to generated update channel JSON.
- Carry update release notes/download links through native update parsing and frontend update UI.
- Prefer installer/portable direct download URLs for manual update fallback instead of only opening the GitHub release page.

## Related issue or RFC

Link the issue or RFC:

- Related to #48

For code changes, link the tracking issue. Only documentation wording, link fixes, or comment-only cleanups may skip the issue-first flow.

## AI assistance disclosure

If AI tools materially assisted this contribution, disclose that here or point to the relevant commit trailer.

- Tool(s) used: Codex
- Scope of assistance: implementation, test updates, local verification, PR preparation
- Human review or rewrite performed: pending maintainer review
- Architecture or boundary impact: release/update metadata contract now includes release notes and direct download assets

## Testing evidence

List the commands you ran and the results you observed.

- `git diff --check` - passed
- `node --check apps/desktop/scripts/ci/build-update-channels.mjs` - passed
- `cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml --all -- --check` - passed
- `pnpm exec prettier --check ...` for changed workflow, scripts, frontend, and tests - passed
- `pnpm --filter @touchai/desktop exec vue-tsc --noEmit` - passed
- `pnpm exec vitest run --configLoader runner tests/ci/build-update-channels.test.ts tests/components/AppUpdateRequiredGate.test.ts tests/views/SettingsView/About.test.ts tests/services/AppUpdateService/service.test.ts tests/services/AppUpdateService/state.test.ts tests/services/native-service.test.ts --passWithNoTests` - passed once locally: 6 files, 73 tests
- `pnpm exec vitest run --configLoader runner tests/ci/build-update-channels.test.ts --pool=forks --maxWorkers=1 --no-file-parallelism --passWithNoTests` with `TEMP/TMP` on `G:\TouchAI\tmp\issue-48-update-downloads` - passed: 1 file, 6 tests
- Manual channel JSON generation verified `latest.releaseNotes` and `latest.downloads` include GitHub release download URLs
- Full `pnpm test:pr` not run locally; relying on PR CI for the complete suite

Did you follow TDD (test-first) for feature and fix work? Strongly recommended. See [docs/testing/testing.md](../docs/testing/testing.md).

```text
pnpm test:pr
pnpm test:coverage:rust
pnpm test:e2e
```

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: none
- database baseline or migration impact: none
- release or packaging impact: update channel JSON schema now includes optional release notes and direct download entries; older remote JSON remains parseable on the native side

## Screenshots or recordings

Not included. This is primarily release metadata and update fallback behavior.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [ ] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [x] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [x] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.