### PR TITLE
fix(webfetch): block private mapped ipv6 hosts

### DIFF
--- a/apps/desktop/src/services/BuiltInToolService/tools/webFetch/helper.ts
+++ b/apps/desktop/src/services/BuiltInToolService/tools/webFetch/helper.ts
@@ -71,8 +71,30 @@ function isPrivateIpv4(hostname: string): boolean {
     );
 }
 
+function ipv4FromMappedIpv6(hostname: string): string | null {
+    const normalized = stripIpv6Brackets(hostname).toLowerCase();
+    const dottedMatch = /^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/.exec(normalized);
+    if (dottedMatch) {
+        return dottedMatch[1] ?? null;
+    }
+
+    const hexMatch = /^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/.exec(normalized);
+    if (!hexMatch) {
+        return null;
+    }
+
+    const high = Number.parseInt(hexMatch[1]!, 16);
+    const low = Number.parseInt(hexMatch[2]!, 16);
+    return [(high >> 8) & 255, high & 255, (low >> 8) & 255, low & 255].join('.');
+}
+
 function isPrivateIpv6(hostname: string): boolean {
     const normalized = stripIpv6Brackets(hostname).toLowerCase();
+    const mappedIpv4 = ipv4FromMappedIpv6(normalized);
+    if (mappedIpv4) {
+        return isPrivateIpv4(mappedIpv4);
+    }
+
     return (
         normalized === '::1' ||
         normalized.startsWith('fc') ||

--- a/apps/desktop/tests/services/BuiltInToolService/tools/webFetch/helper.test.ts
+++ b/apps/desktop/tests/services/BuiltInToolService/tools/webFetch/helper.test.ts
@@ -17,6 +17,40 @@ describe('parseWebFetchRequest', () => {
             })
         ).toThrow('WebFetch tool only supports http:// and https:// URLs.');
     });
+
+    it('rejects IPv4-mapped IPv6 hosts for private network addresses', () => {
+        setLocale('en-US');
+        const privateMappedHosts = [
+            'http://[::ffff:0.0.0.0]/',
+            'http://[::ffff:10.0.0.1]/',
+            'http://[::ffff:127.0.0.1]/',
+            'http://[::ffff:169.254.1.1]/',
+            'http://[::ffff:172.16.0.1]/',
+            'http://[::ffff:192.168.0.1]/',
+        ];
+
+        for (const url of privateMappedHosts) {
+            expect(() =>
+                parseWebFetchRequest({
+                    url,
+                    mode: 'page_markdown',
+                    maxChars: 1000,
+                })
+            ).toThrow(
+                'WebFetch tool blocks localhost, private-network and single-label hostnames.'
+            );
+        }
+    });
+
+    it('allows IPv4-mapped IPv6 hosts for public addresses', () => {
+        const request = parseWebFetchRequest({
+            url: 'https://[::ffff:8.8.8.8]/dns-query',
+            mode: 'page_markdown',
+            maxChars: 1000,
+        });
+
+        expect(request.url.hostname).toBe('[::ffff:808:808]');
+    });
 });
 
 describe('buildPageMarkdown', () => {


### PR DESCRIPTION
## Summary

- Block IPv4-mapped IPv6 hostnames when the embedded IPv4 address belongs to local, private, link-local, or 0.0.0.0 ranges.
- Keep public IPv4-mapped IPv6 addresses allowed.

## Related issue or RFC

Related to https://github.com/TouchAI-org/TouchAI

## AI assistance disclosure

- Tool(s) used: local development assistant
- Scope of assistance: bug discovery, test-first patch, local verification, and PR preparation
- Human review or rewrite performed: reviewed the diff and command outputs before submission
- Architecture or boundary impact: no new boundary or architecture changes

## Testing evidence

- `corepack pnpm --filter @touchai/desktop exec vitest run --configLoader runner tests/services/BuiltInToolService/tools/webFetch/helper.test.ts` - passed, 4 tests.
- `corepack pnpm --dir apps/desktop exec eslint src/services/BuiltInToolService/tools/webFetch/helper.ts tests/services/BuiltInToolService/tools/webFetch/helper.test.ts` - passed.
- `corepack pnpm --dir apps/desktop exec prettier --check src/services/BuiltInToolService/tools/webFetch/helper.ts tests/services/BuiltInToolService/tools/webFetch/helper.test.ts` - passed.
- `corepack pnpm --dir apps/desktop run test:typecheck` - passed.
- Full `pnpm test:pr` was not run locally because the direct `pnpm` shim is not available on this machine; focused checks were run through `corepack pnpm`.

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: none.
- database baseline or migration impact: none.
- release or packaging impact: none.

## Screenshots or recordings

Not applicable; parser-only change.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [x] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [x] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.

## Summary by Sourcery

Tighten webFetch URL validation to treat IPv4-mapped IPv6 hostnames as private when the embedded IPv4 address is non-public, while still allowing public mapped addresses.

Bug Fixes:
- Block IPv4-mapped IPv6 hostnames whose embedded IPv4 falls into localhost, private, link-local, or 0.0.0.0 ranges in webFetch requests.

Tests:
- Add unit tests covering rejection of private IPv4-mapped IPv6 hosts and acceptance/normalization of public mapped IPv6 hosts in webFetch parsing.