### PR TITLE
fix(release): handle full-object update proxy responses

### DIFF
--- a/apps/desktop/scripts/cloudflare/update-proxy-worker.mjs
+++ b/apps/desktop/scripts/cloudflare/update-proxy-worker.mjs
@@ -96,6 +96,10 @@ function canUseWorkerCache(request) {
     return (request.method === 'GET' || request.method === 'HEAD') && !request.headers.has('range');
 }
 
+function rangeOptions(request) {
+    return request.headers.has('range') ? { range: request.headers } : undefined;
+}
+
 function defaultCacheControl(fileName, env) {
     if (isFeedFile(fileName)) {
         return `public, max-age=${cacheSeconds(env.UPDATE_FEED_CACHE_SECONDS, DEFAULT_FEED_CACHE_SECONDS)}`;
@@ -107,7 +111,11 @@ function defaultCacheControl(fileName, env) {
     )}, immutable`;
 }
 
-function r2ObjectRange(object) {
+function r2ObjectRange(request, object) {
+    if (!request.headers.has('range')) {
+        return null;
+    }
+
     const range = object?.range;
     const size = object?.size;
     if (!range || typeof range !== 'object' || !Number.isFinite(size) || size < 0) {
@@ -159,14 +167,14 @@ async function responseFromR2Object(request, object, fileName, env) {
     if (typeof object.size === 'number' && !headers.has('content-length')) {
         headers.set('content-length', String(object.size));
     }
-    const range = r2ObjectRange(object);
+    const range = r2ObjectRange(request, object);
     if (range) {
         headers.set('content-range', range.contentRange);
         headers.set('content-length', String(range.contentLength));
     }
 
     return new Response(request.method === 'HEAD' ? null : object.body, {
-        status: object.range ? 206 : 200,
+        status: range ? 206 : 200,
         headers,
     });
 }
@@ -179,10 +187,12 @@ async function responseFromR2(request, env, key, fileName) {
 
     let object;
     try {
-        object =
-            request.method === 'HEAD' && bucket.head
-                ? await bucket.head(key)
-                : await bucket.get(key, { range: request.headers });
+        const options = rangeOptions(request);
+        if (request.method === 'HEAD' && !options && bucket.head) {
+            object = await bucket.head(key);
+        } else {
+            object = options ? await bucket.get(key, options) : await bucket.get(key);
+        }
     } catch (error) {
         console.error('Update R2 lookup failed', {
             error: messageFromError(error),

--- a/apps/desktop/tests/ci/update-proxy-worker.test.ts
+++ b/apps/desktop/tests/ci/update-proxy-worker.test.ts
@@ -114,10 +114,7 @@ describe('update proxy Worker', () => {
         expect(await response.text()).toBe('from-r2');
         expect(response.headers.get('etag')).toBe('"r2-etag"');
         expect(env.UPDATE_BUCKET.get).toHaveBeenCalledWith(
-            'touchai-app/v1/TouchAI-beta-0.1.1-beta.14-windows.msi',
-            {
-                range: request.headers,
-            }
+            'touchai-app/v1/TouchAI-beta-0.1.1-beta.14-windows.msi'
         );
         expect(fetchMock).not.toHaveBeenCalled();
         expect(cache.put).not.toHaveBeenCalled();
@@ -201,6 +198,77 @@ describe('update proxy Worker', () => {
         expect(response.headers.get('content-range')).toBe('bytes 2-5/10');
         expect(response.headers.get('content-length')).toBe('4');
         expect(await response.text()).toBe('2345');
+        expect(env.UPDATE_BUCKET.get).toHaveBeenCalledWith(
+            'touchai-app/v1/TouchAI-0.2.0-windows.msi',
+            {
+                range: request.headers,
+            }
+        );
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('serves non-range HEAD requests from R2 as a full object response', async () => {
+        const worker = await loadWorker();
+        const fetchMock = vi.fn<typeof fetch>();
+        vi.stubGlobal('fetch', fetchMock);
+
+        const env = {
+            UPDATE_BASE_PATH: 'touchai-app/v1',
+            GITHUB_REPOSITORY: 'TouchAI-org/TouchAI',
+            UPDATE_BUCKET: {
+                head: vi.fn(async () =>
+                    r2Object('', {}, { range: { offset: 0, length: 10 }, size: 10 })
+                ),
+                get: vi.fn(async () => null),
+            },
+        };
+        const request = new Request(
+            'https://updates.touch-ai.org/touchai-app/v1/TouchAI-0.2.0-windows.msi',
+            { method: 'HEAD' }
+        );
+
+        expect(worker?.default.fetch).toBeTypeOf('function');
+        const response = await worker!.default.fetch(request, env, workerContext().context);
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get('content-range')).toBeNull();
+        expect(response.headers.get('content-length')).toBe('10');
+        expect(await response.text()).toBe('');
+        expect(env.UPDATE_BUCKET.head).toHaveBeenCalledWith(
+            'touchai-app/v1/TouchAI-0.2.0-windows.msi'
+        );
+        expect(env.UPDATE_BUCKET.get).not.toHaveBeenCalled();
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('serves non-range GET requests from R2 as a full object response', async () => {
+        const worker = await loadWorker();
+        const fetchMock = vi.fn<typeof fetch>();
+        vi.stubGlobal('fetch', fetchMock);
+
+        const env = {
+            UPDATE_BASE_PATH: 'touchai-app/v1',
+            GITHUB_REPOSITORY: 'TouchAI-org/TouchAI',
+            UPDATE_BUCKET: {
+                get: vi.fn(async () =>
+                    r2Object('0123456789', {}, { range: { offset: 0, length: 10 }, size: 10 })
+                ),
+            },
+        };
+        const request = new Request(
+            'https://updates.touch-ai.org/touchai-app/v1/TouchAI-0.2.0-windows.msi'
+        );
+
+        expect(worker?.default.fetch).toBeTypeOf('function');
+        const response = await worker!.default.fetch(request, env, workerContext().context);
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get('content-range')).toBeNull();
+        expect(response.headers.get('content-length')).toBe('10');
+        expect(await response.text()).toBe('0123456789');
+        expect(env.UPDATE_BUCKET.get).toHaveBeenCalledWith(
+            'touchai-app/v1/TouchAI-0.2.0-windows.msi'
+        );
         expect(fetchMock).not.toHaveBeenCalled();
     });
 


### PR DESCRIPTION
﻿## Summary

Fixes the Cloudflare update proxy response handling for full-object downloads. The deployed Worker was returning `206 Partial Content` for ordinary `HEAD` requests because it treated R2 object range metadata as proof that the client requested a range. Chrome download probing can reject that response shape and show “无法从网站上提取文件”.

This change only returns `206` and `Content-Range` when the incoming request actually contains a `Range` header. Non-range `HEAD` and `GET` requests now return normal full-object `200` responses, while real range requests still pass range options through to R2.

## Related issue or RFC

- Related to #48

## AI assistance disclosure

- Tool(s) used: OpenAI Codex
- Scope of assistance: diagnosis, test-first Worker fix, local verification, PR preparation
- Human review or rewrite performed: Maintainer review required before merge
- Architecture or boundary impact: None; scoped to the existing update proxy Worker behavior

## Testing evidence

```text
pnpm --dir apps/desktop exec vitest run --configLoader runner tests/ci/update-proxy-worker.test.ts -t "non-range HEAD"
# initially failed: expected 206 to be 200

pnpm --dir apps/desktop exec vitest run --configLoader runner tests/ci/update-proxy-worker.test.ts
# 1 file passed, 9 tests passed

pnpm --dir apps/desktop exec vitest run --configLoader runner tests/ci
# 13 files passed, 52 tests passed

pnpm --dir apps/desktop test:typecheck
# passed

pnpm --dir apps/desktop format:check
# passed

pnpm --dir apps/desktop lint:check
# passed with 0 errors and existing warnings
```

TDD: yes. Added a failing regression test for non-range `HEAD` returning `206`, then fixed the Worker and added the matching non-range `GET`/range preservation coverage.

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: None
- database baseline or migration impact: None
- release or packaging impact: Requires redeploying the update proxy Worker after merge. Existing GitHub Release assets do not need to be rebuilt.

## Screenshots or recordings

Not applicable; no UI changes.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [x] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [x] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.

## Summary by Sourcery

Correct R2 range handling in the Cloudflare update proxy so that only explicit range requests receive partial-content responses while non-range requests get full-object responses.

Bug Fixes:
- Ensure non-range GET and HEAD requests to the update proxy return 200 with full-object metadata instead of 206 Partial Content based solely on R2 range metadata.

Enhancements:
- Add a helper to derive R2 range options from incoming requests and tighten range header propagation and response status/content-range calculations.

Tests:
- Extend update proxy Worker tests to cover non-range HEAD/GET behavior, verify range preservation, and adjust expectations for R2 range option usage.