### PR TITLE
fix(updater): keep checks responsive and clean up before install

### DIFF
--- a/apps/desktop/src-tauri/src/commands/updater.rs
+++ b/apps/desktop/src-tauri/src/commands/updater.rs
@@ -5,14 +5,19 @@
 use crate::core::updater::{
     self, AppUpdateChannel, AppUpdateCheckResult, AppUpdateInfo, AppUpdaterState,
 };
-use tauri::{AppHandle, Runtime, State};
+use tauri::{AppHandle, Manager, Runtime, State};
+
+use crate::core::{built_in_tools::BuiltInProcessExecutionRegistry, mcp::McpClientManager};
 
 #[tauri::command]
-pub fn updater_check_for_updates(
+pub async fn updater_check_for_updates(
     state: State<'_, AppUpdaterState>,
     channel: AppUpdateChannel,
 ) -> Result<AppUpdateCheckResult, String> {
-    updater::check_for_updates(state.inner(), channel)
+    let state = state.inner().clone();
+    tauri::async_runtime::spawn_blocking(move || updater::check_for_updates(&state, channel))
+        .await
+        .map_err(|error| format!("check for updates task join failed: {}", error))?
 }
 
 #[tauri::command]
@@ -28,5 +33,16 @@ pub async fn updater_install_update<R: Runtime>(
     app: AppHandle<R>,
     state: State<'_, AppUpdaterState>,
 ) -> Result<bool, String> {
+    if let Some(client_manager) = app.try_state::<McpClientManager>() {
+        client_manager.disconnect_all().await?;
+    }
+
+    if let Some(registry) = app.try_state::<BuiltInProcessExecutionRegistry>() {
+        let cancelled = registry.cancel_all();
+        if cancelled > 0 {
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        }
+    }
+
     updater::install_update(app, state.inner()).await
 }

--- a/apps/desktop/src-tauri/src/core/built_in_tools/registry.rs
+++ b/apps/desktop/src-tauri/src/core/built_in_tools/registry.rs
@@ -84,6 +84,25 @@ impl BuiltInProcessExecutionRegistry {
         false
     }
 
+    pub fn cancel_all(&self) -> usize {
+        let senders = {
+            let mut state = self
+                .state
+                .lock()
+                .expect("BuiltInProcessExecutionRegistry poisoned");
+            prune_expired_pending_cancellations(&mut state);
+            state.pending_cancellations.clear();
+            std::mem::take(&mut state.senders)
+        };
+
+        let count = senders.len();
+        for (_, sender) in senders {
+            let _ = sender.send(());
+        }
+
+        count
+    }
+
     #[cfg_attr(not(target_os = "windows"), allow(dead_code))]
     pub fn complete(&self, execution_id: &str) {
         let mut state = self
@@ -101,4 +120,21 @@ fn prune_expired_pending_cancellations(state: &mut BuiltInProcessRegistryState) 
     state
         .pending_cancellations
         .retain(|_, created_at| now.duration_since(*created_at) <= PENDING_CANCELLATION_TTL);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BuiltInProcessExecutionRegistry;
+
+    #[test]
+    fn cancel_all_signals_every_registered_execution() {
+        let registry = BuiltInProcessExecutionRegistry::new();
+        let mut first = registry.register("first".to_string());
+        let mut second = registry.register("second".to_string());
+
+        assert_eq!(registry.cancel_all(), 2);
+        assert!(first.try_recv().is_ok());
+        assert!(second.try_recv().is_ok());
+        assert_eq!(registry.cancel_all(), 0);
+    }
 }

--- a/apps/desktop/src-tauri/src/core/updater/mod.rs
+++ b/apps/desktop/src-tauri/src/core/updater/mod.rs
@@ -7,8 +7,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     cmp::Ordering,
     collections::BTreeMap,
-    sync::mpsc,
-    sync::{Mutex, OnceLock},
+    sync::{mpsc, Arc, Mutex, OnceLock},
     time::Duration,
 };
 use tauri::{AppHandle, Emitter, Runtime};
@@ -25,9 +24,9 @@ const VELOPACK_WORKER_STACK_SIZE: usize = 8 * 1024 * 1024;
 const MAXIMUM_DELTAS_BEFORE_FULL_FALLBACK: i32 = 10;
 const UPDATE_POLICY_TIMEOUT_SECONDS: u64 = 5;
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct AppUpdaterState {
-    pending_update: Mutex<Option<PendingUpdate>>,
+    pending_update: Arc<Mutex<Option<PendingUpdate>>>,
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
﻿## Summary

- move `updater_check_for_updates` onto a background task so manual checks do not block the desktop UI thread
- disconnect active MCP clients and cancel in-flight built-in tool executions before handing off to Velopack install/restart
- make `AppUpdaterState` clonable so the updater command layer can offload blocking work safely

## Related issue or RFC

- Related to #48

## AI assistance disclosure

- Tool(s) used: Codex (GPT-5)
- Scope of assistance: investigated the updater regressions, prepared the code changes, and drafted this PR body
- Human review or rewrite performed: reviewed each changed file and kept the patch limited to updater command wiring and process cleanup
- Architecture or boundary impact: no new abstraction; reuses existing `McpClientManager::disconnect_all()` and updater state patterns

## Testing evidence

Local evidence:

- `git diff --check`
- `cargo fmt --check`
  - blocked by unrelated formatting drift already present in `apps/desktop/src-tauri/src/core/setup.rs` on top of current `origin/main`
- `cargo check --lib --profile ci-check --message-format short`
  - timed out locally after a long Rust/Tauri compile in this environment, so CI is the first valid proof for this follow-up
- `cargo test --lib cancel_all_signals_every_registered_execution -- --exact`
  - same local compile-time blocker as above; rely on CI

Did you follow TDD (test-first) for feature and fix work? No. This was a regression follow-up against a live repro and existing code path.

```text
git diff --check
cargo fmt --check
cargo check --lib --profile ci-check --message-format short
cargo test --lib cancel_all_signals_every_registered_execution -- --exact
```

## Risk notes

- `AgentService`, runtime, MCP, or schema impact:
  narrow runtime impact; updater install now asks existing MCP connections and built-in tool executions to shut down before restart
- database baseline or migration impact:
  none
- release or packaging impact:
  affects in-app update check/install behavior only; no release asset or pipeline changes in this PR

## Screenshots or recordings

None. This change is native updater control flow.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [ ] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [x] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.
