### PR TITLE
fix(database): avoid case update when switching default model

### DIFF
--- a/apps/desktop/src/database/queries/models.ts
+++ b/apps/desktop/src/database/queries/models.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2026. 千诚. Licensed under GPL v3
 
-import { and, desc, eq, or, sql } from 'drizzle-orm';
+import { and, desc, eq, sql } from 'drizzle-orm';
 
 import { type DatabaseExecutor, db } from '../index';
 import { models, providers } from '../schema';
@@ -167,13 +167,9 @@ export const setDefaultModel = async ({ modelId }: { modelId: number }): Promise
             throw new Error(`无法设置默认模型：服务商 "${modelWithProvider.provider_name}" 未启用`);
         }
 
-        await tx
-            .update(models)
-            .set({
-                is_default: sql<number>`case when ${models.id} = ${modelId} then 1 else 0 end`,
-            })
-            .where(or(eq(models.is_default, 1), eq(models.id, modelId)))
-            .run();
+        await tx.update(models).set({ is_default: 0 }).where(eq(models.is_default, 1)).run();
+
+        await tx.update(models).set({ is_default: 1 }).where(eq(models.id, modelId)).run();
     });
 };
 

--- a/apps/desktop/tests/database/models.test.ts
+++ b/apps/desktop/tests/database/models.test.ts
@@ -1,0 +1,64 @@
+import type { InvokeArgs } from '@tauri-apps/api/core';
+import { describe, expect, it } from 'vitest';
+
+import { setDefaultModel } from '@database/queries/models';
+import { getTauriInvokeCalls, interceptTauriInvoke } from '@tests/utils/tauri';
+
+function getRequest(payload: InvokeArgs | undefined) {
+    return (payload as { request?: { sql: string; params?: unknown[]; method: string } })
+        ?.request;
+}
+
+describe('model database queries', () => {
+    it('switches the default model without emitting a CASE update through sqlite-proxy', async () => {
+        interceptTauriInvoke((call) => {
+            if (call.cmd === 'database_tx_begin') {
+                return 'tx_issue_72';
+            }
+
+            if (call.cmd === 'database_tx_commit' || call.cmd === 'database_tx_rollback') {
+                return undefined;
+            }
+
+            if (call.cmd === 'database_tx_query') {
+                const request = getRequest(call.payload);
+
+                if (request?.method === 'get') {
+                    return {
+                        rows: [{ id: 211, enabled: 1, provider_name: 'OpenAI' }],
+                        rowsAffected: 0,
+                        lastInsertId: null,
+                    };
+                }
+
+                if (request?.sql.toLowerCase().includes('case when')) {
+                    throw new Error(
+                        `Failed query: ${request.sql} params: ${(request.params ?? []).join(',')}`
+                    );
+                }
+
+                return { rows: [], rowsAffected: 1, lastInsertId: null };
+            }
+
+            return undefined;
+        });
+
+        await expect(setDefaultModel({ modelId: 211 })).resolves.toBeUndefined();
+
+        const updateQueries = getTauriInvokeCalls('database_tx_query')
+            .map((call) => getRequest(call.payload))
+            .filter((request) => request?.method === 'run');
+
+        expect(updateQueries).toHaveLength(2);
+        expect(updateQueries.map((request) => request?.sql.toLowerCase())).toEqual([
+            expect.stringContaining(
+                'update "models" set "is_default" = ? where "models"."is_default" = ?'
+            ),
+            expect.stringContaining('update "models" set "is_default" = ? where "models"."id" = ?'),
+        ]);
+        expect(updateQueries.map((request) => request?.params)).toEqual([
+            [0, 1],
+            [1, 211],
+        ]);
+    });
+});

--- a/apps/desktop/tests/database/models.test.ts
+++ b/apps/desktop/tests/database/models.test.ts
@@ -1,12 +1,10 @@
+import { setDefaultModel } from '@database/queries/models';
 import type { InvokeArgs } from '@tauri-apps/api/core';
+import { getTauriInvokeCalls, interceptTauriInvoke } from '@tests/utils/tauri';
 import { describe, expect, it } from 'vitest';
 
-import { setDefaultModel } from '@database/queries/models';
-import { getTauriInvokeCalls, interceptTauriInvoke } from '@tests/utils/tauri';
-
 function getRequest(payload: InvokeArgs | undefined) {
-    return (payload as { request?: { sql: string; params?: unknown[]; method: string } })
-        ?.request;
+    return (payload as { request?: { sql: string; params?: unknown[]; method: string } })?.request;
 }
 
 describe('model database queries', () => {


### PR DESCRIPTION
## Summary

- Replace the sqlite-proxy `CASE WHEN` update in `setDefaultModel` with two simple updates inside the existing transaction.
- Add a regression test that fails when default-model switching emits the problematic `CASE WHEN` update SQL.

## Related issue or RFC

- Closes #72

For code changes, link the tracking issue. Only documentation wording, link fixes, or comment-only cleanups may skip the issue-first flow.

## AI assistance disclosure

If AI tools materially assisted this contribution, disclose that here or point to the relevant commit trailer.

- Tool(s) used: Codex
- Scope of assistance: diagnosis, implementation, regression test, and PR preparation
- Human review or rewrite performed: pending maintainer review
- Architecture or boundary impact: no schema or architecture change; database query implementation only

## Testing evidence

List the commands you ran and the results you observed.

- `node E:\TouchAI-worktrees\issue-72-default-model-switch\node_modules\vitest\vitest.mjs run --configLoader runner tests/database/models.test.ts` from `apps/desktop`: 1 test file passed, 1 test passed.
- Red/green check: temporarily restored the old `CASE WHEN` implementation and the same test failed with `Failed query: update "models" set "is_default" = case when ... params: 211,1,211`; restored the fix and the test passed again.
- `git diff --check`: passed.
- `pnpm --filter @touchai/desktop test:typecheck`: could not run locally because this worktree's dependency links are incomplete and `vue-tsc` was not found.
- `pnpm test:pr`: not run locally for the same dependency-link issue and low free space on `D:` where the repository git metadata lives; CI should provide the full validation.

Did you follow TDD (test-first) for feature and fix work? Strongly recommended. See [docs/testing/testing.md](../docs/testing/testing.md).

```text
node E:\TouchAI-worktrees\issue-72-default-model-switch\node_modules\vitest\vitest.mjs run --configLoader runner tests/database/models.test.ts
# 1 passed

git diff --check
# passed

pnpm --filter @touchai/desktop test:typecheck
# blocked: vue-tsc not found in this worktree
```

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: none.
- database baseline or migration impact: none; query implementation only.
- release or packaging impact: none.

## Screenshots or recordings

Not applicable; no UI change.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [ ] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [ ] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [ ] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.
