### PR TITLE
fix(release): remove conflicting Velopack installer flag

### DIFF
--- a/.github/workflows/velopack-build.yml
+++ b/.github/workflows/velopack-build.yml
@@ -278,7 +278,6 @@ jobs:
                     --packVersion "${{ inputs.version }}" `
                     --packDir "$env:VELOPACK_STAGE" `
                     --mainExe "$env:VELOPACK_MAIN_EXE" `
-                    --noInst `
                     --noPortable `
                     --msi `
                     --instLocation Either `

--- a/apps/desktop/tests/ci/release-workflow-environments.test.ts
+++ b/apps/desktop/tests/ci/release-workflow-environments.test.ts
@@ -26,4 +26,12 @@ describe('release workflow deployment environments', () => {
 
         expect(workflow).toContain('deployment-environment: prerelease');
     });
+
+    it('packs Windows releases as MSI without conflicting Velopack installer flags', async () => {
+        const workflow = await readWorkflow('velopack-build.yml');
+
+        expect(workflow).toContain('--msi');
+        expect(workflow).toContain('--noPortable');
+        expect(workflow).not.toMatch(/--noInst[\s\S]*--noPortable|--noPortable[\s\S]*--noInst/);
+    });
 });


### PR DESCRIPTION
> First external contributors may need to complete the `CLA Assistant` check before merge.
> For code changes, this PR must link the related issue or RFC in the section below.

## Summary

Fixes the prerelease Velopack packaging failure:

- Removes the conflicting `--noInst` flag from the Windows `vpk pack` command.
- Keeps `--msi` and `--noPortable`, so the build still creates MSI and does not create portable packages.
- Leaves the existing normalize step responsible for dropping setup artifacts before publishing, so public Windows distribution remains MSI plus Velopack full/delta update packages.
- Adds a workflow regression test that fails if `--noInst` and `--noPortable` are combined again.

## Related issue or RFC

- Related to #48

## AI assistance disclosure

- Tool(s) used: Codex
- Scope of assistance: root-cause diagnosis, workflow fix, regression test, local verification, PR preparation
- Human review or rewrite performed: human review pending on this PR
- Architecture or boundary impact: release workflow only; no AgentService, runtime, MCP, database schema, or migration impact

## Testing evidence

```text
node_modules\.bin\vitest.cmd run tests/ci/release-workflow-environments.test.ts --configLoader runner
# Red before fix: failed because workflow contained both --noInst and --noPortable.
# Green after fix: 1 file, 3 tests passed.

node_modules\.bin\prettier.cmd --check .github/workflows/velopack-build.yml apps/desktop/tests/ci/release-workflow-environments.test.ts --ignore-path .prettierignore
# Passed.

git diff --check
# Passed.

node_modules\.bin\eslint.cmd --no-ignore apps/desktop/tests/ci/release-workflow-environments.test.ts
# Timed out locally in the .worktrees path; CI should provide the authoritative lint result.
```

Did you follow TDD (test-first) for feature and fix work? Yes. Added the workflow regression test first, verified it failed on the existing `--noInst` + `--noPortable` combination, then removed `--noInst` and verified the test passed.

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: none
- database baseline or migration impact: none
- release or packaging impact: low but direct. This unblocks prerelease Windows Velopack packaging while preserving MSI-only public distribution.

## Screenshots or recordings

Not applicable; workflow-only fix.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [ ] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [x] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [x] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.

## Summary by Sourcery

Adjust Velopack Windows packaging to avoid conflicting installer flags and add a regression test to enforce the expected configuration.

Bug Fixes:
- Resolve prerelease Velopack packaging failures by removing a conflicting Windows installer flag from the release workflow.

Tests:
- Add a CI test to verify Windows Velopack builds use MSI with no portable artifacts and do not combine incompatible installer flags.