### PR TITLE
ci(site): deploy website to GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,62 @@
+name: Pages
+
+on:
+    push:
+        branches:
+            - main
+        paths:
+            - apps/site/**
+            - package.json
+            - pnpm-lock.yaml
+            - pnpm-workspace.yaml
+            - .github/workflows/pages.yml
+    workflow_dispatch:
+
+permissions:
+    contents: read
+    pages: write
+    id-token: write
+
+concurrency:
+    group: pages
+    cancel-in-progress: false
+
+jobs:
+    build:
+        name: Build site
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+            - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
+
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+              with:
+                  node-version: 22
+                  cache: pnpm
+
+            - name: Configure GitHub Pages
+              uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Build site
+              run: pnpm site:build
+
+            - name: Upload Pages artifact
+              uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+              with:
+                  path: apps/site/dist
+
+    deploy:
+        name: Deploy to GitHub Pages
+        needs: build
+        runs-on: ubuntu-latest
+        environment:
+            name: github-pages
+            url: ${{ steps.deployment.outputs.page_url }}
+        steps:
+            - name: Deploy to GitHub Pages
+              id: deployment
+              uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/apps/site/astro.config.mjs
+++ b/apps/site/astro.config.mjs
@@ -5,6 +5,7 @@ import starlight from '@astrojs/starlight';
 // https://astro.build/config
 export default defineConfig({
 	site: 'https://touchai-org.github.io/TouchAI/',
+	base: '/TouchAI/',
 	integrations: [
 		starlight({
 			title: 'TouchAI',

--- a/apps/site/astro.config.mjs
+++ b/apps/site/astro.config.mjs
@@ -4,8 +4,7 @@ import starlight from '@astrojs/starlight';
 
 // https://astro.build/config
 export default defineConfig({
-	site: 'https://touchai-org.github.io/TouchAI/',
-	base: '/TouchAI/',
+	site: 'https://touch-ai.org/',
 	integrations: [
 		starlight({
 			title: 'TouchAI',

--- a/apps/site/public/CNAME
+++ b/apps/site/public/CNAME
@@ -1,0 +1,1 @@
+touch-ai.org


### PR DESCRIPTION
﻿## Summary

- Adds a GitHub Pages workflow that builds `@touchai/site`, uploads `apps/site/dist`, and deploys through the Pages Actions flow.
- Configures the official website for the custom apex domain `https://touch-ai.org/` with no repository subdirectory.
- Adds `apps/site/public/CNAME` so the Pages artifact contains the custom domain declaration.
- Repository Pages has been enabled with `build_type=workflow` and `cname=touch-ai.org`.

## Related issue or RFC

- Closes #251

## AI assistance disclosure

- Tool(s) used: Codex
- Scope of assistance: drafted the CI workflow, adjusted Astro and Pages custom-domain configuration, ran local verification, and prepared this PR.
- Human review or rewrite performed: updated after maintainer feedback that the site must use `touch-ai.org` directly without a `/TouchAI/` subdirectory.
- Architecture or boundary impact: CI/site deployment only; no runtime, MCP, AgentService, or database boundary impact.

## Testing evidence

- `pnpm --filter @touchai/site install --frozen-lockfile --prefer-offline --ignore-scripts --reporter append-only` - passed.
- `pnpm site:build` - passed; Astro built 4 pages into `apps/site/dist` and copied `CNAME` into the artifact root.
- `pnpm exec prettier --check .github/workflows/pages.yml` - passed.
- `python -c "import yaml, pathlib; ... yaml.safe_load(...) ..."` - passed, confirming the workflow YAML parses and contains `build` and `deploy` jobs.
- `rg -n 'touchai-org\.github\.io|/TouchAI/' apps/site/astro.config.mjs apps/site/dist` - no matches, confirming the old GitHub Pages project URL/subdirectory is gone from config and generated output.
- `Get-Content apps/site/dist/sitemap-0.xml` - generated sitemap URLs use `https://touch-ai.org/`.
- `Resolve-DnsName touch-ai.org -Type A/AAAA` - no records returned from this environment yet, so DNS still needs to point the apex domain at GitHub Pages before the domain will resolve publicly.
- `npx tsc --noEmit` - not applicable at the repository root because there is no root `tsconfig.json` or input file set; TypeScript printed help and exited 1.
- `pnpm test:pr` - not run locally; this change is scoped to GitHub Pages/site deployment and avoids desktop app runtime paths.

Did you follow TDD (test-first) for feature and fix work? Not applicable for this CI/site deployment workflow change.

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: none.
- database baseline or migration impact: none.
- release or packaging impact: adds a main-branch GitHub Pages deployment workflow for the official website only; desktop release workflows are untouched.
- custom-domain impact: GitHub Pages is set to `cname=touch-ai.org`; HTTPS enforcement could not be enabled yet because GitHub reported that the certificate does not exist yet. This should be retried after DNS is configured and GitHub provisions the certificate.

## Screenshots or recordings

N/A.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [x] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [x] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.
