### PR TITLE
fix(search): keep requested pin state

### DIFF
--- a/apps/desktop/src/views/SearchView/composables/useSearchPage.ts
+++ b/apps/desktop/src/views/SearchView/composables/useSearchPage.ts
@@ -37,6 +37,7 @@ const HIDE_TIMEOUT_MS = 5 * 60 * 1000;
 export function useSearchWindowPin() {
     const currentWindow = getCurrentWindow();
     const isPinned = ref(false);
+    let desiredPinnedState: boolean | null = null;
     let lastOperation: Promise<void> = Promise.resolve();
 
     function queuePinOperation<T>(operation: () => Promise<T>): Promise<T> {
@@ -50,6 +51,11 @@ export function useSearchWindowPin() {
 
     function syncWindowPinState(): Promise<boolean> {
         return queuePinOperation(async () => {
+            if (desiredPinnedState !== null) {
+                isPinned.value = desiredPinnedState;
+                return desiredPinnedState;
+            }
+
             const nextState = await currentWindow.isAlwaysOnTop();
             isPinned.value = nextState;
             return nextState;
@@ -58,18 +64,18 @@ export function useSearchWindowPin() {
 
     function setWindowPinned(value: boolean): Promise<boolean> {
         return queuePinOperation(async () => {
+            desiredPinnedState = value;
             await currentWindow.setAlwaysOnTop(value);
-            const nextState = await currentWindow.isAlwaysOnTop();
-            isPinned.value = nextState;
-            return nextState;
+            isPinned.value = value;
+            return value;
         });
     }
 
     function toggleWindowPin(): Promise<boolean> {
         return queuePinOperation(async () => {
-            const currentState = await currentWindow.isAlwaysOnTop();
-            await currentWindow.setAlwaysOnTop(!currentState);
-            const nextState = await currentWindow.isAlwaysOnTop();
+            const nextState = !isPinned.value;
+            desiredPinnedState = nextState;
+            await currentWindow.setAlwaysOnTop(nextState);
             isPinned.value = nextState;
             return nextState;
         });

--- a/apps/desktop/tests/composables/SearchView/useSearchPage.test.ts
+++ b/apps/desktop/tests/composables/SearchView/useSearchPage.test.ts
@@ -7,6 +7,7 @@ import { createSearchInteractionContext } from '@/views/SearchView/composables/s
 import {
     useSearchPageController,
     useSearchPageLifecycle,
+    useSearchWindowPin,
 } from '@/views/SearchView/composables/useSearchPage';
 
 const {
@@ -183,6 +184,40 @@ describe('useSearchPageController', () => {
         controller.closeQuickSearch();
 
         expect(quickSearchOpen.value).toBe(false);
+    });
+});
+
+describe('useSearchWindowPin', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        currentWindowMock.isAlwaysOnTop.mockResolvedValue(false);
+        currentWindowMock.setAlwaysOnTop.mockResolvedValue(undefined);
+    });
+
+    it('keeps the requested pinned state after toggling even when the platform reports false', async () => {
+        const { isPinned, toggleWindowPin, syncWindowPinState } = useSearchWindowPin();
+
+        await toggleWindowPin();
+
+        expect(currentWindowMock.setAlwaysOnTop).toHaveBeenCalledWith(true);
+        expect(isPinned.value).toBe(true);
+
+        const syncedState = await syncWindowPinState();
+
+        expect(syncedState).toBe(true);
+        expect(isPinned.value).toBe(true);
+        expect(currentWindowMock.isAlwaysOnTop).not.toHaveBeenCalled();
+    });
+
+    it('syncs from the native window state before the user changes the pin state', async () => {
+        currentWindowMock.isAlwaysOnTop.mockResolvedValue(true);
+
+        const { isPinned, syncWindowPinState } = useSearchWindowPin();
+
+        const syncedState = await syncWindowPinState();
+
+        expect(syncedState).toBe(true);
+        expect(isPinned.value).toBe(true);
     });
 });
 


### PR DESCRIPTION
## Summary

Fixes #287.

Keep the requested search-window pinned state after the user toggles the pin button. This prevents Linux/Wayland from immediately reverting the UI state when `isAlwaysOnTop()` reports `false` even after `setAlwaysOnTop(true)` was requested.

Changes:
- Track the user's requested pinned state in `useSearchWindowPin()`.
- Keep app-blur hide policy driven by the requested pinned state.
- Preserve the native `setAlwaysOnTop()` call.
- Add a regression test for platforms that report `isAlwaysOnTop()` as `false` after a pin request.

## Related issue or RFC

- Fixes #287

## AI assistance disclosure

- Tool(s) used: Codex
- Scope of assistance: implementation, focused test, local validation, PR preparation
- Human review or rewrite performed: I reviewed the diff and manually validated the behavior on Ubuntu GNOME using a Linux package build
- Architecture or boundary impact: none; this is isolated to SearchView window pin state handling

## Testing evidence

Local checks:

```text
pnpm --filter @touchai/desktop exec vitest run tests/composables/SearchView/useSearchPage.test.ts --environment happy-dom --configLoader runner
pnpm --filter @touchai/desktop type:check
pnpm --filter @touchai/desktop exec prettier --check src/views/SearchView/composables/useSearchPage.ts tests/composables/SearchView/useSearchPage.test.ts
```

Observed results:
- Focused test passed: 8 tests passed
- Type check passed
- Prettier check passed for touched files

Manual verification:
- Built a Linux `.deb` from the fix branch through GitHub Actions on my fork
- Installed and tested it on Ubuntu 24.04 GNOME / Wayland
- Confirmed the pin button state changes and the pinned window no longer auto-hides on blur

Notes:
- I did not run the full `pnpm test:pr` locally due to runtime cost; this PR includes a focused regression test and relies on repository CI for the full suite.
- I did not follow strict TDD because the issue was first reproduced manually on Ubuntu, then covered with a regression test.

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: none
- database baseline or migration impact: none
- release or packaging impact: none

## Screenshots or recordings

Manual Ubuntu/GNOME verification was performed locally after installing the generated `.deb`.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [x] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [x] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.

## Summary by Sourcery

Ensure the search window pin state is driven by the user’s requested state instead of relying solely on the native always-on-top result.

Bug Fixes:
- Prevent the search window from unpinning or auto-hiding when the platform reports an incorrect always-on-top state, particularly on Linux/Wayland.

Tests:
- Add regression tests for useSearchWindowPin to verify requested pin state is preserved and correctly synced with the native window state.