### PR TITLE
ci(release): route prerelease deployments to prerelease environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,4 +66,5 @@ jobs:
             prerelease: ${{ needs.resolve.outputs.prerelease }}
             target-commitish: ${{ github.sha }}
             deploy-production: ${{ github.ref_name == 'main' }}
+            deployment-environment: prerelease
         secrets: inherit

--- a/.github/workflows/velopack-build.yml
+++ b/.github/workflows/velopack-build.yml
@@ -22,6 +22,10 @@ on:
                 required: false
                 type: boolean
                 default: false
+            deployment-environment:
+                required: false
+                type: string
+                default: release
 
 permissions:
     contents: write
@@ -614,7 +618,7 @@ jobs:
             - prepare-release
             - build-update-channels
         runs-on: ubuntu-latest
-        environment: release
+        environment: ${{ inputs.deployment-environment }}
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
               with:

--- a/apps/desktop/tests/ci/release-workflow-environments.test.ts
+++ b/apps/desktop/tests/ci/release-workflow-environments.test.ts
@@ -1,0 +1,29 @@
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const testDirectory = dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = resolve(testDirectory, '../../../..');
+
+async function readWorkflow(path: string) {
+    return readFile(resolve(repositoryRoot, '.github/workflows', path), 'utf8');
+}
+
+describe('release workflow deployment environments', () => {
+    it('keeps stable releases on the protected release environment by default', async () => {
+        const workflow = await readWorkflow('velopack-build.yml');
+
+        expect(workflow).toMatch(
+            /deployment-environment:\s*\n\s+required:\s+false\s*\n\s+type:\s+string\s*\n\s+default:\s+release/
+        );
+        expect(workflow).toContain('environment: ${{ inputs.deployment-environment }}');
+    });
+
+    it('routes prerelease and nightly deployments to the prerelease environment', async () => {
+        const workflow = await readWorkflow('release.yml');
+
+        expect(workflow).toContain('deployment-environment: prerelease');
+    });
+});


### PR DESCRIPTION
## Summary

- Adds a `deployment-environment` input to the reusable Velopack release workflow, defaulting to the protected `release` environment.
- Routes the manual/scheduled prerelease workflow (`beta` and `nightly`) to the `prerelease` environment so maintainers do not need a second release approval for those channels.
- Adds a lightweight workflow contract test for stable vs prerelease deployment environment routing.

## Related issue or RFC

Link the issue or RFC:

- Closes #255

For code changes, link the tracking issue. Only documentation wording, link fixes, or comment-only cleanups may skip the issue-first flow.

## AI assistance disclosure

If AI tools materially assisted this contribution, disclose that here or point to the relevant commit trailer.

- Tool(s) used: Codex
- Scope of assistance: Workflow configuration update, targeted contract test, local verification, PR preparation.
- Human review or rewrite performed: Maintainer requested the behavior and approved the prerelease/nightly-only scope before implementation.
- Architecture or boundary impact: CI/release workflow only; no app runtime, schema, AgentService, MCP, or frontend architecture impact.

## Testing evidence

List the commands you ran and the results you observed.

- `node -` workflow contract assertion: passed. Verified the reusable workflow defaults `deployment-environment` to `release`, the deploy job uses that input, prerelease workflow passes `prerelease`, and stable release does not target `prerelease`.
- `git diff --check HEAD~1..HEAD -- .github/workflows/release.yml .github/workflows/velopack-build.yml apps/desktop/tests/ci/release-workflow-environments.test.ts`: passed.
- `pnpm test:pr`: not run locally. The local environment has `D:` at 0 bytes free, and `pnpm install --frozen-lockfile --store-dir E:\TouchAI\pnpm-store` timed out before Vitest could be installed. CI is the first full-suite validation for this PR.

Did you follow TDD (test-first) for feature and fix work? Strongly recommended. See [docs/testing/testing.md](../docs/testing/testing.md).

```text
node -
git diff --check HEAD~1..HEAD -- .github/workflows/release.yml .github/workflows/velopack-build.yml apps/desktop/tests/ci/release-workflow-environments.test.ts
```

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: none.
- database baseline or migration impact: none.
- release or packaging impact: Low-to-medium. Stable releases keep the protected `release` environment by default. Prerelease/nightly deployments now target the `prerelease` environment, which should be configured without required reviewers if the intended behavior is no second approval.

## Screenshots or recordings

Not applicable; workflow-only change.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [ ] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [ ] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.