### PR TITLE
fix(updater): ignore stale download progress

### DIFF
--- a/apps/desktop/src/services/AppUpdateService/state.ts
+++ b/apps/desktop/src/services/AppUpdateService/state.ts
@@ -131,6 +131,10 @@ export function reduceAppUpdateState(
                 error: null,
             };
         case 'download-progress':
+            if (state.status !== 'downloading') {
+                return state;
+            }
+
             return {
                 ...state,
                 status: 'downloading',

--- a/apps/desktop/tests/services/AppUpdateService/state.test.ts
+++ b/apps/desktop/tests/services/AppUpdateService/state.test.ts
@@ -192,6 +192,27 @@ describe('AppUpdateService state reducer', () => {
         });
     });
 
+    it('ignores stale download progress after a download finishes', () => {
+        const downloaded = reduceAppUpdateState(
+            {
+                ...createInitialAppUpdateState(),
+                status: 'downloaded',
+                downloadedUpdate: availableUpdate.update,
+                downloadProgress: 100,
+            },
+            {
+                type: 'download-progress',
+                progress: 64,
+            }
+        );
+
+        expect(downloaded).toMatchObject({
+            status: 'downloaded',
+            downloadedUpdate: availableUpdate.update,
+            downloadProgress: 100,
+        });
+    });
+
     it('records installing and failed states', () => {
         const installing = reduceAppUpdateState(createInitialAppUpdateState(), {
             type: 'install-started',


### PR DESCRIPTION
## Summary

- Ignore late updater progress events unless the update state is actively downloading.
- Preserve the downloaded state and 100% progress after the download has completed.
- Add a reducer regression test for stale progress after completion.

## Related issue or RFC

Related to https://github.com/TouchAI-org/TouchAI

## AI assistance disclosure

- Tool(s) used: local development assistant
- Scope of assistance: bug discovery, test-first patch, local verification, and PR preparation
- Human review or rewrite performed: reviewed the diff and command outputs before submission
- Architecture or boundary impact: no new boundary or architecture changes

## Testing evidence

- `corepack pnpm --filter @touchai/desktop exec vitest run --configLoader runner tests/services/AppUpdateService/state.test.ts` - failed before the fix, then passed after the fix.
- `corepack pnpm --filter @touchai/desktop exec vitest run --configLoader runner tests/services/AppUpdateService` - passed, 25 tests.
- `corepack pnpm --dir apps/desktop exec eslint src/services/AppUpdateService/state.ts tests/services/AppUpdateService/state.test.ts` - passed.
- `corepack pnpm --dir apps/desktop exec prettier --check src/services/AppUpdateService/state.ts tests/services/AppUpdateService/state.test.ts` - passed.
- `corepack pnpm install --frozen-lockfile` - refreshed local dependencies after main added new packages.
- `corepack pnpm --dir apps/desktop run test:typecheck` - passed.
- Full `pnpm test:pr` was not run locally because focused checks covered the touched reducer and typecheck; CI remains the full proof before merge.

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: none.
- database baseline or migration impact: none.
- release or packaging impact: none.

## Screenshots or recordings

Not applicable; state reducer change only.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [x] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [x] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.