### PR TITLE
fix(desktop): avoid blocking updater download freezes

### DIFF
--- a/apps/desktop/src-tauri/src/commands/updater.rs
+++ b/apps/desktop/src-tauri/src/commands/updater.rs
@@ -16,17 +16,17 @@ pub fn updater_check_for_updates(
 }
 
 #[tauri::command]
-pub fn updater_download_update<R: Runtime>(
+pub async fn updater_download_update<R: Runtime>(
     app: AppHandle<R>,
     state: State<'_, AppUpdaterState>,
 ) -> Result<AppUpdateInfo, String> {
-    updater::download_update(app, state.inner())
+    updater::download_update(app, state.inner()).await
 }
 
 #[tauri::command]
-pub fn updater_install_update<R: Runtime>(
+pub async fn updater_install_update<R: Runtime>(
     app: AppHandle<R>,
     state: State<'_, AppUpdaterState>,
 ) -> Result<bool, String> {
-    updater::install_update(app, state.inner())
+    updater::install_update(app, state.inner()).await
 }

--- a/apps/desktop/src-tauri/src/core/updater/mod.rs
+++ b/apps/desktop/src-tauri/src/core/updater/mod.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     cmp::Ordering,
     collections::BTreeMap,
+    sync::mpsc,
     sync::{Mutex, OnceLock},
     time::Duration,
 };
@@ -602,7 +603,7 @@ pub fn check_for_updates(
     }
 }
 
-pub fn download_update<R: Runtime>(
+pub async fn download_update<R: Runtime>(
     app: AppHandle<R>,
     state: &AppUpdaterState,
 ) -> Result<AppUpdateInfo, String> {
@@ -614,14 +615,31 @@ pub fn download_update<R: Runtime>(
         .ok_or_else(|| "没有可下载的更新，请先检查更新".to_string())?;
 
     let update_info = update_info_from_target(&pending_update.update);
-    download_updates_on_velopack_worker(pending_update)?;
+    download_updates_on_velopack_worker(app.clone(), pending_update).await?;
     let _ = app.emit(DOWNLOAD_PROGRESS_EVENT, 100_i16);
 
     Ok(update_info)
 }
 
-fn download_updates_on_velopack_worker(pending_update: PendingUpdate) -> Result<(), String> {
-    run_on_velopack_worker(move || {
+async fn download_updates_on_velopack_worker<R: Runtime>(
+    app: AppHandle<R>,
+    pending_update: PendingUpdate,
+) -> Result<(), String> {
+    let (progress_tx, progress_rx) = mpsc::channel::<i16>();
+    let progress_app = app.clone();
+    let progress_worker = std::thread::Builder::new()
+        .name("touchai-velopack-progress".to_string())
+        .spawn(move || {
+            forward_download_progress(progress_rx, move |progress| {
+                let _ = progress_app.emit(DOWNLOAD_PROGRESS_EVENT, progress);
+            });
+        });
+
+    if let Err(error) = &progress_worker {
+        log::warn!("启动更新进度转发任务失败，继续下载但不会显示实时进度：{error}");
+    }
+
+    let result = run_on_velopack_worker_async(move || {
         let manager = match manager(pending_update.channel) {
             Ok(manager) => manager,
             Err(VelopackError::NotInstalled(_)) => {
@@ -631,24 +649,48 @@ fn download_updates_on_velopack_worker(pending_update: PendingUpdate) -> Result<
         };
 
         manager
-            .download_updates(&pending_update.update, None)
+            .download_updates(&pending_update.update, Some(progress_tx))
             .map_err(|error| format!("下载更新失败：{error}"))
     })
+    .await;
+
+    if let Ok(handle) = progress_worker {
+        let _ = tauri::async_runtime::spawn_blocking(move || handle.join()).await;
+    }
+
+    result
 }
 
-fn run_on_velopack_worker(
+async fn run_on_velopack_worker_async(
     task: impl FnOnce() -> Result<(), String> + Send + 'static,
 ) -> Result<(), String> {
+    let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+
     std::thread::Builder::new()
         .name("touchai-velopack-download".to_string())
         .stack_size(VELOPACK_WORKER_STACK_SIZE)
-        .spawn(task)
-        .map_err(|error| format!("启动更新下载任务失败：{error}"))?
-        .join()
+        .spawn(move || {
+            let result = task();
+            let _ = result_tx.send(result);
+        })
+        .map_err(|error| format!("启动更新下载任务失败：{error}"))?;
+
+    result_rx
+        .await
         .map_err(|_| "更新下载任务异常退出".to_string())?
 }
 
-pub fn install_update<R: Runtime>(
+fn clamp_download_progress(progress: i16) -> i16 {
+    progress.clamp(0, 100)
+}
+
+fn forward_download_progress(progress_rx: mpsc::Receiver<i16>, mut emit_progress: impl FnMut(i16)) {
+    while let Ok(progress) = progress_rx.recv() {
+        emit_progress(clamp_download_progress(progress));
+    }
+}
+
+pub async fn install_update<R: Runtime>(
     app: AppHandle<R>,
     state: &AppUpdaterState,
 ) -> Result<bool, String> {
@@ -659,17 +701,21 @@ pub fn install_update<R: Runtime>(
         .clone()
         .ok_or_else(|| "没有已下载的更新，请先下载更新".to_string())?;
 
-    let manager = match manager(pending_update.channel) {
-        Ok(manager) => manager,
-        Err(VelopackError::NotInstalled(_)) => {
-            return Err("当前运行方式暂不支持应用内更新".to_string())
-        }
-        Err(error) => return Err(format!("初始化更新器失败：{error}")),
-    };
+    run_on_velopack_worker_async(move || {
+        let manager = match manager(pending_update.channel) {
+            Ok(manager) => manager,
+            Err(VelopackError::NotInstalled(_)) => {
+                return Err("当前运行方式暂不支持应用内更新".to_string())
+            }
+            Err(error) => return Err(format!("初始化更新器失败：{error}")),
+        };
 
-    manager
-        .wait_exit_then_apply_updates(pending_update.update, true, true, Vec::<String>::new())
-        .map_err(|error| format!("安装更新失败：{error}"))?;
+        manager
+            .wait_exit_then_apply_updates(pending_update.update, true, true, Vec::<String>::new())
+            .map_err(|error| format!("安装更新失败：{error}"))
+    })
+    .await?;
+
     app.exit(0);
     Ok(true)
 }
@@ -925,8 +971,8 @@ mod tests {
     }
 
     #[test]
-    fn velopack_worker_uses_large_stack() {
-        let result = run_on_velopack_worker(|| {
+    fn velopack_async_worker_uses_large_stack() {
+        let result = tauri::async_runtime::block_on(run_on_velopack_worker_async(|| {
             const BUFFER_SIZE: usize = 2 * 1024 * 1024;
             let mut buffer = [0_u8; BUFFER_SIZE];
             buffer[0] = 1;
@@ -934,8 +980,34 @@ mod tests {
             std::hint::black_box(&mut buffer);
             assert_eq!(buffer[0] + buffer[BUFFER_SIZE - 1], 3);
             Ok(())
-        });
+        }));
 
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn forwards_download_progress_updates_in_order() {
+        use std::sync::{mpsc, Arc, Mutex};
+
+        let (progress_tx, progress_rx) = mpsc::channel();
+        let forwarded = Arc::new(Mutex::new(Vec::new()));
+        let forwarded_clone = Arc::clone(&forwarded);
+        let handle = std::thread::spawn(move || {
+            forward_download_progress(progress_rx, move |progress| {
+                forwarded_clone
+                    .lock()
+                    .expect("forwarded lock")
+                    .push(progress);
+            });
+        });
+
+        progress_tx.send(-5).expect("send progress");
+        progress_tx.send(42).expect("send progress");
+        progress_tx.send(120).expect("send progress");
+        drop(progress_tx);
+
+        handle.join().expect("progress forwarder joins");
+
+        assert_eq!(*forwarded.lock().expect("forwarded lock"), vec![0, 42, 100]);
     }
 }


### PR DESCRIPTION
## Summary

Fix a desktop updater regression where clicking download could leave the TouchAI window unresponsive while the UI stayed stuck at `0%`.

This patch moves Velopack download/install work off the blocking Tauri command path and forwards Velopack download progress events to the frontend.

## Related issue or RFC

- Related to #48

## AI assistance disclosure

- Tool(s) used: Codex
- Scope of assistance: root-cause investigation, updater runtime patching, regression test additions, and PR maintenance
- Human review or rewrite performed: reviewed the updater call chain, narrowed the fix to the Rust updater boundary, and rebuilt the PR branch on top of latest `main`
- Architecture or boundary impact: touches the desktop Tauri updater runtime only; no AgentService, MCP, or schema boundary changes

## Testing evidence

Commands run locally:

```text
cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml --all -- --check
pnpm --filter @touchai/desktop type:check
cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml
cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml forwards_download_progress_updates_in_order -- --exact
```

Observed results:

- `cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml --all -- --check` passed.
- `pnpm --filter @touchai/desktop type:check` could not run in this workspace because `node_modules` is missing and `vue-tsc` is not installed locally.
- targeted `cargo check` / `cargo test` were attempted with `CARGO_TARGET_DIR`, `TEMP`, and `TMP` redirected to `G:` and build jobs reduced, but this machine still hit local Rust environment/resource failures (page file / temp disk / system resource exhaustion). CI is the first reliable full proof for Rust verification on this patch.
- manual packaged-build validation reproduced the freeze: update UI entered downloading state, remained at `0%`, and the window became unresponsive.

Did you follow TDD (test-first) for feature and fix work? Partially. Focused regression coverage was added around progress forwarding and the async large-stack worker path, but full local red/green execution was blocked by the current Rust environment limits on this machine.

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: none
- database baseline or migration impact: none
- release or packaging impact: low to medium; changes desktop updater execution behavior, not release asset generation

## Screenshots or recordings

- Manual validation screenshot for the freeze was captured locally during packaged-build testing.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [ ] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [ ] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [ ] I updated docs when behavior changed.