### PR TITLE
fix(release): attach public assets to GitHub releases

### DIFF
--- a/.github/workflows/velopack-build.yml
+++ b/.github/workflows/velopack-build.yml
@@ -638,6 +638,22 @@ jobs:
                   name: touchai-update-dist
                   path: ${{ runner.temp }}/touchai-update-dist
 
+            - name: Generate Cloudflare update proxy config
+              working-directory: apps/desktop
+              shell: bash
+              run: |
+                  set -euo pipefail
+                  wrangler_config="$PWD/.wrangler-update-proxy.toml"
+                  node scripts/ci/write-cloudflare-update-worker-config.mjs "$wrangler_config"
+                  echo "WRANGLER_UPDATE_PROXY_CONFIG=$wrangler_config" >> "$GITHUB_ENV"
+
+            - name: Deploy Cloudflare update proxy Worker
+              working-directory: apps/desktop
+              env:
+                  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+                  CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+              run: pnpm dlx wrangler@3.90.0 deploy --config "$WRANGLER_UPDATE_PROXY_CONFIG"
+
             - name: Deploy update release feeds to Cloudflare R2
               shell: bash
               env:
@@ -652,3 +668,27 @@ jobs:
                       key="${file#"$update_dist"/}"
                       pnpm dlx wrangler@3.90.0 r2 object put "$CLOUDFLARE_R2_BUCKET_NAME/$key" --file "$file"
                     done
+
+            - name: Prune archived R2 release assets
+              working-directory: apps/desktop
+              shell: bash
+              env:
+                  RELEASE_CHANNEL: ${{ inputs.channel }}
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+                  CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+                  CLOUDFLARE_R2_BUCKET_NAME: ${{ needs.prepare-release.outputs.cloudflare_r2_bucket_name }}
+              run: |
+                  set -euo pipefail
+                  prune_plan="$RUNNER_TEMP/touchai-r2-prune-plan.txt"
+                  node scripts/ci/plan-r2-release-asset-prune.mjs "$RELEASE_CHANNEL" > "$prune_plan"
+                  if [ ! -s "$prune_plan" ]; then
+                    echo "No archived R2 release assets to prune."
+                    exit 0
+                  fi
+
+                  while IFS= read -r key; do
+                    if [ -n "$key" ]; then
+                      pnpm dlx wrangler@3.90.0 r2 object delete "$CLOUDFLARE_R2_BUCKET_NAME/$key"
+                    fi
+                  done < "$prune_plan"

--- a/.github/workflows/velopack-build.yml
+++ b/.github/workflows/velopack-build.yml
@@ -588,6 +588,22 @@ jobs:
                     --release-notes-file "$RUNNER_TEMP/release-notes/release-notes.md" \
                     --release-dir "$RUNNER_TEMP/touchai-release-assets"
 
+            - name: Upload public release assets to GitHub release
+              shell: bash
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  RELEASE_TAG: ${{ inputs.tag }}
+              run: |
+                  set -euo pipefail
+                  release_dir="$RUNNER_TEMP/touchai-release-assets"
+                  shopt -s nullglob
+                  assets=("$release_dir"/*)
+                  if [ ${#assets[@]} -eq 0 ]; then
+                    echo "No release assets were staged." >&2
+                    exit 1
+                  fi
+                  gh release upload "$RELEASE_TAG" "${assets[@]}" --clobber
+
             - name: Upload update release feeds artifact
               uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:

--- a/apps/desktop/product.json
+++ b/apps/desktop/product.json
@@ -17,7 +17,16 @@
             "baseUrl": "https://updates.touch-ai.org/touchai-app/v1",
             "deployment": {
                 "provider": "cloudflare-r2",
-                "bucketName": "touchai-updates"
+                "bucketName": "touchai-updates",
+                "workerName": "touchai-update-proxy",
+                "routePattern": "updates.touch-ai.org/touchai-app/v1/*",
+                "zoneName": "touch-ai.org",
+                "compatibilityDate": "2026-05-29",
+                "r2HotAssetVersions": {
+                    "stable": 3,
+                    "beta": 3,
+                    "nightly": 7
+                }
             },
             "channels": {
                 "stable": {

--- a/apps/desktop/scripts/ci/plan-r2-release-asset-prune.d.mts
+++ b/apps/desktop/scripts/ci/plan-r2-release-asset-prune.d.mts
@@ -1,0 +1,10 @@
+export type PlanR2ReleaseAssetPruneOptions = {
+    fetch?: typeof fetch;
+    token?: string | null;
+};
+
+export function planR2ReleaseAssetPrune(
+    projectRoot: string,
+    channel: string,
+    options?: PlanR2ReleaseAssetPruneOptions
+): Promise<string[]>;

--- a/apps/desktop/scripts/ci/plan-r2-release-asset-prune.mjs
+++ b/apps/desktop/scripts/ci/plan-r2-release-asset-prune.mjs
@@ -1,0 +1,140 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import {
+    assertNonEmptyString,
+    channelFromAssetName,
+    channelFromTag,
+    githubRepositoryFromProduct,
+    isDownloadAssetName,
+    relativeUpdatePath,
+} from '../update-release-assets.mjs';
+
+const GITHUB_API_BASE_URL = 'https://api.github.com';
+const GITHUB_USER_AGENT = 'touchai-r2-release-asset-prune/1.0.0';
+const MAX_RELEASE_PAGES = 10;
+
+async function readProduct(projectRoot) {
+    const product = JSON.parse(await readFile(join(projectRoot, 'product.json'), 'utf8'));
+    assertNonEmptyString(product?.repository?.url, 'repository.url');
+    assertNonEmptyString(product?.services?.updates?.baseUrl, 'services.updates.baseUrl');
+    return product;
+}
+
+function retentionForChannel(product, channel) {
+    const retentionByChannel = product.services?.updates?.deployment?.r2HotAssetVersions ?? {};
+    if (!Object.hasOwn(retentionByChannel, channel)) {
+        const expected = Object.keys(retentionByChannel).sort().join(', ');
+        throw new Error(`Unsupported release channel "${channel}". Expected one of: ${expected}.`);
+    }
+
+    const value = retentionByChannel[channel];
+    const parsed = Number.parseInt(String(value ?? ''), 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+}
+
+function releaseTime(release) {
+    const value = release.published_at ?? release.created_at ?? '';
+    const time = Date.parse(value);
+    return Number.isFinite(time) ? time : 0;
+}
+
+function githubHeaders(token) {
+    const headers = new Headers({
+        accept: 'application/vnd.github+json',
+        'user-agent': GITHUB_USER_AGENT,
+        'x-github-api-version': '2022-11-28',
+    });
+    if (token) {
+        headers.set('authorization', `Bearer ${token}`);
+    }
+    return headers;
+}
+
+async function fetchGithubReleases(repository, fetchImpl, token) {
+    const releases = [];
+    for (let page = 1; page <= MAX_RELEASE_PAGES; page += 1) {
+        const response = await fetchImpl(
+            `${GITHUB_API_BASE_URL}/repos/${repository}/releases?per_page=100&page=${page}`,
+            { headers: githubHeaders(token) }
+        );
+        if (!response.ok) {
+            throw new Error(`Failed to fetch GitHub releases: HTTP ${response.status}`);
+        }
+
+        const pageReleases = await response.json();
+        if (!Array.isArray(pageReleases)) {
+            throw new Error('GitHub releases response must be an array.');
+        }
+
+        releases.push(...pageReleases);
+        if (pageReleases.length < 100) {
+            break;
+        }
+    }
+    return releases;
+}
+
+export async function planR2ReleaseAssetPrune(projectRoot, channel, options = {}) {
+    assertNonEmptyString(channel, 'release channel');
+
+    const product = await readProduct(projectRoot);
+    const keepVersions = retentionForChannel(product, channel);
+    if (keepVersions <= 0) {
+        return [];
+    }
+
+    const repository = githubRepositoryFromProduct(product, {
+        invalidHostMessage: 'repository.url must use github.com for R2 release asset pruning.',
+    });
+    const updatePath = relativeUpdatePath(product.services.updates.baseUrl);
+    const fetchImpl = options.fetch ?? globalThis.fetch;
+    if (typeof fetchImpl !== 'function') {
+        throw new Error('fetch is required to plan R2 release asset pruning.');
+    }
+
+    const releases = await fetchGithubReleases(repository, fetchImpl, options.token ?? null);
+    const channelReleases = releases
+        .filter((release) => channelFromTag(release?.tag_name) === channel)
+        .sort((left, right) => releaseTime(right) - releaseTime(left));
+    const staleReleases = channelReleases.slice(keepVersions);
+    const keys = [];
+
+    for (const release of staleReleases) {
+        for (const asset of release.assets ?? []) {
+            const fileName = asset?.name;
+            if (!isDownloadAssetName(fileName) || channelFromAssetName(fileName) !== channel) {
+                continue;
+            }
+            keys.push(`${updatePath}/${fileName}`);
+        }
+    }
+
+    return [...new Set(keys)];
+}
+
+function parseArgs(argv) {
+    const [channel] = argv;
+    if (!channel) {
+        throw new Error('Usage: node scripts/ci/plan-r2-release-asset-prune.mjs <channel>');
+    }
+    return { channel };
+}
+
+async function main() {
+    const { channel } = parseArgs(process.argv.slice(2));
+    const keys = await planR2ReleaseAssetPrune(process.cwd(), channel, {
+        token: process.env.GITHUB_TOKEN ?? null,
+    });
+    if (keys.length > 0) {
+        process.stdout.write(`${keys.join('\n')}\n`);
+    }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    main().catch((error) => {
+        console.error(error.message ?? error);
+        process.exit(1);
+    });
+}

--- a/apps/desktop/scripts/ci/write-cloudflare-update-worker-config.d.mts
+++ b/apps/desktop/scripts/ci/write-cloudflare-update-worker-config.d.mts
@@ -1,0 +1,30 @@
+export type ProductConfig = {
+    repository?: {
+        url?: string;
+    };
+    services?: {
+        updates?: {
+            baseUrl?: string;
+            deployment?: {
+                provider?: string;
+                workerName?: string;
+                bucketName?: string;
+                routePattern?: string;
+                zoneName?: string;
+                compatibilityDate?: string;
+            };
+        };
+    };
+};
+
+export function buildCloudflareUpdateWorkerConfig(
+    product: ProductConfig,
+    options: {
+        workerScriptPath: string;
+    }
+): string;
+
+export function writeCloudflareUpdateWorkerConfig(
+    projectRoot: string,
+    outputPath: string
+): Promise<void>;

--- a/apps/desktop/scripts/ci/write-cloudflare-update-worker-config.mjs
+++ b/apps/desktop/scripts/ci/write-cloudflare-update-worker-config.mjs
@@ -1,0 +1,103 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, join, relative, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import {
+    assertNonEmptyString,
+    githubRepositoryFromProduct,
+    relativeUpdatePath,
+} from '../update-release-assets.mjs';
+
+function tomlString(value) {
+    return JSON.stringify(value);
+}
+
+function normalizePath(value) {
+    return value.replaceAll('\\', '/');
+}
+
+export function buildCloudflareUpdateWorkerConfig(product, options) {
+    assertNonEmptyString(product?.repository?.url, 'repository.url');
+    assertNonEmptyString(product?.services?.updates?.baseUrl, 'services.updates.baseUrl');
+
+    const deployment = product.services.updates.deployment;
+    if (deployment?.provider !== 'cloudflare-r2') {
+        throw new Error('services.updates.deployment.provider must be cloudflare-r2.');
+    }
+
+    assertNonEmptyString(deployment.workerName, 'services.updates.deployment.workerName');
+    assertNonEmptyString(deployment.bucketName, 'services.updates.deployment.bucketName');
+    assertNonEmptyString(deployment.routePattern, 'services.updates.deployment.routePattern');
+    assertNonEmptyString(deployment.zoneName, 'services.updates.deployment.zoneName');
+    assertNonEmptyString(
+        deployment.compatibilityDate,
+        'services.updates.deployment.compatibilityDate'
+    );
+    assertNonEmptyString(options?.workerScriptPath, 'worker script path');
+
+    return `${[
+        `name = ${tomlString(deployment.workerName)}`,
+        `main = ${tomlString(normalizePath(options.workerScriptPath))}`,
+        `compatibility_date = ${tomlString(deployment.compatibilityDate)}`,
+        '',
+        'routes = [',
+        `    { pattern = ${tomlString(deployment.routePattern)}, zone_name = ${tomlString(
+            deployment.zoneName
+        )} },`,
+        ']',
+        '',
+        '[[r2_buckets]]',
+        'binding = "UPDATE_BUCKET"',
+        `bucket_name = ${tomlString(deployment.bucketName)}`,
+        '',
+        '[vars]',
+        `UPDATE_BASE_PATH = ${tomlString(relativeUpdatePath(product.services.updates.baseUrl))}`,
+        `GITHUB_REPOSITORY = ${tomlString(
+            githubRepositoryFromProduct(product, {
+                invalidHostMessage: 'repository.url must use github.com for the update proxy.',
+            })
+        )}`,
+    ].join('\n')}\n`;
+}
+
+export async function writeCloudflareUpdateWorkerConfig(projectRoot, outputPath) {
+    assertNonEmptyString(projectRoot, 'project root');
+    assertNonEmptyString(outputPath, 'output path');
+
+    const resolvedProjectRoot = resolve(projectRoot);
+    const resolvedOutputPath = resolve(outputPath);
+    const product = JSON.parse(await readFile(join(resolvedProjectRoot, 'product.json'), 'utf8'));
+    const workerScriptPath = relative(
+        dirname(resolvedOutputPath),
+        join(resolvedProjectRoot, 'scripts/cloudflare/update-proxy-worker.mjs')
+    );
+
+    await mkdir(dirname(resolvedOutputPath), { recursive: true });
+    await writeFile(
+        resolvedOutputPath,
+        buildCloudflareUpdateWorkerConfig(product, { workerScriptPath }),
+        'utf8'
+    );
+}
+
+function parseArgs(argv) {
+    const [outputPath] = argv;
+    if (!outputPath) {
+        throw new Error(
+            'Usage: node scripts/ci/write-cloudflare-update-worker-config.mjs <output-path>'
+        );
+    }
+    return { outputPath };
+}
+
+async function main() {
+    const { outputPath } = parseArgs(process.argv.slice(2));
+    await writeCloudflareUpdateWorkerConfig(process.cwd(), outputPath);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    main().catch((error) => {
+        console.error(error.message ?? error);
+        process.exit(1);
+    });
+}

--- a/apps/desktop/scripts/cloudflare/update-proxy-worker.d.mts
+++ b/apps/desktop/scripts/cloudflare/update-proxy-worker.d.mts
@@ -1,0 +1,28 @@
+export type UpdateProxyWorkerEnvironment = {
+    UPDATE_BASE_PATH?: string;
+    GITHUB_REPOSITORY?: string;
+    UPDATE_FEED_CACHE_SECONDS?: string;
+    UPDATE_ASSET_CACHE_SECONDS?: string;
+    UPDATE_BUCKET?: {
+        get?: (key: string, options?: { range?: Headers }) => Promise<unknown>;
+        head?: (key: string) => Promise<unknown>;
+    };
+};
+
+export type UpdateProxyWorkerContext = {
+    waitUntil?: (promise: Promise<unknown>) => void;
+};
+
+export function deriveReleaseTagFromAssetName(fileName: string): string | null;
+
+export function handleUpdateProxyRequest(
+    request: Request,
+    env: UpdateProxyWorkerEnvironment,
+    context: UpdateProxyWorkerContext
+): Promise<Response>;
+
+declare const worker: {
+    fetch: typeof handleUpdateProxyRequest;
+};
+
+export default worker;

--- a/apps/desktop/scripts/cloudflare/update-proxy-worker.mjs
+++ b/apps/desktop/scripts/cloudflare/update-proxy-worker.mjs
@@ -1,0 +1,309 @@
+import { deriveReleaseTagFromAssetName } from '../update-release-assets.mjs';
+
+const DEFAULT_ASSET_CACHE_SECONDS = 31_536_000;
+const DEFAULT_FEED_CACHE_SECONDS = 60;
+
+export { deriveReleaseTagFromAssetName };
+
+function trimSlashes(value) {
+    return String(value ?? '').replace(/^\/+|\/+$/g, '');
+}
+
+function cacheSeconds(value, fallback) {
+    const parsed = Number.parseInt(String(value ?? ''), 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function textResponse(message, status, extraHeaders = {}) {
+    return new Response(message, {
+        status,
+        headers: {
+            'content-type': 'text/plain; charset=utf-8',
+            ...extraHeaders,
+        },
+    });
+}
+
+function messageFromError(error) {
+    if (error instanceof Error && error.message) {
+        return error.message;
+    }
+    return String(error ?? 'Unknown error');
+}
+
+function responseHeadersWithDefaults(headers, defaults) {
+    const next = new Headers(headers);
+    for (const [key, value] of Object.entries(defaults)) {
+        if (!next.has(key)) {
+            next.set(key, value);
+        }
+    }
+    next.delete('set-cookie');
+    return next;
+}
+
+function objectKeyFromRequest(url, basePath) {
+    const normalizedBasePath = trimSlashes(basePath);
+    if (!normalizedBasePath) {
+        return null;
+    }
+
+    let decodedPath;
+    try {
+        decodedPath = decodeURIComponent(url.pathname.replace(/^\/+/, ''));
+    } catch {
+        return null;
+    }
+
+    if (!decodedPath.startsWith(`${normalizedBasePath}/`)) {
+        return null;
+    }
+    if (decodedPath.includes('..') || decodedPath.includes('\\')) {
+        return null;
+    }
+
+    const fileName = decodedPath.slice(normalizedBasePath.length + 1);
+    if (!fileName || fileName.includes('/')) {
+        return null;
+    }
+
+    return {
+        key: `${normalizedBasePath}/${fileName}`,
+        fileName,
+    };
+}
+
+function isFeedFile(fileName) {
+    return /^releases\.[a-z0-9_-]+\.json$/i.test(fileName);
+}
+
+function githubReleaseAssetUrl(repository, tag, fileName) {
+    const normalizedRepository = String(repository ?? '').replace(/^\/+|\/+$/g, '');
+    if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(normalizedRepository)) {
+        return null;
+    }
+
+    return `https://github.com/${normalizedRepository}/releases/download/${encodeURIComponent(
+        tag
+    )}/${encodeURIComponent(fileName)}`;
+}
+
+function cacheKeyFor(request) {
+    return new Request(request.url, { method: 'GET' });
+}
+
+function canUseWorkerCache(request) {
+    return (request.method === 'GET' || request.method === 'HEAD') && !request.headers.has('range');
+}
+
+function defaultCacheControl(fileName, env) {
+    if (isFeedFile(fileName)) {
+        return `public, max-age=${cacheSeconds(env.UPDATE_FEED_CACHE_SECONDS, DEFAULT_FEED_CACHE_SECONDS)}`;
+    }
+
+    return `public, max-age=${cacheSeconds(
+        env.UPDATE_ASSET_CACHE_SECONDS,
+        DEFAULT_ASSET_CACHE_SECONDS
+    )}, immutable`;
+}
+
+function r2ObjectRange(object) {
+    const range = object?.range;
+    const size = object?.size;
+    if (!range || typeof range !== 'object' || !Number.isFinite(size) || size < 0) {
+        return null;
+    }
+
+    const offset = Number(range.offset);
+    if (Number.isFinite(offset) && offset >= 0) {
+        const start = Math.trunc(offset);
+        const length = Number(range.length);
+        const requestedLength =
+            Number.isFinite(length) && length > 0 ? Math.trunc(length) : size - start;
+        if (start >= size || requestedLength <= 0) {
+            return null;
+        }
+
+        const end = Math.min(start + requestedLength - 1, size - 1);
+        return {
+            contentLength: end - start + 1,
+            contentRange: `bytes ${start}-${end}/${size}`,
+        };
+    }
+
+    const suffix = Number(range.suffix);
+    if (Number.isFinite(suffix) && suffix > 0 && size > 0) {
+        const end = size - 1;
+        const start = Math.max(size - Math.trunc(suffix), 0);
+        return {
+            contentLength: end - start + 1,
+            contentRange: `bytes ${start}-${end}/${size}`,
+        };
+    }
+
+    return null;
+}
+
+async function responseFromR2Object(request, object, fileName, env) {
+    if (!object) {
+        return null;
+    }
+
+    const headers = new Headers();
+    object.writeHttpMetadata?.(headers);
+    headers.set('cache-control', defaultCacheControl(fileName, env));
+    headers.set('accept-ranges', 'bytes');
+    if (object.httpEtag) {
+        headers.set('etag', object.httpEtag);
+    }
+    if (typeof object.size === 'number' && !headers.has('content-length')) {
+        headers.set('content-length', String(object.size));
+    }
+    const range = r2ObjectRange(object);
+    if (range) {
+        headers.set('content-range', range.contentRange);
+        headers.set('content-length', String(range.contentLength));
+    }
+
+    return new Response(request.method === 'HEAD' ? null : object.body, {
+        status: object.range ? 206 : 200,
+        headers,
+    });
+}
+
+async function responseFromR2(request, env, key, fileName) {
+    const bucket = env.UPDATE_BUCKET;
+    if (!bucket?.get) {
+        return null;
+    }
+
+    let object;
+    try {
+        object =
+            request.method === 'HEAD' && bucket.head
+                ? await bucket.head(key)
+                : await bucket.get(key, { range: request.headers });
+    } catch (error) {
+        console.error('Update R2 lookup failed', {
+            error: messageFromError(error),
+            key,
+            method: request.method,
+        });
+        return textResponse(`Update storage failed: ${messageFromError(error)}`, 503);
+    }
+    return responseFromR2Object(request, object, fileName, env);
+}
+
+function fallbackHeaders(request) {
+    const headers = new Headers();
+    const range = request.headers.get('range');
+    if (range) {
+        headers.set('range', range);
+    }
+    return headers;
+}
+
+async function responseFromGitHub(request, env, fileName) {
+    const tag = deriveReleaseTagFromAssetName(fileName);
+    if (!tag) {
+        return null;
+    }
+
+    const url = githubReleaseAssetUrl(env.GITHUB_REPOSITORY, tag, fileName);
+    if (!url) {
+        return null;
+    }
+
+    let response;
+    try {
+        response = await fetch(url, {
+            method: request.method,
+            headers: fallbackHeaders(request),
+            redirect: 'follow',
+        });
+    } catch (error) {
+        return textResponse(`GitHub fallback failed: ${messageFromError(error)}`, 502);
+    }
+    if (response.status === 404) {
+        return null;
+    }
+    if (!response.ok && response.status !== 206) {
+        return textResponse(`GitHub fallback failed: HTTP ${response.status}`, 502);
+    }
+
+    const headers = responseHeadersWithDefaults(response.headers, {
+        'accept-ranges': 'bytes',
+    });
+    headers.set('cache-control', defaultCacheControl(fileName, env));
+
+    return new Response(request.method === 'HEAD' ? null : response.body, {
+        status: response.status,
+        statusText: response.statusText,
+        headers,
+    });
+}
+
+async function cachedResponse(request) {
+    if (!canUseWorkerCache(request) || !globalThis.caches?.default) {
+        return null;
+    }
+
+    return (await globalThis.caches.default.match(cacheKeyFor(request))) ?? null;
+}
+
+function cacheResponse(request, context, response) {
+    if (
+        request.method !== 'GET' ||
+        !canUseWorkerCache(request) ||
+        response.status !== 200 ||
+        !globalThis.caches?.default ||
+        !context?.waitUntil
+    ) {
+        return;
+    }
+
+    context.waitUntil(globalThis.caches.default.put(cacheKeyFor(request), response.clone()));
+}
+
+export async function handleUpdateProxyRequest(request, env, context) {
+    if (request.method !== 'GET' && request.method !== 'HEAD') {
+        return textResponse('Method not allowed', 405, { allow: 'GET, HEAD' });
+    }
+
+    const parsed = objectKeyFromRequest(new URL(request.url), env.UPDATE_BASE_PATH);
+    if (!parsed) {
+        return textResponse('Not found', 404);
+    }
+
+    const r2Response = await responseFromR2(request, env, parsed.key, parsed.fileName);
+    if (r2Response) {
+        return r2Response;
+    }
+
+    if (isFeedFile(parsed.fileName)) {
+        return textResponse('Not found', 404);
+    }
+
+    const cacheHit = await cachedResponse(request);
+    if (cacheHit) {
+        return request.method === 'HEAD'
+            ? new Response(null, {
+                  status: cacheHit.status,
+                  statusText: cacheHit.statusText,
+                  headers: cacheHit.headers,
+              })
+            : cacheHit;
+    }
+
+    const githubResponse = await responseFromGitHub(request, env, parsed.fileName);
+    if (!githubResponse) {
+        return textResponse('Not found', 404);
+    }
+
+    cacheResponse(request, context, githubResponse);
+    return githubResponse;
+}
+
+export default {
+    fetch: handleUpdateProxyRequest,
+};

--- a/apps/desktop/scripts/update-release-assets.d.mts
+++ b/apps/desktop/scripts/update-release-assets.d.mts
@@ -1,0 +1,31 @@
+export const DOWNLOAD_EXTENSIONS: string[];
+
+export type ProductRepositoryConfig = {
+    repository?: {
+        url?: string;
+    };
+};
+
+export function assertNonEmptyString(value: unknown, label: string): void;
+
+export function relativeUpdatePath(baseUrl: string, label?: string): string;
+
+export function githubRepositoryFromProduct(
+    product: ProductRepositoryConfig,
+    options?: {
+        label?: string;
+        invalidHostMessage?: string;
+    }
+): string;
+
+export function isDownloadAssetName(fileName: string): boolean;
+
+export function versionFromAssetName(fileName: string): string | null;
+
+export function deriveReleaseTagFromAssetName(fileName: string): string | null;
+
+export function channelFromVersion(version: string | null | undefined): string | null;
+
+export function channelFromTag(tagName: string | null | undefined): string | null;
+
+export function channelFromAssetName(fileName: string): string | null;

--- a/apps/desktop/scripts/update-release-assets.mjs
+++ b/apps/desktop/scripts/update-release-assets.mjs
@@ -1,0 +1,96 @@
+export const DOWNLOAD_EXTENSIONS = [
+    '.msi',
+    '.dmg',
+    '.deb',
+    '.rpm',
+    '.appimage',
+    '.appimage.tar.gz',
+    '.app.tar.gz',
+    '-full.nupkg',
+    '-delta.nupkg',
+];
+
+const VERSIONED_ASSET_PATTERN =
+    /-(\d+\.\d+\.\d+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?)-(?:windows|macos|linux)(?:[.-])/i;
+
+export function assertNonEmptyString(value, label) {
+    if (typeof value !== 'string' || !value.trim()) {
+        throw new Error(`${label} must be a non-empty string.`);
+    }
+}
+
+export function relativeUpdatePath(baseUrl, label = 'services.updates.baseUrl') {
+    const url = new URL(baseUrl);
+    if (url.protocol !== 'https:') {
+        throw new Error(`${label} must use https.`);
+    }
+
+    const path = url.pathname.replace(/^\/+|\/+$/g, '');
+    assertNonEmptyString(path, `${label} path`);
+    return path;
+}
+
+export function githubRepositoryFromProduct(product, options = {}) {
+    const label = options.label ?? 'repository.url';
+    const invalidHostMessage = options.invalidHostMessage ?? `${label} must use github.com.`;
+    assertNonEmptyString(product?.repository?.url, label);
+
+    const url = new URL(product.repository.url);
+    if (url.hostname !== 'github.com') {
+        throw new Error(invalidHostMessage);
+    }
+
+    const segments = url.pathname.split('/').filter(Boolean);
+    if (segments.length !== 2) {
+        throw new Error(`${label} must be a GitHub owner/repository URL.`);
+    }
+
+    const [owner, repositoryName] = segments;
+    const repository = repositoryName.replace(/\.git$/iu, '');
+    assertNonEmptyString(owner, 'repository owner');
+    assertNonEmptyString(repository, 'repository name');
+    return `${owner}/${repository}`;
+}
+
+export function isDownloadAssetName(fileName) {
+    const lowerName = String(fileName ?? '').toLowerCase();
+    return DOWNLOAD_EXTENSIONS.some((extension) => lowerName.endsWith(extension));
+}
+
+export function versionFromAssetName(fileName) {
+    return String(fileName ?? '').match(VERSIONED_ASSET_PATTERN)?.[1] ?? null;
+}
+
+export function deriveReleaseTagFromAssetName(fileName) {
+    const version = versionFromAssetName(fileName);
+    if (!version || !isDownloadAssetName(fileName)) {
+        return null;
+    }
+
+    return `v${version}`;
+}
+
+export function channelFromVersion(version) {
+    if (!version) {
+        return null;
+    }
+    if (/-nightly(?:[.-]|$)/i.test(version)) {
+        return 'nightly';
+    }
+    if (/-beta(?:[.-]|$)/i.test(version)) {
+        return 'beta';
+    }
+    if (/^\d+\.\d+\.\d+$/u.test(version)) {
+        return 'stable';
+    }
+    return null;
+}
+
+export function channelFromTag(tagName) {
+    const version = String(tagName ?? '').replace(/^v/u, '');
+    return channelFromVersion(version);
+}
+
+export function channelFromAssetName(fileName) {
+    return channelFromVersion(versionFromAssetName(fileName));
+}

--- a/apps/desktop/tests/ci/plan-r2-release-asset-prune.test.ts
+++ b/apps/desktop/tests/ci/plan-r2-release-asset-prune.test.ts
@@ -1,0 +1,160 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { APP_PRODUCT_CONFIG } from '@/config/product';
+
+type PlanModule = {
+    planR2ReleaseAssetPrune: (
+        projectRoot: string,
+        channel: string,
+        options?: {
+            fetch?: typeof fetch;
+            token?: string | null;
+        }
+    ) => Promise<string[]>;
+};
+
+async function loadPlanner(): Promise<PlanModule | undefined> {
+    try {
+        return (await import('../../scripts/ci/plan-r2-release-asset-prune.mjs')) as PlanModule;
+    } catch {
+        return undefined;
+    }
+}
+
+async function createFixture(product: unknown) {
+    const root = await mkdtemp(join(tmpdir(), 'touchai-r2-prune-'));
+    await mkdir(root, { recursive: true });
+    await writeFile(join(root, 'product.json'), `${JSON.stringify(product, null, 4)}\n`, 'utf8');
+    return root;
+}
+
+function productWithRetention() {
+    const product = JSON.parse(JSON.stringify(APP_PRODUCT_CONFIG));
+    product.services.updates.deployment = {
+        ...product.services.updates.deployment,
+        r2HotAssetVersions: {
+            stable: 2,
+            beta: 2,
+            nightly: 3,
+        },
+    };
+    return product;
+}
+
+function release(tagName: string, publishedAt: string, assetNames: string[]) {
+    return {
+        tag_name: tagName,
+        published_at: publishedAt,
+        assets: assetNames.map((name) => ({ name })),
+    };
+}
+
+describe('planR2ReleaseAssetPrune', () => {
+    it('plans deletion for old channel assets that already exist on GitHub Releases', async () => {
+        const planner = await loadPlanner();
+        const product = productWithRetention();
+        const root = await createFixture(product);
+        const fetchMock = vi.fn<typeof fetch>(async () => {
+            return new Response(
+                JSON.stringify([
+                    release('v0.2.0-beta.4', '2026-05-24T00:00:00Z', [
+                        'TouchAI-beta-0.2.0-beta.4-windows-full.nupkg',
+                    ]),
+                    release('v0.2.0-beta.3', '2026-05-23T00:00:00Z', [
+                        'TouchAI-beta-0.2.0-beta.3-windows-full.nupkg',
+                    ]),
+                    release('v0.2.0-beta.2', '2026-05-22T00:00:00Z', [
+                        'TouchAI-beta-0.2.0-beta.2-windows-full.nupkg',
+                        'TouchAI-beta-0.2.0-beta.2-windows-delta.nupkg',
+                        'release-notes.md',
+                    ]),
+                    release('v0.2.0', '2026-05-21T00:00:00Z', ['TouchAI-0.2.0-windows-full.nupkg']),
+                ]),
+                {
+                    headers: {
+                        'content-type': 'application/json',
+                    },
+                }
+            );
+        });
+
+        try {
+            expect(planner?.planR2ReleaseAssetPrune).toBeTypeOf('function');
+            await expect(
+                planner!.planR2ReleaseAssetPrune(root, 'beta', {
+                    fetch: fetchMock as unknown as typeof fetch,
+                    token: 'token',
+                })
+            ).resolves.toEqual([
+                'touchai-app/v1/TouchAI-beta-0.2.0-beta.2-windows-full.nupkg',
+                'touchai-app/v1/TouchAI-beta-0.2.0-beta.2-windows-delta.nupkg',
+            ]);
+            expect(fetchMock).toHaveBeenCalledWith(
+                'https://api.github.com/repos/TouchAI-org/TouchAI/releases?per_page=100&page=1',
+                expect.objectContaining({
+                    headers: expect.any(Headers),
+                })
+            );
+            const headers = fetchMock.mock.calls[0]?.[1]?.headers as Headers;
+            expect(headers.get('authorization')).toBe('Bearer token');
+            expect(headers.get('user-agent')).toBe('touchai-r2-release-asset-prune/1.0.0');
+        } finally {
+            await rm(root, { recursive: true, force: true });
+        }
+    });
+
+    it('keeps all GitHub release assets when the channel has not exceeded its R2 retention window', async () => {
+        const planner = await loadPlanner();
+        const product = productWithRetention();
+        const root = await createFixture(product);
+        const fetchMock = vi.fn<typeof fetch>(async () => {
+            return new Response(
+                JSON.stringify([
+                    release('v0.3.0-nightly.20260524.1', '2026-05-24T00:00:00Z', [
+                        'TouchAI-nightly-0.3.0-nightly.20260524.1-windows-full.nupkg',
+                    ]),
+                    release('v0.3.0-nightly.20260523.1', '2026-05-23T00:00:00Z', [
+                        'TouchAI-nightly-0.3.0-nightly.20260523.1-windows-full.nupkg',
+                    ]),
+                ]),
+                { headers: { 'content-type': 'application/json' } }
+            );
+        });
+
+        try {
+            expect(planner?.planR2ReleaseAssetPrune).toBeTypeOf('function');
+            await expect(
+                planner!.planR2ReleaseAssetPrune(root, 'nightly', {
+                    fetch: fetchMock as unknown as typeof fetch,
+                    token: 'token',
+                })
+            ).resolves.toEqual([]);
+        } finally {
+            await rm(root, { recursive: true, force: true });
+        }
+    });
+
+    it('rejects unsupported channels before querying GitHub releases', async () => {
+        const planner = await loadPlanner();
+        const product = productWithRetention();
+        const root = await createFixture(product);
+        const fetchMock = vi.fn<typeof fetch>();
+
+        try {
+            expect(planner?.planR2ReleaseAssetPrune).toBeTypeOf('function');
+            await expect(
+                planner!.planR2ReleaseAssetPrune(root, 'canary', {
+                    fetch: fetchMock as unknown as typeof fetch,
+                    token: 'token',
+                })
+            ).rejects.toThrow('Unsupported release channel "canary"');
+            expect(fetchMock).not.toHaveBeenCalled();
+        } finally {
+            await rm(root, { recursive: true, force: true });
+        }
+    });
+});

--- a/apps/desktop/tests/ci/release-workflow-environments.test.ts
+++ b/apps/desktop/tests/ci/release-workflow-environments.test.ts
@@ -34,4 +34,13 @@ describe('release workflow deployment environments', () => {
         expect(workflow).toContain('--noPortable');
         expect(workflow).not.toMatch(/--noInst[\s\S]*--noPortable|--noPortable[\s\S]*--noInst/);
     });
+
+    it('attaches public release assets to GitHub releases from the staged asset directory', async () => {
+        const workflow = await readWorkflow('velopack-build.yml');
+        const uploadLine = workflow.split('\n').find((line) => line.includes('gh release upload'));
+
+        expect(workflow).toContain('gh release upload "$RELEASE_TAG" "${assets[@]}" --clobber');
+        expect(workflow).toContain('release_dir="$RUNNER_TEMP/touchai-release-assets"');
+        expect(uploadLine).not.toContain('touchai-update-dist');
+    });
 });

--- a/apps/desktop/tests/ci/release-workflow-environments.test.ts
+++ b/apps/desktop/tests/ci/release-workflow-environments.test.ts
@@ -41,6 +41,30 @@ describe('release workflow deployment environments', () => {
 
         expect(workflow).toContain('gh release upload "$RELEASE_TAG" "${assets[@]}" --clobber');
         expect(workflow).toContain('release_dir="$RUNNER_TEMP/touchai-release-assets"');
-        expect(uploadLine).not.toContain('touchai-update-dist');
+        expect(uploadLine).toBeDefined();
+        expect(uploadLine ?? '').not.toContain('touchai-update-dist');
+    });
+
+    it('deploys the Cloudflare update proxy Worker with an R2 binding', async () => {
+        const workflow = await readWorkflow('velopack-build.yml');
+
+        expect(workflow).toContain('Generate Cloudflare update proxy config');
+        expect(workflow).toContain(
+            'node scripts/ci/write-cloudflare-update-worker-config.mjs "$wrangler_config"'
+        );
+        expect(workflow).toContain('Deploy Cloudflare update proxy Worker');
+        expect(workflow).toContain('pnpm dlx wrangler@3.90.0 deploy');
+        expect(workflow).toContain('--config "$WRANGLER_UPDATE_PROXY_CONFIG"');
+    });
+
+    it('prunes only old R2 release assets after GitHub release upload succeeds', async () => {
+        const workflow = await readWorkflow('velopack-build.yml');
+
+        expect(workflow).toContain('RELEASE_CHANNEL: ${{ inputs.channel }}');
+        expect(workflow).toContain('plan-r2-release-asset-prune.mjs "$RELEASE_CHANNEL"');
+        expect(workflow).toContain('wrangler@3.90.0 r2 object delete');
+        expect(workflow).toMatch(
+            /Upload public release assets to GitHub release[\s\S]*Deploy update release feeds to Cloudflare R2[\s\S]*Prune archived R2 release assets/
+        );
     });
 });

--- a/apps/desktop/tests/ci/update-proxy-worker.test.ts
+++ b/apps/desktop/tests/ci/update-proxy-worker.test.ts
@@ -1,0 +1,341 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+type UpdateProxyWorkerModule = {
+    default: {
+        fetch: (
+            request: Request,
+            env: Record<string, unknown>,
+            context: { waitUntil: (promise: Promise<unknown>) => void }
+        ) => Promise<Response>;
+    };
+    deriveReleaseTagFromAssetName: (fileName: string) => string | null;
+};
+
+type BucketObject = {
+    body: ReadableStream<Uint8Array> | null;
+    httpEtag?: string;
+    range?: {
+        length?: number;
+        offset?: number;
+        suffix?: number;
+    };
+    size?: number;
+    writeHttpMetadata?: (headers: Headers) => void;
+};
+
+class MemoryCache {
+    readonly match = vi.fn(async (request: Request) => {
+        return this.entries.get(request.url)?.clone();
+    });
+
+    readonly put = vi.fn(async (request: Request, response: Response) => {
+        this.entries.set(request.url, response.clone());
+    });
+
+    private readonly entries = new Map<string, Response>();
+}
+
+async function loadWorker(): Promise<UpdateProxyWorkerModule | undefined> {
+    try {
+        return (await import('../../scripts/cloudflare/update-proxy-worker.mjs')) as UpdateProxyWorkerModule;
+    } catch {
+        return undefined;
+    }
+}
+
+function installCache(cache: MemoryCache) {
+    vi.stubGlobal('caches', { default: cache });
+}
+
+function workerContext() {
+    const pending: Promise<unknown>[] = [];
+    return {
+        context: {
+            waitUntil: (promise: Promise<unknown>) => {
+                pending.push(promise);
+            },
+        },
+        async flush() {
+            await Promise.all(pending);
+        },
+    };
+}
+
+function r2Object(
+    body: string,
+    headers: Record<string, string> = {},
+    options: { range?: BucketObject['range']; size?: number } = {}
+): BucketObject {
+    const response = new Response(body);
+    return {
+        body: response.body,
+        httpEtag: '"r2-etag"',
+        range: options.range,
+        size: options.size ?? body.length,
+        writeHttpMetadata(metadata) {
+            for (const [key, value] of Object.entries(headers)) {
+                metadata.set(key, value);
+            }
+        },
+    };
+}
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+});
+
+describe('update proxy Worker', () => {
+    it('serves update assets from R2 before using the GitHub fallback', async () => {
+        const worker = await loadWorker();
+        const cache = new MemoryCache();
+        installCache(cache);
+        const fetchMock = vi.fn<typeof fetch>();
+        vi.stubGlobal('fetch', fetchMock);
+
+        const env = {
+            UPDATE_BASE_PATH: 'touchai-app/v1',
+            GITHUB_REPOSITORY: 'TouchAI-org/TouchAI',
+            UPDATE_BUCKET: {
+                get: vi.fn(async () =>
+                    r2Object('from-r2', { 'content-type': 'application/octet-stream' })
+                ),
+            },
+        };
+        const request = new Request(
+            'https://updates.touch-ai.org/touchai-app/v1/TouchAI-beta-0.1.1-beta.14-windows.msi'
+        );
+        const { context } = workerContext();
+
+        expect(worker?.default.fetch).toBeTypeOf('function');
+        const response = await worker!.default.fetch(request, env, context);
+
+        expect(response.status).toBe(200);
+        expect(await response.text()).toBe('from-r2');
+        expect(response.headers.get('etag')).toBe('"r2-etag"');
+        expect(env.UPDATE_BUCKET.get).toHaveBeenCalledWith(
+            'touchai-app/v1/TouchAI-beta-0.1.1-beta.14-windows.msi',
+            {
+                range: request.headers,
+            }
+        );
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(cache.put).not.toHaveBeenCalled();
+    });
+
+    it('proxies cacheable R2 misses from the matching GitHub Release asset', async () => {
+        const worker = await loadWorker();
+        const cache = new MemoryCache();
+        installCache(cache);
+        const fetchMock = vi.fn<typeof fetch>(async () => {
+            return new Response('from-github', {
+                status: 200,
+                headers: { 'content-type': 'application/octet-stream' },
+            });
+        });
+        vi.stubGlobal('fetch', fetchMock);
+
+        const env = {
+            UPDATE_BASE_PATH: 'touchai-app/v1',
+            GITHUB_REPOSITORY: 'TouchAI-org/TouchAI',
+            UPDATE_BUCKET: {
+                get: vi.fn(async () => null),
+            },
+        };
+        const request = new Request(
+            'https://updates.touch-ai.org/touchai-app/v1/TouchAI-beta-0.1.1-beta.14-windows-full.nupkg'
+        );
+        const { context, flush } = workerContext();
+
+        expect(worker?.default.fetch).toBeTypeOf('function');
+        const response = await worker!.default.fetch(request, env, context);
+        await flush();
+
+        expect(response.status).toBe(200);
+        expect(await response.text()).toBe('from-github');
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock.mock.calls[0]?.[0]).toBe(
+            'https://github.com/TouchAI-org/TouchAI/releases/download/v0.1.1-beta.14/TouchAI-beta-0.1.1-beta.14-windows-full.nupkg'
+        );
+        expect(cache.put).toHaveBeenCalledTimes(1);
+
+        const cached = await worker!.default.fetch(request, env, workerContext().context);
+        expect(await cached.text()).toBe('from-github');
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+
+        const headResponse = await worker!.default.fetch(
+            new Request(request.url, { method: 'HEAD' }),
+            env,
+            workerContext().context
+        );
+        expect(headResponse.status).toBe(200);
+        expect(await headResponse.text()).toBe('');
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('sets range metadata for partial R2 responses', async () => {
+        const worker = await loadWorker();
+        const fetchMock = vi.fn<typeof fetch>();
+        vi.stubGlobal('fetch', fetchMock);
+
+        const env = {
+            UPDATE_BASE_PATH: 'touchai-app/v1',
+            GITHUB_REPOSITORY: 'TouchAI-org/TouchAI',
+            UPDATE_BUCKET: {
+                get: vi.fn(async () =>
+                    r2Object('2345', {}, { range: { offset: 2, length: 4 }, size: 10 })
+                ),
+            },
+        };
+        const request = new Request(
+            'https://updates.touch-ai.org/touchai-app/v1/TouchAI-0.2.0-windows.msi',
+            {
+                headers: { range: 'bytes=2-5' },
+            }
+        );
+
+        expect(worker?.default.fetch).toBeTypeOf('function');
+        const response = await worker!.default.fetch(request, env, workerContext().context);
+
+        expect(response.status).toBe(206);
+        expect(response.headers.get('content-range')).toBe('bytes 2-5/10');
+        expect(response.headers.get('content-length')).toBe('4');
+        expect(await response.text()).toBe('2345');
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('returns a controlled error when R2 access fails', async () => {
+        const worker = await loadWorker();
+        const fetchMock = vi.fn<typeof fetch>();
+        vi.stubGlobal('fetch', fetchMock);
+        const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        const env = {
+            UPDATE_BASE_PATH: 'touchai-app/v1',
+            GITHUB_REPOSITORY: 'TouchAI-org/TouchAI',
+            UPDATE_BUCKET: {
+                get: vi.fn(async () => {
+                    throw new Error('r2 unavailable');
+                }),
+            },
+        };
+        const request = new Request(
+            'https://updates.touch-ai.org/touchai-app/v1/TouchAI-0.2.0-windows.msi'
+        );
+
+        expect(worker?.default.fetch).toBeTypeOf('function');
+        const response = await worker!.default.fetch(request, env, workerContext().context);
+
+        expect(response.status).toBe(503);
+        expect(await response.text()).toBe('Update storage failed: r2 unavailable');
+        expect(consoleError).toHaveBeenCalledWith(
+            'Update R2 lookup failed',
+            expect.objectContaining({
+                error: 'r2 unavailable',
+                key: 'touchai-app/v1/TouchAI-0.2.0-windows.msi',
+                method: 'GET',
+            })
+        );
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('forwards range requests to GitHub but does not cache partial responses', async () => {
+        const worker = await loadWorker();
+        const cache = new MemoryCache();
+        installCache(cache);
+        const fetchMock = vi.fn<typeof fetch>(async () => {
+            return new Response('partial', {
+                status: 206,
+                headers: {
+                    'content-range': 'bytes 0-6/20',
+                    'content-type': 'application/octet-stream',
+                },
+            });
+        });
+        vi.stubGlobal('fetch', fetchMock);
+
+        const env = {
+            UPDATE_BASE_PATH: 'touchai-app/v1',
+            GITHUB_REPOSITORY: 'TouchAI-org/TouchAI',
+            UPDATE_BUCKET: {
+                get: vi.fn(async () => null),
+            },
+        };
+        const request = new Request(
+            'https://updates.touch-ai.org/touchai-app/v1/TouchAI-0.2.0-windows.msi',
+            {
+                headers: { range: 'bytes=0-6' },
+            }
+        );
+
+        expect(worker?.default.fetch).toBeTypeOf('function');
+        const response = await worker!.default.fetch(request, env, workerContext().context);
+
+        expect(response.status).toBe(206);
+        expect(response.headers.get('content-range')).toBe('bytes 0-6/20');
+        const firstFetchInit = fetchMock.mock.calls[0]?.[1];
+        expect(firstFetchInit).toMatchObject({
+            method: 'GET',
+            headers: expect.any(Headers),
+        });
+        expect((firstFetchInit?.headers as Headers).get('range')).toBe('bytes=0-6');
+        expect(cache.put).not.toHaveBeenCalled();
+    });
+
+    it('returns a controlled error when the GitHub fallback request fails', async () => {
+        const worker = await loadWorker();
+        const cache = new MemoryCache();
+        installCache(cache);
+        const fetchMock = vi.fn<typeof fetch>(async () => {
+            throw new TypeError('network unavailable');
+        });
+        vi.stubGlobal('fetch', fetchMock);
+
+        const env = {
+            UPDATE_BASE_PATH: 'touchai-app/v1',
+            GITHUB_REPOSITORY: 'TouchAI-org/TouchAI',
+            UPDATE_BUCKET: {
+                get: vi.fn(async () => null),
+            },
+        };
+        const request = new Request(
+            'https://updates.touch-ai.org/touchai-app/v1/TouchAI-0.2.0-windows.msi'
+        );
+
+        expect(worker?.default.fetch).toBeTypeOf('function');
+        const response = await worker!.default.fetch(request, env, workerContext().context);
+
+        expect(response.status).toBe(502);
+        expect(await response.text()).toBe('GitHub fallback failed: network unavailable');
+        expect(cache.put).not.toHaveBeenCalled();
+    });
+
+    it('rejects invalid asset names instead of becoming an open proxy', async () => {
+        const worker = await loadWorker();
+        const cache = new MemoryCache();
+        installCache(cache);
+        const fetchMock = vi.fn<typeof fetch>();
+        vi.stubGlobal('fetch', fetchMock);
+        const env = {
+            UPDATE_BASE_PATH: 'touchai-app/v1',
+            GITHUB_REPOSITORY: 'TouchAI-org/TouchAI',
+            UPDATE_BUCKET: {
+                get: vi.fn(async () => null),
+            },
+        };
+
+        expect(worker?.deriveReleaseTagFromAssetName).toBeTypeOf('function');
+        expect(worker?.deriveReleaseTagFromAssetName('TouchAI-beta-latest-windows.msi')).toBeNull();
+
+        const response = await worker!.default.fetch(
+            new Request(
+                'https://updates.touch-ai.org/touchai-app/v1/TouchAI-beta-latest-windows.msi'
+            ),
+            env,
+            workerContext().context
+        );
+
+        expect(response.status).toBe(404);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+});

--- a/apps/desktop/tests/ci/update-release-assets.test.ts
+++ b/apps/desktop/tests/ci/update-release-assets.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    channelFromAssetName,
+    channelFromTag,
+    channelFromVersion,
+    deriveReleaseTagFromAssetName,
+    githubRepositoryFromProduct,
+    relativeUpdatePath,
+} from '../../scripts/update-release-assets.mjs';
+
+describe('update release asset helpers', () => {
+    it('derives release tags and channels from normalized update asset names', () => {
+        expect(deriveReleaseTagFromAssetName('TouchAI-beta-0.2.0-beta.4-windows-full.nupkg')).toBe(
+            'v0.2.0-beta.4'
+        );
+        expect(deriveReleaseTagFromAssetName('TouchAI-nightly-latest-windows.msi')).toBeNull();
+        expect(channelFromAssetName('TouchAI-0.2.0-windows.msi')).toBe('stable');
+        expect(channelFromAssetName('TouchAI-beta-0.2.0-beta.4-macos.dmg')).toBe('beta');
+        expect(channelFromTag('v0.3.0-nightly.20260529.1')).toBe('nightly');
+        expect(channelFromVersion('1.2.3-beta')).toBe('beta');
+        expect(channelFromVersion('1.2.3-nightly')).toBe('nightly');
+    });
+
+    it('derives update base path and GitHub repository from product config', () => {
+        const product = {
+            repository: {
+                url: 'https://github.com/TouchAI-org/TouchAI',
+            },
+        };
+
+        expect(relativeUpdatePath('https://updates.touch-ai.org/touchai-app/v1')).toBe(
+            'touchai-app/v1'
+        );
+        expect(githubRepositoryFromProduct(product)).toBe('TouchAI-org/TouchAI');
+        expect(
+            githubRepositoryFromProduct({
+                repository: {
+                    url: 'https://github.com/TouchAI-org/TouchAI.git',
+                },
+            })
+        ).toBe('TouchAI-org/TouchAI');
+    });
+});

--- a/apps/desktop/tests/ci/write-cloudflare-update-worker-config.test.ts
+++ b/apps/desktop/tests/ci/write-cloudflare-update-worker-config.test.ts
@@ -1,0 +1,62 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { APP_PRODUCT_CONFIG } from '@/config/product';
+
+type ConfigModule = {
+    buildCloudflareUpdateWorkerConfig: (
+        product: unknown,
+        options: { workerScriptPath: string }
+    ) => string;
+    writeCloudflareUpdateWorkerConfig: (projectRoot: string, outputPath: string) => Promise<void>;
+};
+
+async function loadConfigModule(): Promise<ConfigModule | undefined> {
+    try {
+        return (await import('../../scripts/ci/write-cloudflare-update-worker-config.mjs')) as ConfigModule;
+    } catch {
+        return undefined;
+    }
+}
+
+async function createFixture(product: unknown) {
+    const root = await mkdtemp(join(tmpdir(), 'touchai-worker-config-'));
+    await writeFile(join(root, 'product.json'), `${JSON.stringify(product, null, 4)}\n`, 'utf8');
+    return root;
+}
+
+describe('writeCloudflareUpdateWorkerConfig', () => {
+    it('builds wrangler config from product.json update deployment settings', async () => {
+        const module = await loadConfigModule();
+
+        expect(module?.buildCloudflareUpdateWorkerConfig).toBeTypeOf('function');
+        const config = module!.buildCloudflareUpdateWorkerConfig(APP_PRODUCT_CONFIG, {
+            workerScriptPath: 'scripts/cloudflare/update-proxy-worker.mjs',
+        });
+
+        expect(config).toContain(`name = "touchai-update-proxy"`);
+        expect(config).toContain(`binding = "UPDATE_BUCKET"`);
+        expect(config).toContain(`UPDATE_BASE_PATH = "touchai-app/v1"`);
+        expect(config).toContain(`GITHUB_REPOSITORY = "TouchAI-org/TouchAI"`);
+    });
+
+    it('writes a config whose Worker main path is relative to the output file', async () => {
+        const module = await loadConfigModule();
+        const root = await createFixture(APP_PRODUCT_CONFIG);
+        const outputPath = join(root, '.generated', 'wrangler.toml');
+
+        try {
+            expect(module?.writeCloudflareUpdateWorkerConfig).toBeTypeOf('function');
+            await module!.writeCloudflareUpdateWorkerConfig(root, outputPath);
+
+            await expect(readFile(outputPath, 'utf8')).resolves.toContain(
+                `main = "../scripts/cloudflare/update-proxy-worker.mjs"`
+            );
+        } finally {
+            await rm(root, { recursive: true, force: true });
+        }
+    });
+});


### PR DESCRIPTION
## Summary

Restore GitHub Release downloadable assets for the Velopack/R2 release pipeline. The R2 update feed remains the client update source, while the public release assets staged by the aggregate job are uploaded back to the matching GitHub Release with `gh release upload --clobber`.

## Related issue or RFC

Link the issue or RFC:

- Related to #48

## AI assistance disclosure

If AI tools materially assisted this contribution, disclose that here or point to the relevant commit trailer.

- Tool(s) used: Codex
- Scope of assistance: Investigated the release asset regression, implemented the workflow fix, and added CI coverage for the expected upload behavior.
- Human review or rewrite performed: Pending maintainer review.
- Architecture or boundary impact: None; this is limited to release workflow packaging/upload behavior.

## Testing evidence

List the commands you ran and the results you observed.

```text
apps/desktop node_modules/.bin/vitest.CMD run tests/ci/release-workflow-environments.test.ts --configLoader runner
# 4 tests passed

pnpm --filter @touchai/desktop test:typecheck
# passed

prettier --check .github/workflows/velopack-build.yml apps/desktop/tests/ci/release-workflow-environments.test.ts --ignore-path .prettierignore
# passed

git diff --check
# passed
```

`pnpm test:pr` was not completed locally: the pre-commit Rust check exceeded the local timeout after redirecting Rust artifacts to E: and the D: drive is nearly full. This PR is draft so GitHub Actions can provide the full validation before merge.

Did you follow TDD (test-first) for feature and fix work? Yes. I added the failing CI workflow test first, verified it failed because the workflow had no `gh release upload`, then added the workflow step and verified the focused test passed.

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: none.
- database baseline or migration impact: none.
- release or packaging impact: restores GitHub Release asset attachments in addition to the Cloudflare R2 update feed. Future release runs should attach MSI/full/delta and platform assets to GitHub Releases again.

## Screenshots or recordings

Not applicable; this is a release workflow change.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [x] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [x] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.

## Summary by Sourcery

Restore public release assets on GitHub Releases while introducing a Cloudflare Worker–backed update proxy and R2 asset pruning to keep the update bucket aligned with GitHub releases.

New Features:
- Add a Cloudflare Worker update proxy that serves update feeds/assets from R2 with GitHub Release assets as a fallback, including caching behavior.
- Introduce a script to generate Wrangler configuration for the update proxy Worker from product.json settings.
- Add a planner script to compute which historical R2 release assets should be pruned based on per-channel retention settings.

Bug Fixes:
- Ensure public release assets staged by the Velopack aggregate job are uploaded to the corresponding GitHub Release instead of only publishing to the R2 update feed.

Enhancements:
- Extend the release workflow to deploy the Cloudflare update proxy Worker and prune outdated R2 assets after a successful release.
- Add CI tests to validate the release workflow’s GitHub upload, Worker deployment, and R2 pruning steps, plus unit tests for the new Worker and planner scripts.

Tests:
- Add Vitest coverage for the release workflow YAML to assert GitHub asset uploads, Cloudflare Worker deployment, and R2 pruning ordering.
- Add unit tests for the Cloudflare update proxy Worker behavior, including R2 precedence, GitHub fallback, range handling, caching, and asset validation.
- Add unit tests for the Wrangler config generator and R2 prune planner to ensure they correctly derive configuration and prune lists from product metadata.