### PR TITLE
feat(site): add waitlist form, analytics, and env-based config

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -42,6 +42,9 @@ jobs:
               run: pnpm install --frozen-lockfile
 
             - name: Build site
+              env:
+                  PUBLIC_CLARITY_ID: ${{ secrets.SITE_CLARITY_ID }}
+                  PUBLIC_WAITLIST_ENDPOINT: ${{ secrets.SITE_WAITLIST_ENDPOINT }}
               run: pnpm site:build
 
             - name: Upload Pages artifact

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,11 @@ dist-ssr
 *.local
 *.tsbuildinfo
 
+# Environment files (keep .env.example committed)
+.env
+.env.*
+!.env.example
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/apps/site/.env.example
+++ b/apps/site/.env.example
@@ -1,0 +1,13 @@
+# Public runtime config for the placeholder site.
+# Copy this file to `.env.local` (gitignored) and fill in real values for local dev.
+# In CI, these are injected from GitHub Actions secrets — see .github/workflows/pages.yml.
+#
+# Vars MUST be prefixed with PUBLIC_ to be exposed to client-side code.
+
+# Microsoft Clarity project ID (https://clarity.microsoft.com).
+# Leave empty to disable analytics in this build.
+PUBLIC_CLARITY_ID=
+
+# Waitlist subscribe endpoint (Cloudflare Worker URL + /subscribe).
+# Leave empty to disable form submission gracefully.
+PUBLIC_WAITLIST_ENDPOINT=

--- a/apps/site/astro.config.mjs
+++ b/apps/site/astro.config.mjs
@@ -1,26 +1,13 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
-import { fileURLToPath } from 'node:url';
-import path from 'node:path';
-
-const pkgDir = path.dirname(fileURLToPath(import.meta.url));
-const glimmPath = path.resolve(pkgDir, 'node_modules/glimm/dist/index.js');
+import react from '@astrojs/react';
 
 // https://astro.build/config
 export default defineConfig({
 	site: 'https://touch-ai.org/',
-	vite: {
-		resolve: {
-			alias: {
-				'glimm': glimmPath,
-			},
-		},
-		optimizeDeps: {
-			include: ['glimm'],
-		},
-	},
 	integrations: [
+		react(),
 		starlight({
 			title: 'TouchAI',
 			social: [{ icon: 'github', label: 'GitHub', href: 'https://github.com/TouchAI-org/TouchAI' }],
@@ -28,7 +15,6 @@ export default defineConfig({
 				{
 					label: 'Guides',
 					items: [
-						// Each item here is one entry in the navigation menu.
 						{ label: 'Example Guide', slug: 'guides/example' },
 					],
 				},

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -11,9 +11,17 @@
         "astro": "astro"
     },
     "dependencies": {
+        "@astrojs/react": "^5.0.6",
         "@astrojs/starlight": "^0.39.2",
         "astro": "^6.3.1",
         "glimm": "^0.1.3",
-        "sharp": "^0.34.5"
+        "react": "^19.2.6",
+        "react-dom": "^19.2.6",
+        "sharp": "^0.34.5",
+        "sonner": "^2.0.7"
+    },
+    "devDependencies": {
+        "@types/react": "^19.2.15",
+        "@types/react-dom": "^19.2.3"
     }
 }

--- a/apps/site/src/components/ToastProvider.tsx
+++ b/apps/site/src/components/ToastProvider.tsx
@@ -1,0 +1,22 @@
+import { Toaster, toast } from 'sonner';
+import { useEffect } from 'react';
+
+// Expose toast globally so inline scripts can call window.__toast.error(...) etc.
+export default function ToastProvider() {
+    useEffect(() => {
+        (window as any).__toast = toast;
+    }, []);
+
+    return (
+        <Toaster
+            position="top-center"
+            richColors
+            toastOptions={{
+                style: {
+                    fontFamily: "'Inter', -apple-system, BlinkMacSystemFont, sans-serif",
+                    fontSize: '0.875rem',
+                },
+            }}
+        />
+    );
+}

--- a/apps/site/src/pages/index.astro
+++ b/apps/site/src/pages/index.astro
@@ -1288,8 +1288,6 @@ const WAITLIST_ENDPOINT = import.meta.env.PUBLIC_WAITLIST_ENDPOINT ?? '';
                         .catch(function () {
                             waitlistSubmit.classList.remove('loading');
                             showToast(waitlistMessages[lang].networkError, 'error');
-                        })
-                        .then(function () {
                             waitlistSubmit.disabled = false;
                         });
                 });

--- a/apps/site/src/pages/index.astro
+++ b/apps/site/src/pages/index.astro
@@ -1,5 +1,11 @@
 ---
+import ToastProvider from '../components/ToastProvider';
 
+// Public runtime config — values are injected at build time from env vars.
+// Set in apps/site/.env.local for local dev; set as GitHub Actions secrets for CI.
+// Empty values disable the corresponding feature gracefully.
+const CLARITY_ID = import.meta.env.PUBLIC_CLARITY_ID ?? '';
+const WAITLIST_ENDPOINT = import.meta.env.PUBLIC_WAITLIST_ENDPOINT ?? '';
 ---
 
 <!doctype html>
@@ -40,6 +46,14 @@
         <link rel="apple-touch-icon" href="/favicon.svg" />
         <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
         <meta name="theme-color" content="#09090b" media="(prefers-color-scheme: dark)" />
+        {
+            CLARITY_ID && (
+                <script
+                    is:inline
+                    set:html={`(function(c,l,a,r,i,t,y){c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};t=l.createElement(r);t.async=1;t.src='https://www.clarity.ms/tag/'+i;y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y)})(window,document,'clarity','script','${CLARITY_ID}');`}
+                />
+            )
+        }
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
         <link
@@ -115,6 +129,8 @@
                 display: flex;
                 flex-direction: column;
                 gap: 0.5rem;
+                min-height: 5.5rem;
+                justify-content: center;
             }
             .title {
                 font-size: 2.25rem;
@@ -134,6 +150,7 @@
                 justify-content: center;
                 align-items: center;
                 gap: 0.6rem;
+                min-height: 2.6rem;
             }
             .cd-pair {
                 display: flex;
@@ -181,6 +198,172 @@
                 line-height: 2.6rem;
                 text-align: center;
                 user-select: none;
+            }
+            .waitlist {
+                display: flex;
+                flex-direction: column;
+                align-items: stretch;
+                gap: 0.4rem;
+                width: 100%;
+                max-width: 100%;
+                overflow: hidden;
+                transition:
+                    opacity 0.4s ease,
+                    transform 0.4s ease,
+                    max-height 0.5s ease 0.05s,
+                    margin 0.5s ease 0.05s;
+                max-height: 200px;
+            }
+            .waitlist.hide {
+                opacity: 0;
+                transform: translateY(-8px);
+                max-height: 0;
+                margin: -1.5rem 0;
+                pointer-events: none;
+            }
+            .waitlist.gone {
+                display: none;
+            }
+            .waitlist-row {
+                display: flex;
+                flex-wrap: wrap;
+                gap: 0.5rem;
+                width: 100%;
+            }
+            .waitlist input {
+                flex: 1;
+                min-width: 0;
+                padding: 0.6rem 0.9rem;
+                border: 1px solid var(--cell-border);
+                border-radius: 0.5rem;
+                background: var(--cell-bg);
+                color: var(--fg);
+                font-family: inherit;
+                font-size: 0.875rem;
+                outline: none;
+                transition:
+                    border-color 0.2s,
+                    background 0.2s;
+            }
+            .waitlist input::placeholder {
+                color: var(--muted);
+                opacity: 0.7;
+            }
+            .waitlist input:focus {
+                border-color: var(--muted);
+            }
+            .waitlist button {
+                padding: 0.6rem 1.1rem;
+                border: 1px solid var(--cell-border);
+                border-radius: 0.5rem;
+                background: var(--fg);
+                color: var(--bg);
+                font-family: inherit;
+                font-size: 0.875rem;
+                font-weight: 500;
+                cursor: pointer;
+                white-space: nowrap;
+                transition:
+                    opacity 0.2s,
+                    transform 0.1s;
+            }
+            .waitlist button:hover:not(:disabled) {
+                opacity: 0.85;
+            }
+            .waitlist button:active:not(:disabled) {
+                transform: scale(0.98);
+            }
+            .waitlist button:disabled {
+                opacity: 0.5;
+                cursor: not-allowed;
+            }
+            .waitlist button {
+                position: relative;
+            }
+            .waitlist button .btn-label {
+                transition: opacity 0.2s ease;
+            }
+            .waitlist button .btn-check {
+                position: absolute;
+                inset: 0;
+                margin: auto;
+                width: 18px;
+                height: 18px;
+                color: #fff;
+                opacity: 0;
+                pointer-events: none;
+            }
+            .waitlist button .btn-check path {
+                stroke-dasharray: 30;
+                stroke-dashoffset: 30;
+            }
+            .waitlist button.loading .btn-label {
+                opacity: 0;
+            }
+            .waitlist button.loading::after {
+                content: '';
+                position: absolute;
+                inset: 0;
+                margin: auto;
+                width: 14px;
+                height: 14px;
+                border: 2px solid rgba(255, 255, 255, 0.3);
+                border-top-color: #fff;
+                border-radius: 50%;
+                animation: spin 0.6s linear infinite;
+            }
+            .waitlist button.success {
+                background: #16a34a;
+                border-color: #16a34a;
+            }
+            .waitlist button.success .btn-label {
+                opacity: 0;
+            }
+            .waitlist button.success .btn-check {
+                opacity: 1;
+            }
+            .waitlist button.success .btn-check path {
+                animation: drawCheck 0.45s cubic-bezier(0.65, 0, 0.45, 1) forwards;
+            }
+            .waitlist-row {
+                overflow: hidden;
+                transition:
+                    opacity 0.4s ease,
+                    transform 0.4s ease,
+                    max-height 0.5s ease 0.1s,
+                    margin 0.5s ease 0.1s,
+                    padding 0.5s ease 0.1s;
+                max-height: 200px;
+            }
+            .waitlist-row.hide {
+                opacity: 0;
+                transform: translateY(-8px);
+                max-height: 0;
+                margin: 0;
+                padding: 0;
+                pointer-events: none;
+            }
+            @keyframes spin {
+                to {
+                    transform: rotate(360deg);
+                }
+            }
+            @keyframes drawCheck {
+                to {
+                    stroke-dashoffset: 0;
+                }
+            }
+            .waitlist-msg {
+                font-size: 0.78rem;
+                color: var(--muted);
+                min-height: 1.1em;
+                text-align: center;
+            }
+            .waitlist-msg.ok {
+                color: #16a34a;
+            }
+            .waitlist-msg.err {
+                color: #ef4444;
             }
             .gh {
                 display: flex;
@@ -262,6 +445,14 @@
                 }
                 .sep {
                     font-size: 0.7rem;
+                }
+                .waitlist {
+                    max-width: 100%;
+                }
+                .waitlist input,
+                .waitlist button {
+                    font-size: 0.8rem;
+                    padding: 0.55rem 0.8rem;
                 }
             }
         </style>
@@ -687,6 +878,35 @@
                 </p>
             </div>
             <div class="countdown" id="cd"></div>
+            <form class="waitlist" id="waitlistForm" novalidate>
+                <div class="waitlist-row">
+                    <input
+                        type="email"
+                        id="waitlistEmail"
+                        autocomplete="email"
+                        required
+                        data-zh-placeholder="输入邮箱，发布时第一时间通知您"
+                        data-en-placeholder="Enter your email for launch notification"
+                        placeholder="输入邮箱，发布时第一时间通知您"
+                    />
+                    <button type="submit" id="waitlistSubmit">
+                        <span class="btn-label" data-zh="加入等候" data-en="Join">加入等候</span>
+                        <svg
+                            class="btn-check"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2.5"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            aria-hidden="true"
+                        >
+                            <path d="M5 12.5l4.5 4.5L19 7.5"></path>
+                        </svg>
+                    </button>
+                </div>
+                <p class="waitlist-msg" id="waitlistMsg" aria-live="polite"></p>
+            </form>
             <a
                 href="https://github.com/TouchAI-org/TouchAI"
                 target="_blank"
@@ -701,7 +921,7 @@
                 </svg>
             </a>
         </div>
-        <script type="module">
+        <script type="module" define:vars={{ WAITLIST_ENDPOINT }}>
             import { createShader, playSweep as glimmPlaySweep } from '/glimm.js';
 
             console.log(
@@ -729,7 +949,7 @@
                 if (shader && shader.canvas) {
                     var c = shader.canvas;
                     c.style.cssText =
-                        'position:fixed;inset:0;width:100vw;height:100vh;pointer-events:none;z-index:9999;';
+                        'position:fixed;top:0;left:0;right:0;bottom:0;width:100%;height:100%;display:block;pointer-events:none;z-index:9999;';
                     document.body.appendChild(c);
                 }
             } catch (e) {
@@ -763,8 +983,8 @@
                 var btn = document.getElementById('themeBtn');
                 if (!btn) return;
                 btn.innerHTML = isDark
-                    ? '<svg viewBox="0 0 24 24"><path d="M12 7a5 5 0 100 10 5 5 0 000-10zm0-3a1 1 0 01-1-1V1a1 1 0 112 0v2a1 1 0 01-1 1zm0 18a1 1 0 01-1-1v-2a1 1 0 112 0v2a1 1 0 01-1 1zm9-9a1 1 0 01-1 1h-2a1 1 0 110-2h2a1 1 0 011 1zM6 12a1 1 0 01-1 1H3a1 1 0 110-2h2a1 1 0 011 1zm12.36-5.64a1 1 0 01-.7-.3l-1.42-1.42a1 1 0 011.41-1.41l1.42 1.42a1 1 0 01-.71 1.71zM5.76 18.24a1 1 0 01-.7-.3l-1.42-1.42a1 1 0 011.41-1.41l1.42 1.42a1 1 0 01-.71 1.71zM18.24 18.24a1 1 0 01-.71-1.71l1.42-1.42a1 1 0 011.41 1.41l-1.42 1.42a1 1 0 01-.7.3zM5.76 5.76a1 1 0 01-.71-1.71l1.42-1.42A1 1 0 017.87 4.04L6.46 5.46a1 1 0 01-.7.3z"/></svg>'
-                    : '<svg viewBox="0 0 24 24"><path d="M12 3a9 9 0 109 9c0-.46-.04-.92-.1-1.36a5.389 5.389 0 01-4.4 2.26 5.403 5.403 0 01-3.14-9.8c-.44-.06-.9-.1-1.36-.1z"/></svg>';
+                    ? '<svg viewBox="0 0 24 24" fill-rule="evenodd" clip-rule="evenodd"><path d="M12 2.25a.75.75 0 01.75.75v2.25a.75.75 0 01-1.5 0V3a.75.75 0 01.75-.75zM7.5 12a4.5 4.5 0 119 0 4.5 4.5 0 01-9 0zm11.394-5.834a.75.75 0 00-1.06-1.06l-1.591 1.59a.75.75 0 101.06 1.061l1.591-1.59zM21.75 12a.75.75 0 01-.75.75h-2.25a.75.75 0 010-1.5H21a.75.75 0 01.75.75zm-3.916 6.894a.75.75 0 001.06-1.06l-1.59-1.591a.75.75 0 10-1.061 1.06l1.59 1.591zM12 18a.75.75 0 01.75.75V21a.75.75 0 01-1.5 0v-2.25A.75.75 0 0112 18zm-4.242-.697a.75.75 0 00-1.061-1.06l-1.591 1.59a.75.75 0 001.06 1.061l1.591-1.59zM6 12a.75.75 0 01-.75.75H3a.75.75 0 010-1.5h2.25A.75.75 0 016 12zm.697-4.243a.75.75 0 001.06-1.06l-1.59-1.591a.75.75 0 00-1.061 1.06l1.59 1.591z"/></svg>'
+                    : '<svg viewBox="0 0 24 24"><path d="M21.752 15.002A9.72 9.72 0 0118 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 003 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 009.002-5.998z"/></svg>';
                 btn.setAttribute(
                     'aria-label',
                     isDark ? 'Switch to light mode' : 'Switch to dark mode'
@@ -783,6 +1003,10 @@
                     } else {
                         el.textContent = val;
                     }
+                });
+                document.querySelectorAll('[data-zh-placeholder]').forEach(function (el) {
+                    var val = el.getAttribute('data-' + lang + '-placeholder');
+                    if (val) el.setAttribute('placeholder', val);
                 });
                 localStorage.setItem('ta_lang', lang);
                 var sps = document.querySelectorAll('.sep');
@@ -904,6 +1128,173 @@
 
             tick();
             setInterval(tick, 1000);
+
+            // --- Sync waitlist width to countdown ---
+            (function () {
+                var cd = document.getElementById('cd');
+                var wl = document.getElementById('waitlistForm');
+                if (!cd || !wl) return;
+                function sync() {
+                    var w = cd.offsetWidth;
+                    if (w > 0) wl.style.maxWidth = w + 'px';
+                }
+                sync();
+                if (typeof ResizeObserver !== 'undefined') {
+                    new ResizeObserver(sync).observe(cd);
+                }
+                window.addEventListener('resize', sync);
+            })();
+
+            // --- Waitlist ---
+            // WAITLIST_ENDPOINT is injected at build time via define:vars (PUBLIC_WAITLIST_ENDPOINT).
+            // If empty, the form shows a fallback message instead of submitting.
+            var waitlistMessages = {
+                zh: {
+                    invalid: '请输入有效的邮箱地址',
+                    success: '订阅成功，发布时第一时间通知您！',
+                    duplicate: '该邮箱已订阅，发布时会通知您',
+                    rateLimit: '请求过于频繁，请稍后再试',
+                    serverError: '服务暂时不可用，请稍后再试',
+                    networkError: '网络错误，请重试',
+                },
+                en: {
+                    invalid: 'Please enter a valid email address',
+                    success: 'Subscribed! We will notify you at launch.',
+                    duplicate: 'Already subscribed — we will notify you',
+                    rateLimit: 'Too many requests, please retry later',
+                    serverError: 'Service unavailable, please retry later',
+                    networkError: 'Network error, please retry',
+                },
+            };
+            var emailRe = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+            var waitlistForm = document.getElementById('waitlistForm');
+            var waitlistEmail = document.getElementById('waitlistEmail');
+            var waitlistSubmit = document.getElementById('waitlistSubmit');
+            var waitlistMsg = document.getElementById('waitlistMsg');
+
+            function showToast(msg, type) {
+                var t = window.__toast;
+                if (t) {
+                    if (type === 'error') t.error(msg);
+                    else if (type === 'success') t.success(msg);
+                    else t(msg);
+                }
+            }
+
+            if (waitlistForm) {
+                waitlistForm.addEventListener('submit', function (e) {
+                    e.preventDefault();
+                    var t = waitlistMessages[lang];
+                    var email = (waitlistEmail.value || '').trim();
+                    if (!emailRe.test(email)) {
+                        showToast(t.invalid, 'error');
+                        waitlistEmail.focus();
+                        return;
+                    }
+                    if (!WAITLIST_ENDPOINT) {
+                        showToast(t.serverError, 'error');
+                        return;
+                    }
+                    // Start loading animation
+                    waitlistSubmit.disabled = true;
+                    waitlistSubmit.classList.add('loading');
+                    if (waitlistMsg) {
+                        waitlistMsg.textContent = '';
+                        waitlistMsg.className = 'waitlist-msg';
+                    }
+                    fetch(WAITLIST_ENDPOINT, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({
+                            email: email,
+                            lang: lang,
+                            ref: document.referrer || '',
+                        }),
+                    })
+                        .then(function (res) {
+                            return res
+                                .json()
+                                .catch(function () {
+                                    return {};
+                                })
+                                .then(function (data) {
+                                    return { status: res.status, data: data };
+                                });
+                        })
+                        .then(function (r) {
+                            var tt = waitlistMessages[lang];
+                            waitlistSubmit.classList.remove('loading');
+                            if (r.status === 200 || r.status === 201) {
+                                // Success: show checkmark then fade out row
+                                waitlistSubmit.classList.add('success');
+                                showToast(
+                                    r.data && r.data.duplicate ? tt.duplicate : tt.success,
+                                    'success'
+                                );
+                                waitlistEmail.value = '';
+                                setTimeout(function () {
+                                    var wrap = document.querySelector('.wrap');
+                                    var siblings = wrap
+                                        ? Array.prototype.filter.call(wrap.children, function (el) {
+                                              return el !== waitlistForm;
+                                          })
+                                        : [];
+                                    var firstRects = siblings.map(function (el) {
+                                        return el.getBoundingClientRect();
+                                    });
+
+                                    waitlistForm.classList.add('hide');
+
+                                    requestAnimationFrame(function () {
+                                        siblings.forEach(function (el, i) {
+                                            var lastRect = el.getBoundingClientRect();
+                                            var dy = firstRects[i].top - lastRect.top;
+                                            if (dy === 0) return;
+                                            el.style.transition = 'none';
+                                            el.style.transform = 'translateY(' + dy + 'px)';
+                                            requestAnimationFrame(function () {
+                                                el.style.transition =
+                                                    'transform 0.5s cubic-bezier(0.4, 0, 0.2, 1)';
+                                                el.style.transform = '';
+                                                setTimeout(function () {
+                                                    el.style.transition = '';
+                                                }, 550);
+                                            });
+                                        });
+                                    });
+
+                                    var onEnd = function (e) {
+                                        if (e.propertyName !== 'max-height') return;
+                                        waitlistForm.classList.add('gone');
+                                        waitlistForm.removeEventListener('transitionend', onEnd);
+                                    };
+                                    waitlistForm.addEventListener('transitionend', onEnd);
+                                }, 800);
+                                if (typeof window.clarity === 'function') {
+                                    try {
+                                        window.clarity('event', 'waitlist_submit');
+                                    } catch (_e) {
+                                        // ignore
+                                    }
+                                }
+                            } else if (r.status === 429) {
+                                showToast(tt.rateLimit, 'error');
+                            } else if (r.status === 400) {
+                                showToast((r.data && r.data.error) || tt.invalid, 'error');
+                            } else {
+                                showToast(tt.serverError, 'error');
+                            }
+                        })
+                        .catch(function () {
+                            waitlistSubmit.classList.remove('loading');
+                            showToast(waitlistMessages[lang].networkError, 'error');
+                        })
+                        .then(function () {
+                            waitlistSubmit.disabled = false;
+                        });
+                });
+            }
         </script>
+        <ToastProvider client:load />
     </body>
 </html>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -335,6 +335,9 @@ importers:
 
   apps/site:
     dependencies:
+      '@astrojs/react':
+        specifier: ^5.0.6
+        version: 5.0.6(@types/node@25.8.0)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(terser@5.47.1)(tsx@4.22.0)(yaml@2.8.4)
       '@astrojs/starlight':
         specifier: ^0.39.2
         version: 0.39.2(astro@6.3.7(@types/node@25.8.0)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.4)(terser@5.47.1)(tsx@4.22.0)(yaml@2.8.4))(typescript@6.0.3)
@@ -343,10 +346,26 @@ importers:
         version: 6.3.7(@types/node@25.8.0)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.4)(terser@5.47.1)(tsx@4.22.0)(yaml@2.8.4)
       glimm:
         specifier: ^0.1.3
-        version: 0.1.3
+        version: 0.1.3(react@19.2.6)
+      react:
+        specifier: ^19.2.6
+        version: 19.2.6
+      react-dom:
+        specifier: ^19.2.6
+        version: 19.2.6(react@19.2.6)
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.15
+        version: 19.2.15
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.15)
 
   packages/shared: {}
 
@@ -466,6 +485,9 @@ packages:
   '@astrojs/compiler@4.0.0':
     resolution: {integrity: sha512-eouss7G8ygdZqHuke033VMcVw5HTZUu+PXd/h06DGDUg/jt5btPYPqh66ENWw/mU78rBrf/oeC4oqoBwMtDMNA==}
 
+  '@astrojs/internal-helpers@0.10.0':
+    resolution: {integrity: sha512-Ry2R3VPeIN4uPCSA4xQc+e+vsJXkalKpEbDc07hV+a/o5Bs2N/s/uDcPJH/05L19DKh9tAy7e6JM3YZ6Cxfezw==}
+
   '@astrojs/internal-helpers@0.9.1':
     resolution: {integrity: sha512-1pWuARqYom/TzuU3+0ZugsTrKlUydWKuULmDqSMTuonY+9IRDUEGKX/8PXQ1nBxRq3w85uGtd9q9SXfqEldMIQ==}
 
@@ -481,6 +503,15 @@ packages:
   '@astrojs/prism@4.0.2':
     resolution: {integrity: sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA==}
     engines: {node: '>=22.12.0'}
+
+  '@astrojs/react@5.0.6':
+    resolution: {integrity: sha512-3pfjmw3sUnV5WplLblDzsAKlHv9kNmlCFAw/xP/agubiZFo4d+uPXX2jynNwAfvwyI5v+Q9uIIFwyujv9jifLg==}
+    engines: {node: '>=22.12.0'}
+    peerDependencies:
+      '@types/react': ^17.0.50 || ^18.0.21 || ^19.0.0
+      '@types/react-dom': ^17.0.17 || ^18.0.6 || ^19.0.0
+      react: ^17.0.2 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.2 || ^18.0.0 || ^19.0.0
 
   '@astrojs/sitemap@3.7.2':
     resolution: {integrity: sha512-PqkzkcZTb5ICiyIR8VoKbIAP/laNRXi5tw616N1Ckk+40oNB8Can1AzVV56lrbC5GKSZFCyJYUVYqVivMisvpA==}
@@ -498,20 +529,70 @@ packages:
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/generator@7.29.1':
     resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-globals@7.28.0':
-    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/parser@7.29.3':
@@ -519,16 +600,37 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/template@7.28.6':
-    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.29.7':
+    resolution: {integrity: sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7':
+    resolution: {integrity: sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/traverse@7.29.0':
-    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@1.0.2':
@@ -1945,6 +2047,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rolldown/pluginutils@1.0.0-rc.3':
+    resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
+
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
@@ -2547,6 +2652,18 @@ packages:
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -2721,6 +2838,14 @@ packages:
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
 
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.15':
+    resolution: {integrity: sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==}
+
   '@types/sax@1.2.7':
     resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
 
@@ -2834,6 +2959,12 @@ packages:
   '@vercel/oidc@3.2.0':
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
     engines: {node: '>= 20'}
+
+  '@vitejs/plugin-react@5.2.0':
+    resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
   '@vitejs/plugin-vue@6.0.7':
     resolution: {integrity: sha512-km+p+XdSz9Sxm5rqUbqcSfZYaAniKxWBj1KURl+Jr7UaPvvX7BmaWMdP69I5rrFDeQGyxAG7NXdc57vz+snhWg==}
@@ -3261,6 +3392,11 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
+  baseline-browser-mapping@2.10.32:
+    resolution: {integrity: sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   basic-ftp@5.3.1:
     resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
     engines: {node: '>=10.0.0'}
@@ -3301,6 +3437,11 @@ packages:
   browser-stdout@1.3.1:
     resolution: {integrity: sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==}
 
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
   buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
@@ -3321,6 +3462,9 @@ packages:
   camelcase@6.3.0:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
+
+  caniuse-lite@1.0.30001793:
+    resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -3978,6 +4122,9 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
+  electron-to-chromium@1.5.364:
+    resolution: {integrity: sha512-G/dYE3+AYhyHwzTwg8UbnXf7zqMERYh7l2jJ3QujhFsH8agSYwtnGAR2aZ7f0AakIKJXd5En/Hre4igIUrdlYw==}
+
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
@@ -4356,6 +4503,10 @@ packages:
     resolution: {integrity: sha512-ZRXLa4ZaYTTgUO4Eefw+RsQCleugU2QLb1ME7qTYxxuRj51yAhfnXaItXNs5/vUzfIaDHuZ+YnSF005hfp07nQ==}
     engines: {node: '>=20.0.0'}
     hasBin: true
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
 
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
@@ -5064,6 +5215,9 @@ packages:
     resolution: {integrity: sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==}
     engines: {node: 20 || >=22}
 
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
   lru-cache@7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
@@ -5415,6 +5569,10 @@ packages:
 
   node-mock-http@1.0.4:
     resolution: {integrity: sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==}
+
+  node-releases@2.0.46:
+    resolution: {integrity: sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==}
+    engines: {node: '>=18'}
 
   nopt@7.2.1:
     resolution: {integrity: sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==}
@@ -5824,11 +5982,24 @@ packages:
   radix3@1.1.2:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
 
+  react-dom@19.2.6:
+    resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
+    peerDependencies:
+      react: ^19.2.6
+
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
   react-is@19.2.6:
     resolution: {integrity: sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==}
+
+  react-refresh@0.18.0:
+    resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.2.6:
+    resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
+    engines: {node: '>=0.10.0'}
 
   read-pkg-up@10.1.0:
     resolution: {integrity: sha512-aNtBq4jR8NawpKJQldrQcSW9y/d+KWH4v24HWkHljOZ7H0av+YTGANBzRh9A5pw7v/bLVsLVPpOhJ7gHNVy8lA==}
@@ -6043,8 +6214,15 @@ packages:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
 
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
   scule@1.3.0:
     resolution: {integrity: sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
 
   semver@7.8.0:
     resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
@@ -6127,6 +6305,12 @@ packages:
   socks@2.8.9:
     resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -6580,6 +6764,12 @@ packages:
       uploadthing:
         optional: true
 
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
@@ -6975,6 +7165,9 @@ packages:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
 
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
   yaml@2.8.4:
     resolution: {integrity: sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==}
     engines: {node: '>= 14.6'}
@@ -7169,6 +7362,17 @@ snapshots:
 
   '@astrojs/compiler@4.0.0': {}
 
+  '@astrojs/internal-helpers@0.10.0':
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      js-yaml: 4.1.1
+      picomatch: 4.0.4
+      retext-smartypants: 6.2.0
+      shiki: 4.1.0
+      smol-toml: 1.6.1
+      unified: 11.0.5
+
   '@astrojs/internal-helpers@0.9.1':
     dependencies:
       picomatch: 4.0.4
@@ -7221,6 +7425,31 @@ snapshots:
   '@astrojs/prism@4.0.2':
     dependencies:
       prismjs: 1.30.0
+
+  '@astrojs/react@5.0.6(@types/node@25.8.0)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(terser@5.47.1)(tsx@4.22.0)(yaml@2.8.4)':
+    dependencies:
+      '@astrojs/internal-helpers': 0.10.0
+      '@types/react': 19.2.15
+      '@types/react-dom': 19.2.3(@types/react@19.2.15)
+      '@vitejs/plugin-react': 5.2.0(vite@7.3.3(@types/node@25.8.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.8.4))
+      devalue: 5.8.1
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      ultrahtml: 1.6.0
+      vite: 7.3.3(@types/node@25.8.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.8.4)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   '@astrojs/sitemap@3.7.2':
     dependencies:
@@ -7277,6 +7506,34 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.7': {}
+
+  '@babel/core@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3(supports-color@8.1.1)
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/generator@7.29.1':
     dependencies:
       '@babel/parser': 7.29.3
@@ -7285,41 +7542,102 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
-  '@babel/helper-globals@7.28.0':
-    optional: true
+  '@babel/generator@7.29.7':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.29.7': {}
 
   '@babel/helper-string-parser@7.27.1': {}
 
+  '@babel/helper-string-parser@7.29.7': {}
+
   '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/helper-validator-option@7.29.7': {}
+
+  '@babel/helpers@7.29.7':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
 
   '@babel/parser@7.29.3':
     dependencies:
       '@babel/types': 7.29.0
 
-  '@babel/template@7.28.6':
+  '@babel/parser@7.29.7':
     dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/parser': 7.29.3
-      '@babel/types': 7.29.0
-    optional: true
+      '@babel/types': 7.29.7
 
-  '@babel/traverse@7.29.0':
+  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.29.3
-      '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/traverse@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   '@babel/types@7.29.0':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@bcoe/v8-coverage@1.0.2': {}
 
@@ -8388,6 +8706,8 @@ snapshots:
   '@rolldown/binding-win32-x64-msvc@1.0.1':
     optional: true
 
+  '@rolldown/pluginutils@1.0.0-rc.3': {}
+
   '@rolldown/pluginutils@1.0.1': {}
 
   '@rollup/pluginutils@5.3.0(rollup@4.60.4)':
@@ -8888,10 +9208,10 @@ snapshots:
 
   '@trivago/prettier-plugin-sort-imports@6.0.0(@vue/compiler-sfc@3.5.34)(prettier@3.8.3)':
     dependencies:
-      '@babel/generator': 7.29.1
-      '@babel/parser': 7.29.3
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/generator': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
       javascript-natural-sort: 0.7.1
       lodash-es: 4.18.1
       minimatch: 9.0.9
@@ -8907,6 +9227,27 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.0
 
   '@types/chai@5.2.3':
     dependencies:
@@ -9107,6 +9448,14 @@ snapshots:
 
   '@types/normalize-package-data@2.4.4': {}
 
+  '@types/react-dom@19.2.3(@types/react@19.2.15)':
+    dependencies:
+      '@types/react': 19.2.15
+
+  '@types/react@19.2.15':
+    dependencies:
+      csstype: 3.2.3
+
   '@types/sax@1.2.7':
     dependencies:
       '@types/node': 25.8.0
@@ -9247,6 +9596,18 @@ snapshots:
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
   '@vercel/oidc@3.2.0': {}
+
+  '@vitejs/plugin-react@5.2.0(vite@7.3.3(@types/node@25.8.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.8.4))':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
+      '@rolldown/pluginutils': 1.0.0-rc.3
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.18.0
+      vite: 7.3.3(@types/node@25.8.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.8.4)
+    transitivePeerDependencies:
+      - supports-color
 
   '@vitejs/plugin-vue@6.0.7(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.8.4))(vue@3.5.34(typescript@6.0.3))':
     dependencies:
@@ -9920,6 +10281,8 @@ snapshots:
 
   base64-js@1.5.1: {}
 
+  baseline-browser-mapping@2.10.32: {}
+
   basic-ftp@5.3.1: {}
 
   bcp-47-match@2.0.3: {}
@@ -9959,6 +10322,14 @@ snapshots:
 
   browser-stdout@1.3.1: {}
 
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.32
+      caniuse-lite: 1.0.30001793
+      electron-to-chromium: 1.5.364
+      node-releases: 2.0.46
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
   buffer-crc32@0.2.13: {}
 
   buffer-crc32@1.0.0: {}
@@ -9973,6 +10344,8 @@ snapshots:
   callsites@3.1.0: {}
 
   camelcase@6.3.0: {}
+
+  caniuse-lite@1.0.30001793: {}
 
   ccount@2.0.1: {}
 
@@ -10578,6 +10951,8 @@ snapshots:
     dependencies:
       jake: 10.9.4
 
+  electron-to-chromium@1.5.364: {}
+
   emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
@@ -11079,6 +11454,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  gensync@1.0.0-beta.2: {}
+
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.6.0: {}
@@ -11120,7 +11497,9 @@ snapshots:
 
   github-slugger@2.0.0: {}
 
-  glimm@0.1.3: {}
+  glimm@0.1.3(react@19.2.6):
+    optionalDependencies:
+      react: 19.2.6
 
   glob-parent@5.1.2:
     dependencies:
@@ -11862,6 +12241,10 @@ snapshots:
 
   lru-cache@11.3.6: {}
 
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
   lru-cache@7.18.3: {}
 
   magic-string-ast@1.0.3:
@@ -12500,6 +12883,8 @@ snapshots:
 
   node-mock-http@1.0.4: {}
 
+  node-releases@2.0.46: {}
+
   nopt@7.2.1:
     dependencies:
       abbrev: 2.0.0
@@ -12919,9 +13304,18 @@ snapshots:
 
   radix3@1.1.2: {}
 
+  react-dom@19.2.6(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+      scheduler: 0.27.0
+
   react-is@18.3.1: {}
 
   react-is@19.2.6: {}
+
+  react-refresh@0.18.0: {}
+
+  react@19.2.6: {}
 
   read-pkg-up@10.1.0:
     dependencies:
@@ -13269,7 +13663,11 @@ snapshots:
     dependencies:
       xmlchars: 2.2.0
 
+  scheduler@0.27.0: {}
+
   scule@1.3.0: {}
+
+  semver@6.3.1: {}
 
   semver@7.8.0: {}
 
@@ -13387,6 +13785,11 @@ snapshots:
     dependencies:
       ip-address: 10.2.0
       smart-buffer: 4.2.0
+
+  sonner@2.0.7(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
 
   source-map-js@1.2.1: {}
 
@@ -13814,6 +14217,12 @@ snapshots:
       ofetch: 1.5.1
       ufo: 1.6.4
 
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
@@ -14164,6 +14573,8 @@ snapshots:
   xxhash-wasm@1.1.0: {}
 
   y18n@5.0.8: {}
+
+  yallist@3.1.1: {}
 
   yaml@2.8.4: {}
 


### PR DESCRIPTION
> First external contributors may need to complete the `CLA Assistant` check before merge.
> For code changes, this PR must link the related issue or RFC in the section below.

## Summary

Adds waitlist signup, analytics, and runtime config for the construction placeholder site:

- Email waitlist form posting to a Cloudflare Worker (separate repo) with KV-backed persistence; submit endpoint is `https://waitlist.touch-ai.org/subscribe`.
- Sonner-based toast notifications for validation, success, duplicate, rate-limit, and network errors; auto-dismissing in localized copy.
- SVG stroke-draw checkmark animation on submit, followed by a FLIP-driven collapse so siblings reflow smoothly without a layout pop.
- Microsoft Clarity analytics, conditionally injected only when `PUBLIC_CLARITY_ID` is set at build time.
- All third-party identifiers (Clarity ID, Waitlist endpoint) extracted into `PUBLIC_*` env vars; documented in `apps/site/.env.example`. CI injects them via repository secrets `SITE_CLARITY_ID` and `SITE_WAITLIST_ENDPOINT` (workflow updated). `.env`/`.env.local` are gitignored.
- Stabilized layout: `.info` min-height to prevent title/subtitle jump on language switch, and `.countdown` min-height to prevent first-paint flash before JS hydrates the rolling cells.
- Adds `@astrojs/react` and a `ToastProvider` island so the otherwise static site can host the Sonner toaster.

Action required before merge: set `SITE_CLARITY_ID` and `SITE_WAITLIST_ENDPOINT` as repository secrets so the production build picks them up; otherwise both features degrade gracefully (no analytics, form shows server-error toast).

## Related issue or RFC

- Follows up on #265 (placeholder page).

## AI assistance disclosure

- Tool(s) used: Kiro
- Scope of assistance: implementation, local verification in dev server, env-var/CI wiring, PR preparation
- Human review or rewrite performed: human review pending on this PR
- Architecture or boundary impact: site (apps/site) only; no AgentService, runtime, MCP, database schema, or migration changes. Worker backend lives in a separate repository.

## Testing evidence

```text
pnpm --filter @touchai/site build
# 4 page(s) built in 13.05s. Complete.
```

Manually verified in `astro dev`:
- Submit with valid email -> spinner, then green check stroke-draw, then form collapses with sibling FLIP animation, toast shows success copy.
- Submit with invalid email -> error toast, no network call.
- Language toggle -> title, subtitle, button label swap; no layout jump; no SVG loss on the submit button.
- Theme toggle -> sweep transition unchanged; sun/moon icon renders correctly in both modes.
- First paint -> no countdown height flash before JS mounts cells.

## Risk notes

- Scope is limited to the placeholder site (apps/site); no desktop, agent, runtime, MCP, or database changes. No migrations.
- Both third-party integrations are guarded by env vars: missing `PUBLIC_CLARITY_ID` skips the analytics tag entirely, missing `PUBLIC_WAITLIST_ENDPOINT` shows the server-error toast instead of a no-op fetch. Worst case if secrets are not configured: site renders identically to the current placeholder, form stays visible and unsubmittable.
- Worker backend lives in a separate repo and is already deployed at `waitlist.touch-ai.org` with CORS restricted to `https://touch-ai.org` plus localhost for dev. No admin/list endpoint is exposed (subscribers are read directly from the KV namespace via Cloudflare dashboard).
- Privacy: form collects email plus minimal metadata (lang, referrer, IP, UA, timestamp) for the waitlist; Clarity is opt-out via standard browser DNT/ad-block controls. No PII is logged in the site code itself.
- Submit button stays disabled through the success animation to prevent double-submit during the 800 ms delay before the form collapses; only error/network paths re-enable it.
- React island is loaded via `client:load` only on the index page, so Starlight docs pages are unaffected.