### PR TITLE
fix(ci): use pull_request trigger to prevent RCE

### DIFF
--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -1,7 +1,7 @@
 name: PR Template Check
 
 on:
-    pull_request_target:
+    pull_request:
         types:
             - opened
             - edited


### PR DESCRIPTION
## Summary

Switch the PR Template Check workflow from `pull_request_target` to `pull_request` to prevent remote code execution. The previous trigger ran workflow code with the target repository's context and secrets, allowing untrusted PR code to potentially exfiltrate credentials.

## Related issue or RFC

- Closes #309

## AI assistance disclosure

- Tool(s) used: Claude Code
- Scope of assistance: Identified the security issue and implemented the fix
- Human review or rewrite performed: User reviewed and approved the change
- Architecture or boundary impact: None — CI workflow only

## Testing evidence

- `pnpm test:pr` — not applicable, this is a CI workflow change only
- Verified the workflow YAML is syntactically valid
- The workflow only reads PR body metadata and runs a template check script; no secrets or elevated privileges are required

```text
N/A — CI workflow change, no local test commands apply
```

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: None
- database baseline or migration impact: None
- release or packaging impact: None

## Screenshots or recordings

N/A

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC. N/A
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC. N/A
- [x] I ran `pnpm test:pr` for this code PR, or this is a docs-only change. CI-only change
- [x] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence. N/A
- [x] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof. N/A
- [x] I added tests or explained why tests are not appropriate. N/A — workflow change
- [x] I updated docs when behavior changed. No behavior change to document