### PR TITLE
fix(agent): preserve reasoning-only assistant messages

### DIFF
--- a/apps/desktop/src/services/AgentService/infrastructure/providers/ai-sdk/messages.ts
+++ b/apps/desktop/src/services/AgentService/infrastructure/providers/ai-sdk/messages.ts
@@ -646,10 +646,15 @@ export async function buildModelMessages(
             continue;
         }
 
-        if (toolCallParts.length === 0 && contentParts.length === 1) {
+        const onlyContentPart = contentParts[0];
+        if (
+            toolCallParts.length === 0 &&
+            contentParts.length === 1 &&
+            onlyContentPart?.type === 'text'
+        ) {
             mappedMessages.push({
                 role: 'assistant',
-                content: contentParts[0]!.text,
+                content: onlyContentPart.text,
             });
             continue;
         }


### PR DESCRIPTION
## Summary

Preserves structured reasoning-only assistant messages when converting conversation history for AI SDK providers. This keeps reasoning metadata from being downgraded into normal assistant text during follow-up requests.

## Related issue or RFC

Related to https://github.com/TouchAI-org/TouchAI

## AI assistance disclosure

- Tool(s) used: AI pair-programming assistant
- Scope of assistance: small logic fix, local verification, and PR preparation
- Human review or rewrite performed: diff was reviewed before submission
- Architecture or boundary impact: no new boundary or architecture changes

## Testing evidence

```text
corepack pnpm --filter @touchai/desktop exec vitest run --configLoader runner tests/services/AgentService/infrastructure/providers/ai-sdk/messages.test.ts
# passed: 1 test file, 5 tests

corepack pnpm --filter @touchai/desktop exec eslint src/services/AgentService/infrastructure/providers/ai-sdk/messages.ts
# passed

corepack pnpm exec prettier --check apps/desktop/src/services/AgentService/infrastructure/providers/ai-sdk/messages.ts
# passed
```

`pnpm test:pr` was not run locally; this change is covered by the targeted frontend test file and CI.

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: scoped to AgentService provider message mapping; no runtime, MCP, or schema changes.
- database baseline or migration impact: none.
- release or packaging impact: none.

## Screenshots or recordings

N/A; no UI changes.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [ ] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [ ] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [ ] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.