### PR TITLE
fix: optimize QuickSearch cross-platform search behavior

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -6860,6 +6860,7 @@ dependencies = [
  "base64 0.22.1",
  "cc",
  "clipboard-rs",
+ "file_icon_provider",
  "flate2",
  "futures",
  "html5gum",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -111,3 +111,6 @@ windows = { version = "0.58", features = [
 ] }
 webview2-com = "0.38.0"
 windows-core = "0.61.2"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+file_icon_provider = "0.3.1"

--- a/apps/desktop/src-tauri/src/core/search/assets.rs
+++ b/apps/desktop/src-tauri/src/core/search/assets.rs
@@ -16,6 +16,7 @@
 //! 会被自动淘汰，防止任意路径探测。
 
 use super::types::QuickShortcutItem;
+#[cfg(target_os = "windows")]
 use log::warn;
 use std::{
     collections::{HashMap, HashSet},
@@ -28,6 +29,7 @@ use cache::{
     icon_cache, lock_mutex, normalize_icon_cache_key, normalize_thumbnail_cache_key,
     read_icon_from_disk_cache, write_icon_to_disk_cache,
 };
+#[cfg(target_os = "windows")]
 use win::{
     image_thumbnail_data_url_shell_item, is_shortcut_file, shortcut_icon_data_url_by_extension,
     shortcut_icon_data_url_fallback, shortcut_icon_data_url_shell_item,
@@ -188,6 +190,7 @@ pub(super) fn remember_search_paths(items: &[QuickShortcutItem]) {
 /// - 普通文件：先按扩展名查系统图标，失败再用 SHGetFileInfo 兜底。
 ///
 /// size 会被 clamp 到 [16, 128]。
+#[cfg(target_os = "windows")]
 pub(super) fn shortcut_icon_data_url(path: &str, size: u32) -> Result<Option<String>, String> {
     if path.trim().is_empty() {
         return Ok(None);
@@ -253,10 +256,41 @@ pub(super) fn shortcut_icon_data_url(path: &str, size: u32) -> Result<Option<Str
     Ok(icon)
 }
 
+/// 获取单个路径的 macOS 系统图标 Data URL。
+///
+/// 通过 NSWorkspace 提取应用、文件和文件夹图标，并经由内存 / 磁盘双层缓存
+/// 加速后续请求。size 会被 clamp 到 [16, 128]。
+#[cfg(target_os = "macos")]
+pub(super) fn shortcut_icon_data_url(path: &str, size: u32) -> Result<Option<String>, String> {
+    if path.trim().is_empty() {
+        return Ok(None);
+    }
+    let size = size.clamp(16, 128);
+
+    let cache_key = normalize_icon_cache_key(path, size);
+    if let Some(cached_icon) = lock_mutex(icon_cache()).get(&cache_key) {
+        return Ok(Some(cached_icon));
+    }
+    if let Some(disk_cached_icon) = read_icon_from_disk_cache(&cache_key) {
+        lock_mutex(icon_cache()).insert(cache_key.clone(), disk_cached_icon.clone());
+        return Ok(Some(disk_cached_icon));
+    }
+
+    let icon = mac::file_icon_data_url(path, size).unwrap_or(None);
+    if let Some(data_url) = icon.as_ref() {
+        lock_mutex(icon_cache()).insert(cache_key.clone(), data_url.clone());
+        write_icon_to_disk_cache(&cache_key, data_url);
+    }
+
+    Ok(icon)
+}
+
 /// 获取单个图片的缩略图 Data URL。
 ///
-/// 通过 IShellItemImageFactory 提取 Windows Shell 缓存中的缩略图，
-/// 并经由内存 / 磁盘双层缓存加速后续请求。size 会被 clamp 到 [24, 128]。
+/// 通过 IShellItemImageFactory 提取 Windows Shell 缓存中的缩略图，或在 macOS
+/// 使用 image crate 直接生成缩略图，并经由内存 / 磁盘双层缓存加速后续请求。
+/// size 会被 clamp 到 [24, 128]。
+#[cfg(target_os = "windows")]
 pub(super) fn image_thumbnail_data_url(path: &str, size: u32) -> Result<Option<String>, String> {
     if path.trim().is_empty() {
         return Ok(None);
@@ -284,6 +318,31 @@ pub(super) fn image_thumbnail_data_url(path: &str, size: u32) -> Result<Option<S
         }
     };
 
+    if let Some(data_url) = thumbnail.as_ref() {
+        lock_mutex(icon_cache()).insert(cache_key.clone(), data_url.clone());
+        write_icon_to_disk_cache(&cache_key, data_url);
+    }
+
+    Ok(thumbnail)
+}
+
+#[cfg(target_os = "macos")]
+pub(super) fn image_thumbnail_data_url(path: &str, size: u32) -> Result<Option<String>, String> {
+    if path.trim().is_empty() {
+        return Ok(None);
+    }
+
+    let size = size.clamp(24, 128);
+    let cache_key = normalize_thumbnail_cache_key(path, size);
+    if let Some(cached_thumbnail) = lock_mutex(icon_cache()).get(&cache_key) {
+        return Ok(Some(cached_thumbnail));
+    }
+    if let Some(disk_cached_thumbnail) = read_icon_from_disk_cache(&cache_key) {
+        lock_mutex(icon_cache()).insert(cache_key.clone(), disk_cached_thumbnail.clone());
+        return Ok(Some(disk_cached_thumbnail));
+    }
+
+    let thumbnail = mac::image_thumbnail_data_url(path, size).unwrap_or(None);
     if let Some(data_url) = thumbnail.as_ref() {
         lock_mutex(icon_cache()).insert(cache_key.clone(), data_url.clone());
         write_icon_to_disk_cache(&cache_key, data_url);
@@ -364,5 +423,9 @@ pub(super) fn get_image_thumbnails(
 mod cache;
 /// RGBA / BGRA 色彩转换与 Data URL 编码。
 mod codec;
+/// macOS NSWorkspace 图标 / 图片缩略图提取。
+#[cfg(target_os = "macos")]
+mod mac;
 /// Windows Shell API 图标 / 缩略图提取。
+#[cfg(target_os = "windows")]
 mod win;

--- a/apps/desktop/src-tauri/src/core/search/assets/cache.rs
+++ b/apps/desktop/src-tauri/src/core/search/assets/cache.rs
@@ -41,10 +41,10 @@ const CACHE_KEY_PREFIX_SHORTCUT: &str = "shortcut";
 const CACHE_KEY_PREFIX_IMAGE: &str = "image";
 /// 缓存键前缀：按扩展名共享图标。
 const CACHE_KEY_PREFIX_EXT: &str = "ext";
+/// 缓存键前缀：按完整路径缓存图标。
+const CACHE_KEY_PREFIX_PATH: &str = "path";
 /// 缓存键前缀：缩略图。
 const CACHE_KEY_PREFIX_THUMB: &str = "thumb";
-/// 无扩展名占位符。
-const CACHE_KEY_EXT_NONE_TOKEN: &str = "<none>";
 /// 快捷方式扩展名。
 const SHORTCUT_EXTENSION: &str = "lnk";
 /// Data URL 图片前缀。
@@ -136,6 +136,7 @@ pub(super) fn thumbnail_jpeg_quality() -> u8 {
 /// 键格式根据文件类型不同：
 /// - .lnk 快捷方式：shortcut|{path}|{size} — 每个快捷方式有独立图标
 /// - 图片文件：image|{path}|{size} — 每个图片有独立图标
+/// - .app 包 / 无扩展路径：path|{path}|{size} — 避免应用和文件夹串图标
 /// - 其他文件：ext|{ext}|{size} — 同扩展名共享系统图标
 pub(super) fn normalize_icon_cache_key(path: &str, size: u32) -> String {
     let normalized_path = path.replace('/', "\\").to_lowercase();
@@ -159,11 +160,11 @@ pub(super) fn normalize_icon_cache_key(path: &str, size: u32) -> String {
     }
 
     match extension {
+        Some(ext) if ext.eq_ignore_ascii_case("app") => {
+            format!("{}|{}|{}", CACHE_KEY_PREFIX_PATH, normalized_path, size)
+        }
         Some(ext) if !ext.is_empty() => format!("{}|{}|{}", CACHE_KEY_PREFIX_EXT, ext, size),
-        _ => format!(
-            "{}|{}|{}",
-            CACHE_KEY_PREFIX_EXT, CACHE_KEY_EXT_NONE_TOKEN, size
-        ),
+        _ => format!("{}|{}|{}", CACHE_KEY_PREFIX_PATH, normalized_path, size),
     }
 }
 
@@ -332,4 +333,33 @@ fn reencode_image_bytes_to_jpeg(bytes: &[u8], quality: u8) -> Result<Vec<u8>, St
         .encode(&rgb_bytes, width, height, ColorType::Rgb8.into())
         .map_err(|err| format!("Failed to encode cache image to JPEG: {}", err))?;
     Ok(jpeg_bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_icon_cache_key;
+
+    #[test]
+    fn extension_icons_share_cache_key() {
+        assert_eq!(
+            normalize_icon_cache_key("/Users/qian/a.txt", 48),
+            normalize_icon_cache_key("/Users/qian/b.txt", 48)
+        );
+    }
+
+    #[test]
+    fn app_bundle_icons_are_cached_by_path() {
+        assert_ne!(
+            normalize_icon_cache_key("/Applications/Safari.app", 48),
+            normalize_icon_cache_key("/Applications/Notes.app", 48)
+        );
+    }
+
+    #[test]
+    fn extensionless_icons_are_cached_by_path() {
+        assert_ne!(
+            normalize_icon_cache_key("/Users/qian/README", 48),
+            normalize_icon_cache_key("/Users/qian/Documents", 48)
+        );
+    }
 }

--- a/apps/desktop/src-tauri/src/core/search/assets/codec.rs
+++ b/apps/desktop/src-tauri/src/core/search/assets/codec.rs
@@ -20,6 +20,7 @@ use std::io::Cursor;
 ///
 /// Windows GDI 返回的位图数据为 BGRA 排列，需交换 R/B 通道后才能
 /// 传入 image crate 或编码为标准 PNG/JPEG。
+#[cfg(target_os = "windows")]
 pub(super) fn bgra_to_rgba(bgra: &[u8]) -> Vec<u8> {
     let mut rgba = Vec::with_capacity(bgra.len());
     for pixel in bgra.chunks_exact(4) {

--- a/apps/desktop/src-tauri/src/core/search/assets/mac.rs
+++ b/apps/desktop/src-tauri/src/core/search/assets/mac.rs
@@ -1,0 +1,82 @@
+// Copyright (c) 2026. 千诚. Licensed under GPL v3.
+
+//! macOS 图标与图片缩略图提取。
+//!
+//! 文件/应用/文件夹图标走 NSWorkspace（通过 file_icon_provider 封装），
+//! 图片缩略图直接用 image crate 解码并按比例缩放。
+
+use std::path::Path;
+
+use file_icon_provider::get_file_icon;
+use image::GenericImageView;
+
+use super::{
+    cache::thumbnail_jpeg_quality,
+    codec::{encode_rgba_to_jpeg_data_url, encode_rgba_to_png_data_url},
+};
+
+/// 获取路径对应的 macOS 系统图标。
+pub(super) fn file_icon_data_url(path: &str, size: u32) -> Result<Option<String>, String> {
+    let trimmed = path.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+
+    let size = size.clamp(16, 256) as u16;
+    let icon = match get_file_icon(Path::new(trimmed), size) {
+        Ok(icon) => icon,
+        Err(error) => return Err(format!("Failed to get macOS file icon: {}", error)),
+    };
+
+    encode_rgba_to_png_data_url(icon.width, icon.height, icon.pixels).map(Some)
+}
+
+/// 获取图片内容缩略图。
+pub(super) fn image_thumbnail_data_url(path: &str, size: u32) -> Result<Option<String>, String> {
+    let trimmed = path.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+
+    let size = size.clamp(24, 256);
+    let image = image::open(trimmed).map_err(|error| {
+        format!(
+            "Failed to open image for macOS thumbnail '{}': {}",
+            trimmed, error
+        )
+    })?;
+    let (width, height) = image.dimensions();
+    if width == 0 || height == 0 {
+        return Ok(None);
+    }
+
+    let thumbnail = image.thumbnail(size, size).to_rgba8();
+    encode_rgba_to_jpeg_data_url(
+        thumbnail.width(),
+        thumbnail.height(),
+        thumbnail.as_raw(),
+        thumbnail_jpeg_quality(),
+    )
+    .map(Some)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::image_thumbnail_data_url;
+    use std::path::Path;
+
+    #[test]
+    fn image_thumbnail_returns_none_for_blank_path() {
+        assert!(image_thumbnail_data_url("   ", 56).unwrap().is_none());
+    }
+
+    #[test]
+    fn image_thumbnail_returns_error_for_missing_path() {
+        let missing = "/tmp/touchai-missing-thumbnail-input.png";
+        if Path::new(missing).exists() {
+            return;
+        }
+
+        assert!(image_thumbnail_data_url(missing, 56).is_err());
+    }
+}

--- a/apps/desktop/src-tauri/src/core/search/mod.rs
+++ b/apps/desktop/src-tauri/src/core/search/mod.rs
@@ -7,30 +7,32 @@
 
 use std::collections::HashMap;
 
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 use tauri::async_runtime;
 
 mod types;
 pub use types::{QuickSearchFileItem, QuickSearchResult, QuickSearchStatus};
 
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 mod assets;
 #[cfg(target_os = "windows")]
 mod manager;
 #[cfg(target_os = "windows")]
 mod provider_everything;
+#[cfg(target_os = "macos")]
+mod provider_spotlight;
 
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 const DEFAULT_PAGE_SIZE: usize = 60;
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 const MAX_PAGE_SIZE: usize = 200;
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 const DEFAULT_LIMIT: usize = 60;
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 const MAX_LIMIT: usize = 200;
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 const DEFAULT_ICON_SIZE: u32 = 48;
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 const MAX_ICON_SIZE: u32 = 256;
 
 /// 搜索快捷项列表（Windows）。
@@ -80,8 +82,30 @@ pub async fn quick_search_search_files(
     .map_err(|err| format!("quick_search_search_files task join failed: {}", err))?
 }
 
-/// 搜索快捷项列表（非 Windows 平台降级实现）。
-#[cfg(not(target_os = "windows"))]
+/// 搜索快捷项列表（macOS Spotlight）。
+#[cfg(target_os = "macos")]
+pub async fn quick_search_search_shortcuts(
+    query: String,
+    page_size: Option<usize>,
+    offset: Option<u32>,
+) -> Result<QuickSearchResult, String> {
+    let normalized_page_size = page_size
+        .unwrap_or(DEFAULT_PAGE_SIZE)
+        .clamp(1, MAX_PAGE_SIZE);
+    let normalized_offset = offset.unwrap_or(0);
+    let result = async_runtime::spawn_blocking(move || {
+        provider_spotlight::search_shortcuts(&query, normalized_page_size, normalized_offset)
+    })
+    .await
+    .map_err(|err| format!("quick_search_search_shortcuts task join failed: {}", err))??;
+
+    // 记住返回路径，缩略图请求按白名单校验。
+    assets::remember_search_paths(&result.files);
+    Ok(result)
+}
+
+/// 搜索快捷项列表（未支持平台降级实现）。
+#[cfg(not(any(target_os = "windows", target_os = "macos")))]
 pub async fn quick_search_search_shortcuts(
     _query: String,
     _page_size: Option<usize>,
@@ -96,8 +120,24 @@ pub async fn quick_search_search_shortcuts(
     })
 }
 
-/// 搜索普通文件列表（非 Windows 平台降级实现）。
-#[cfg(not(target_os = "windows"))]
+/// 搜索普通文件列表（macOS Spotlight）。
+#[cfg(target_os = "macos")]
+pub async fn quick_search_search_files(
+    query: String,
+    limit: Option<usize>,
+    include_shortcuts: Option<bool>,
+) -> Result<Vec<QuickSearchFileItem>, String> {
+    let normalized_limit = limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
+    let include_shortcuts = include_shortcuts.unwrap_or(false);
+    async_runtime::spawn_blocking(move || {
+        provider_spotlight::search_files(&query, normalized_limit, include_shortcuts)
+    })
+    .await
+    .map_err(|err| format!("quick_search_search_files task join failed: {}", err))?
+}
+
+/// 搜索普通文件列表（未支持平台降级实现）。
+#[cfg(not(any(target_os = "windows", target_os = "macos")))]
 pub async fn quick_search_search_files(
     query: String,
     _limit: Option<usize>,
@@ -107,8 +147,8 @@ pub async fn quick_search_search_files(
     Err("Quick search file search is only available on Windows".to_string())
 }
 
-/// 获取单个快捷项图标（Windows）。
-#[cfg(target_os = "windows")]
+/// 获取单个快捷项图标（Windows / macOS）。
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 pub async fn quick_search_get_shortcut_icon(
     path: String,
     size: Option<u32>,
@@ -119,8 +159,8 @@ pub async fn quick_search_get_shortcut_icon(
         .map_err(|err| format!("quick_search_get_shortcut_icon task join failed: {}", err))?
 }
 
-/// 获取单个快捷项图标（非 Windows 平台降级实现）。
-#[cfg(not(target_os = "windows"))]
+/// 获取单个快捷项图标（未支持平台降级实现）。
+#[cfg(not(any(target_os = "windows", target_os = "macos")))]
 pub async fn quick_search_get_shortcut_icon(
     path: String,
     _size: Option<u32>,
@@ -129,8 +169,8 @@ pub async fn quick_search_get_shortcut_icon(
     Ok(None)
 }
 
-/// 批量获取快捷项图标（Windows）。
-#[cfg(target_os = "windows")]
+/// 批量获取快捷项图标（Windows / macOS）。
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 pub async fn quick_search_get_shortcut_icons(
     paths: Vec<String>,
     size: Option<u32>,
@@ -141,8 +181,8 @@ pub async fn quick_search_get_shortcut_icons(
         .map_err(|err| format!("quick_search_get_shortcut_icons task join failed: {}", err))?
 }
 
-/// 批量获取快捷项图标（非 Windows 平台降级实现）。
-#[cfg(not(target_os = "windows"))]
+/// 批量获取快捷项图标（未支持平台降级实现）。
+#[cfg(not(any(target_os = "windows", target_os = "macos")))]
 pub async fn quick_search_get_shortcut_icons(
     paths: Vec<String>,
     _size: Option<u32>,
@@ -151,8 +191,8 @@ pub async fn quick_search_get_shortcut_icons(
     Ok(HashMap::new())
 }
 
-/// 批量获取图片缩略图（Windows）。
-#[cfg(target_os = "windows")]
+/// 批量获取图片缩略图（Windows / macOS）。
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 pub async fn quick_search_get_image_thumbnails(
     paths: Vec<String>,
     size: Option<u32>,
@@ -168,8 +208,8 @@ pub async fn quick_search_get_image_thumbnails(
         })?
 }
 
-/// 批量获取图片缩略图（非 Windows 平台降级实现）。
-#[cfg(not(target_os = "windows"))]
+/// 批量获取图片缩略图（未支持平台降级实现）。
+#[cfg(not(any(target_os = "windows", target_os = "macos")))]
 pub async fn quick_search_get_image_thumbnails(
     paths: Vec<String>,
     _size: Option<u32>,
@@ -184,8 +224,14 @@ pub fn quick_search_prepare_index(force: Option<bool>) -> Result<(), String> {
     manager::prepare_index(force.unwrap_or(false))
 }
 
-/// 预热/刷新索引（非 Windows 平台降级实现）。
-#[cfg(not(target_os = "windows"))]
+/// 预热/刷新索引（macOS Spotlight）。
+#[cfg(target_os = "macos")]
+pub fn quick_search_prepare_index(force: Option<bool>) -> Result<(), String> {
+    provider_spotlight::prepare_index(force)
+}
+
+/// 预热/刷新索引（未支持平台降级实现）。
+#[cfg(not(any(target_os = "windows", target_os = "macos")))]
 pub fn quick_search_prepare_index(force: Option<bool>) -> Result<(), String> {
     let _ = force;
     Ok(())
@@ -197,8 +243,14 @@ pub fn quick_search_get_status() -> QuickSearchStatus {
     manager::get_status()
 }
 
-/// 获取快速搜索当前运行状态（非 Windows 平台降级实现）。
-#[cfg(not(target_os = "windows"))]
+/// 获取快速搜索当前运行状态（macOS Spotlight）。
+#[cfg(target_os = "macos")]
+pub fn quick_search_get_status() -> QuickSearchStatus {
+    provider_spotlight::get_status()
+}
+
+/// 获取快速搜索当前运行状态（未支持平台降级实现）。
+#[cfg(not(any(target_os = "windows", target_os = "macos")))]
 pub fn quick_search_get_status() -> QuickSearchStatus {
     QuickSearchStatus {
         provider: "unavailable".to_string(),

--- a/apps/desktop/src-tauri/src/core/search/provider_spotlight.rs
+++ b/apps/desktop/src-tauri/src/core/search/provider_spotlight.rs
@@ -1,0 +1,188 @@
+// Copyright (c) 2026. 千诚. Licensed under GPL v3.
+
+//! macOS Spotlight 快速搜索提供者。
+//!
+//! 第一版使用系统 `mdfind`，避免引入额外 Objective-C 绑定；后续如果需要更强的
+//! 图标、权限诊断或实时索引状态，再升级到 Metadata framework / FSEvents。
+
+use std::{
+    collections::HashSet,
+    path::Path,
+    process::{Command, Stdio},
+};
+
+use super::types::{QuickSearchFileItem, QuickSearchResult, QuickSearchStatus, QuickShortcutItem};
+
+const PROVIDER_NAME: &str = "spotlight";
+
+/// 执行 QuickSearch 主查询。
+pub fn search_shortcuts(
+    query: &str,
+    page_size: usize,
+    offset: u32,
+) -> Result<QuickSearchResult, String> {
+    let trimmed_query = query.trim();
+    if trimmed_query.is_empty() {
+        return Ok(empty_result());
+    }
+
+    let fetch_limit = page_size
+        .saturating_add(offset as usize)
+        .saturating_add(1)
+        .max(page_size);
+    let paths = run_mdfind(trimmed_query, fetch_limit)?;
+    let total_results = paths.len() as u32;
+    let files = paths
+        .iter()
+        .skip(offset as usize)
+        .take(page_size)
+        .filter_map(|path| spotlight_item_from_path(&path))
+        .collect::<Vec<_>>();
+
+    let total_files = files.len();
+    let next_offset = offset + total_files as u32;
+    Ok(QuickSearchResult {
+        shortcuts: Vec::new(),
+        files,
+        total_files,
+        total_results,
+        next_offset,
+    })
+}
+
+/// 执行内置 file_search 查询。
+pub fn search_files(
+    query: &str,
+    limit: usize,
+    _include_shortcuts: bool,
+) -> Result<Vec<QuickSearchFileItem>, String> {
+    let trimmed_query = query.trim();
+    if trimmed_query.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    Ok(run_mdfind(trimmed_query, limit)?
+        .into_iter()
+        .filter_map(|path| {
+            let item = spotlight_item_from_path(&path)?;
+            Some(QuickSearchFileItem {
+                name: item.name,
+                path: item.path,
+            })
+        })
+        .collect())
+}
+
+/// Spotlight 无需显式预热，保留命令契约。
+pub fn prepare_index(_force: Option<bool>) -> Result<(), String> {
+    Ok(())
+}
+
+/// 返回 macOS provider 状态。
+pub fn get_status() -> QuickSearchStatus {
+    QuickSearchStatus {
+        provider: PROVIDER_NAME.to_string(),
+        db_loaded: true,
+        index_warmed: true,
+        last_refresh_ms: None,
+        last_error: None,
+    }
+}
+
+fn empty_result() -> QuickSearchResult {
+    QuickSearchResult {
+        shortcuts: Vec::new(),
+        files: Vec::new(),
+        total_files: 0,
+        total_results: 0,
+        next_offset: 0,
+    }
+}
+
+fn run_mdfind(query: &str, limit: usize) -> Result<Vec<String>, String> {
+    if limit == 0 {
+        return Ok(Vec::new());
+    }
+
+    let output = Command::new("mdfind")
+        .arg("-name")
+        .arg(query)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|error| format!("执行 Spotlight 搜索失败: {}", error))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(if stderr.is_empty() {
+            "Spotlight 搜索失败".to_string()
+        } else {
+            format!("Spotlight 搜索失败: {}", stderr)
+        });
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(parse_mdfind_output(&stdout, limit))
+}
+
+fn parse_mdfind_output(output: &str, limit: usize) -> Vec<String> {
+    let mut seen = HashSet::new();
+    let mut paths = Vec::new();
+
+    for line in output.lines() {
+        let path = line.trim();
+        if path.is_empty() || !seen.insert(path.to_string()) {
+            continue;
+        }
+
+        paths.push(path.to_string());
+        if paths.len() >= limit {
+            break;
+        }
+    }
+
+    paths
+}
+
+fn spotlight_item_from_path(path: &str) -> Option<QuickShortcutItem> {
+    let path_obj = Path::new(path);
+    let name = path_obj.file_name()?.to_string_lossy().trim().to_string();
+    if name.is_empty() {
+        return None;
+    }
+
+    Some(QuickShortcutItem {
+        name,
+        path: path.to_string(),
+        source: "file".to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_mdfind_output, spotlight_item_from_path};
+
+    #[test]
+    fn parse_mdfind_output_deduplicates_and_limits_paths() {
+        let output = "/Users/qian/Desktop/App.app\n\n/Users/qian/Desktop/App.app\n/Users/qian/Documents/Note.md\n";
+
+        let paths = parse_mdfind_output(output, 2);
+
+        assert_eq!(
+            paths,
+            vec![
+                "/Users/qian/Desktop/App.app".to_string(),
+                "/Users/qian/Documents/Note.md".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn spotlight_item_uses_file_name_as_display_name() {
+        let item = spotlight_item_from_path("/Users/qian/Documents/Note.md").unwrap();
+
+        assert_eq!(item.name, "Note.md");
+        assert_eq!(item.path, "/Users/qian/Documents/Note.md");
+        assert_eq!(item.source, "file");
+    }
+}

--- a/apps/desktop/src/services/NativeService/types.ts
+++ b/apps/desktop/src/services/NativeService/types.ts
@@ -189,7 +189,7 @@ export interface QuickSearchFileItem {
 }
 
 export interface QuickSearchStatus {
-    provider: 'everything' | 'unavailable';
+    provider: 'everything' | 'spotlight' | 'unavailable';
     db_loaded: boolean;
     index_warmed: boolean;
     last_refresh_ms: number | null;

--- a/apps/desktop/src/views/SearchView/components/QuickSearchPanel/composables/useQuickSearchLogic.ts
+++ b/apps/desktop/src/views/SearchView/components/QuickSearchPanel/composables/useQuickSearchLogic.ts
@@ -124,6 +124,7 @@ function useQuickSearchFlow(
     // 1. 搜索流程状态
     let debounceTimer: ReturnType<typeof setTimeout> | null = null;
     let lastSearchedQuery = '';
+    let providerUnavailable = false;
     const clickStats = useQuickSearchClickStats();
 
     // 2. 名称高亮匹配
@@ -160,8 +161,10 @@ function useQuickSearchFlow(
      */
     async function refreshStatus() {
         try {
-            await deps.quickSearch.getStatus();
+            const status = await deps.quickSearch.getStatus();
+            providerUnavailable = status.provider === 'unavailable';
         } catch (error) {
+            providerUnavailable = true;
             console.warn('[QuickSearchPanel] Failed to get status:', error);
         }
     }
@@ -191,6 +194,11 @@ function useQuickSearchFlow(
     async function executeSearch(query: string) {
         const trimmedQuery = query.trim();
         if (!trimmedQuery) {
+            close();
+            return;
+        }
+
+        if (providerUnavailable) {
             close();
             return;
         }
@@ -316,6 +324,10 @@ function useQuickSearchFlow(
      */
     function open() {
         if (!enabled.value) return;
+        if (providerUnavailable) {
+            close();
+            return;
+        }
 
         const query = searchQuery.value.trim();
         if (!query) {
@@ -351,6 +363,10 @@ function useQuickSearchFlow(
      */
     function triggerSearch(query: string) {
         if (!enabled.value) return;
+        if (providerUnavailable) {
+            close();
+            return;
+        }
 
         if (!query.trim()) {
             close();

--- a/apps/desktop/src/views/SearchView/components/SearchBar/composables/useSearchLogic.ts
+++ b/apps/desktop/src/views/SearchView/components/SearchBar/composables/useSearchLogic.ts
@@ -192,6 +192,10 @@ export function useSearchInput(
             editorProps: {
                 attributes: {
                     class: 'tiptap',
+                    spellcheck: 'false',
+                    autocorrect: 'off',
+                    autocapitalize: 'off',
+                    autocomplete: 'off',
                 },
             },
             onUpdate: ({ editor: updatedEditor }) => {

--- a/apps/desktop/src/views/SearchView/composables/useSearchWindowResize.ts
+++ b/apps/desktop/src/views/SearchView/composables/useSearchWindowResize.ts
@@ -13,6 +13,7 @@ import {
     resolveSearchWindowDefaultSizeApplyAction,
     resolveSearchWindowHeightPolicy,
     resolveSearchWindowMinimumSize,
+    shouldCenterSearchWindowResize,
     shouldEnforceIdleDefaultBounds,
     shouldFillConversationAvailableHeight,
     shouldRemeasureAfterMaximizedRestore,
@@ -190,7 +191,10 @@ export function useSearchWindowResize(options: UseSearchWindowResizeOptions) {
 
         await native.window.resizeWindowHeight({
             targetHeight: newHeight,
-            center: true,
+            center: shouldCenterSearchWindowResize({
+                sessionCount: options.sessionCount.value,
+                quickSearchOpen: options.quickSearchOpen.value,
+            }),
             respectManualOverride: searchWindowHeightPolicy.value.respectManualOverride,
         });
         currentHeight.value = newHeight;

--- a/apps/desktop/src/views/SearchView/windowSizing.ts
+++ b/apps/desktop/src/views/SearchView/windowSizing.ts
@@ -62,6 +62,11 @@ export interface SearchWindowMinimumSizeInput {
     autoHeightFloor: number;
 }
 
+export interface SearchWindowResizeCenterInput {
+    sessionCount: number;
+    quickSearchOpen: boolean;
+}
+
 export interface SearchWindowResizeConstraints {
     minWidth: number;
     minHeight: number;
@@ -133,6 +138,21 @@ export function resolveSearchWindowMinimumSize(
         minHeight: height,
         maxHeight: input.hasManagedPanel ? null : input.defaultHeight,
     };
+}
+
+/**
+ * 计算内容驱动 resize 是否需要围绕窗口中心伸缩。
+ *
+ * QuickSearch 处于无会话输入态时，面板位于输入框下方；如果居中伸缩，
+ * 首次检索会把窗口顶部往上抬，产生“弹窗把窗口顶上去”的感觉。
+ * 对话态保留居中伸缩，延续阅读区域的原有视觉稳定性。
+ */
+export function shouldCenterSearchWindowResize(input: SearchWindowResizeCenterInput) {
+    if (input.sessionCount > 0) {
+        return true;
+    }
+
+    return !input.quickSearchOpen;
 }
 
 /**

--- a/apps/desktop/tests/SearchView/windowSizing.test.ts
+++ b/apps/desktop/tests/SearchView/windowSizing.test.ts
@@ -38,6 +38,7 @@ import {
     resolveSearchWindowDefaultSizeApplyAction,
     resolveSearchWindowHeightPolicy,
     resolveSearchWindowMinimumSize,
+    shouldCenterSearchWindowResize,
     shouldEnforceIdleDefaultBounds,
     shouldFillConversationAvailableHeight,
     shouldRemeasureAfterMaximizedRestore,
@@ -161,6 +162,24 @@ describe('resolveSearchWindowMinimumSize', () => {
             minHeight: 60,
             maxHeight: 60,
         });
+    });
+});
+
+describe('shouldCenterSearchWindowResize', () => {
+    it('keeps conversation resize centered but lets quick search expand downward', () => {
+        expect(
+            shouldCenterSearchWindowResize({
+                sessionCount: 1,
+                quickSearchOpen: false,
+            })
+        ).toBe(true);
+
+        expect(
+            shouldCenterSearchWindowResize({
+                sessionCount: 0,
+                quickSearchOpen: true,
+            })
+        ).toBe(false);
     });
 });
 

--- a/apps/desktop/tests/composables/SearchView/QuickSearchPanel/useQuickSearchLogic.test.ts
+++ b/apps/desktop/tests/composables/SearchView/QuickSearchPanel/useQuickSearchLogic.test.ts
@@ -770,4 +770,54 @@ describe('useQuickSearchLogic', () => {
 
         mounted.unmount();
     });
+
+    it('keeps quick search closed when the native provider is unavailable', async () => {
+        const open = ref(false);
+        const searchQuery = ref('');
+        const quickSearchDeps = {
+            quickSearch: {
+                getStatus: vi.fn().mockResolvedValue({
+                    provider: 'unavailable',
+                    db_loaded: false,
+                    index_warmed: false,
+                    last_refresh_ms: null,
+                    last_error: 'Quick search is only available on Windows',
+                }),
+                prepareIndex: vi.fn().mockResolvedValue(undefined),
+                searchShortcuts: vi
+                    .fn()
+                    .mockResolvedValue(createSearchResult([createShortcut('App')])),
+            },
+            window: {
+                hideSearchWindow: vi.fn().mockResolvedValue(undefined),
+            },
+            openPath: vi.fn().mockResolvedValue(undefined),
+        };
+
+        const mounted = await mountComposable(() =>
+            useQuickSearchLogic(
+                {
+                    open,
+                    searchQuery,
+                    enabled: ref(true),
+                    emitOpenUpdate: (value) => {
+                        open.value = value;
+                    },
+                },
+                quickSearchDeps
+            )
+        );
+
+        await flushAsyncWork();
+
+        searchQuery.value = 'app';
+        mounted.result.triggerSearch('app');
+        await vi.advanceTimersByTimeAsync(80);
+        await flushAsyncWork();
+
+        expect(open.value).toBe(false);
+        expect(quickSearchDeps.quickSearch.searchShortcuts).not.toHaveBeenCalled();
+
+        mounted.unmount();
+    });
 });

--- a/apps/desktop/tests/composables/SearchView/SearchBar/useSearchLogic.test.ts
+++ b/apps/desktop/tests/composables/SearchView/SearchBar/useSearchLogic.test.ts
@@ -309,6 +309,16 @@ describe('useSearchInput', () => {
             supportsFiles: false,
         });
         expect(setEditorTextMock).toHaveBeenCalledWith(editorInstances[0], 'hello world');
+        expect(editorInstances[0]?.options).toMatchObject({
+            editorProps: {
+                attributes: {
+                    spellcheck: 'false',
+                    autocorrect: 'off',
+                    autocapitalize: 'off',
+                    autocomplete: 'off',
+                },
+            },
+        });
         expect(insertModelTagMock).toHaveBeenCalledWith(editorInstances[0], {
             modelId: 'model-1',
             modelName: 'GPT-4.1',

--- a/apps/desktop/tests/composables/SearchView/useSearchWindowResize.test.ts
+++ b/apps/desktop/tests/composables/SearchView/useSearchWindowResize.test.ts
@@ -193,6 +193,36 @@ describe('useSearchWindowResize', () => {
         mounted.unmount();
     });
 
+    it('keeps the window top stable when quick search expands without a conversation', async () => {
+        const target = createMeasuredElement(180);
+        const ready = ref(false);
+        const quickSearchOpen = ref(true);
+
+        const mounted = await mountComposable(() =>
+            useSearchWindowResize({
+                target: ref(target.element),
+                sessionCount: ref(0),
+                quickSearchOpen,
+                defaultSize: ref({ width: 750, height: 60 }),
+                ready,
+            })
+        );
+
+        ready.value = true;
+        await flushResizeLifecycle();
+        vi.clearAllMocks();
+
+        await mounted.result.remeasureTargetHeight();
+
+        expect(nativeMock.window.resizeWindowHeight).toHaveBeenCalledWith({
+            targetHeight: 180,
+            center: false,
+            respectManualOverride: false,
+        });
+
+        mounted.unmount();
+    });
+
     it('repairs the search window back to idle defaults when a manual-override conversation view returns to idle', async () => {
         nativeMock.window.getSearchWindowState.mockResolvedValue(
             createWindowState({


### PR DESCRIPTION
> First external contributors may need to complete the CLA Assistant check before merge.
> For code changes, this PR must link the related issue or RFC in the section below.

## Summary

- Keep QuickSearch closed when the native provider is unavailable or status probing fails, preventing open/close flicker while typing in a new conversation.
- Add macOS Spotlight-backed file search while keeping Windows on Everything and unsupported platforms unavailable.
- Add macOS file, folder, app, and image thumbnail icons for QuickSearch results, including path-based cache keys for .app bundles and extensionless paths.
- Disable SearchBar contenteditable spellcheck/autocorrect/autocapitalize/autocomplete for command, path, and filename input.
- Keep the search window top stable when QuickSearch expands without an active conversation; conversation resize remains centered.

## Related issue or RFC

- Closes #243
- Replaces closed PR #244

## AI assistance disclosure

- Tool(s) used: OpenAI Codex
- Scope of assistance: implementation, tests, local verification, issue/PR preparation
- Human review or rewrite performed: maintainer/user reviewed the intended issue and PR flow before submission
- Architecture or boundary impact: adds a macOS QuickSearch provider and macOS search asset loading path; no AgentService, MCP, or database schema changes

## Testing evidence

Commands run successfully:

- PATH="$PWD/.codex-bin:$PATH" RUSTC=$(rustup which rustc) git commit -m "fix: optimize QuickSearch cross-platform search behavior"
  - pre-commit ran check:rust, type:check, eslint --fix, prettier --write, and cargo fmt for staged Rust files
- corepack pnpm vitest run tests/composables/SearchView/QuickSearchPanel/useQuickSearchLogic.test.ts tests/SearchView/windowSizing.test.ts tests/composables/SearchView/useSearchWindowResize.test.ts tests/composables/SearchView/SearchBar/useSearchLogic.test.ts
- corepack pnpm type:check
- git diff --check origin/main...HEAD
- Manual startup verified by maintainer/user on the branch with PATH="$PWD/.codex-bin:$PATH" RUSTC="$(rustup which rustc)" corepack pnpm tauri dev

Did you follow TDD (test-first) for feature and fix work?

- Added focused tests for QuickSearch unavailable state, SearchBar autocorrect attributes, icon cache keys, and QuickSearch resize centering policy while implementing the fixes.

## Risk notes

- AgentService, runtime, MCP, or schema impact: none
- database baseline or migration impact: none
- release or packaging impact: adds macOS-only file_icon_provider dependency and Spotlight provider code path

## Screenshots or recordings

No recording attached. The affected flow is the SearchView QuickSearch typing/expansion path.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use [WIP] or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches AgentService, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran pnpm test:pr for this code PR, or this is a docs-only change.
- [ ] If I changed Rust behavior or tests, I reviewed pnpm test:coverage:rust or relied on CI coverage evidence.
- [ ] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran pnpm test:e2e locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.