### PR TITLE
fix(ask-user): notify background questions

### DIFF
--- a/apps/desktop/src-tauri/src/core/window/status_reminder.rs
+++ b/apps/desktop/src-tauri/src/core/window/status_reminder.rs
@@ -532,35 +532,38 @@ fn build_toast_document(
         .map_err(|error| error.to_string())?;
 
     if payload.kind == SessionStatusReminderKind::WaitingApproval {
-        let Some(approval) = payload.approval.as_ref() else {
-            return Err("waiting_approval reminder requires approval payload".to_string());
-        };
+        if let Some(approval) = payload.approval.as_ref() {
+            let approve_arguments = serialize_activation_payload(
+                payload,
+                SessionStatusReminderAction::Approve,
+                Some(approval.call_id.clone()),
+            )?;
+            let reject_arguments = serialize_activation_payload(
+                payload,
+                SessionStatusReminderAction::Reject,
+                Some(approval.call_id.clone()),
+            )?;
 
-        let approve_arguments = serialize_activation_payload(
-            payload,
-            SessionStatusReminderAction::Approve,
-            Some(approval.call_id.clone()),
-        )?;
-        let reject_arguments = serialize_activation_payload(
-            payload,
-            SessionStatusReminderAction::Reject,
-            Some(approval.call_id.clone()),
-        )?;
-
-        append_action_element(
-            &doc,
-            &actions_element,
-            &approval.approve_label,
-            &approve_arguments,
-            None,
-        )?;
-        append_action_element(
-            &doc,
-            &actions_element,
-            &approval.reject_label,
-            &reject_arguments,
-            None,
-        )?;
+            append_action_element(
+                &doc,
+                &actions_element,
+                &approval.approve_label,
+                &approve_arguments,
+                None,
+            )?;
+            append_action_element(
+                &doc,
+                &actions_element,
+                &approval.reject_label,
+                &reject_arguments,
+                None,
+            )?;
+        } else {
+            let open_arguments =
+                serialize_activation_payload(payload, SessionStatusReminderAction::Open, None)?;
+            let label = payload.open_label.as_deref().unwrap_or("Open");
+            append_action_element(&doc, &actions_element, label, &open_arguments, None)?;
+        }
     } else {
         let reply_arguments =
             serialize_activation_payload(payload, SessionStatusReminderAction::Reply, None)?;
@@ -853,7 +856,8 @@ mod macos_notifications {
 
         let existing_categories = center.notificationCategories();
 
-        if payload.kind == SessionStatusReminderKind::WaitingApproval {
+        if payload.kind == SessionStatusReminderKind::WaitingApproval && payload.approval.is_some()
+        {
             let approve_action = UNNotificationAction::actionWithIdentifier_title_options(
                 &NSString::from_str("approve"),
                 &NSString::from_str(approve_label),
@@ -876,6 +880,28 @@ mod macos_notifications {
                 .to_vec()
                 .into_iter()
                 .filter(|category| category.identifier().to_string() != "touchai-waiting-approval")
+                .collect();
+            all.push(category);
+            center.setNotificationCategories(&NSArray::from_vec(all));
+        } else if payload.kind == SessionStatusReminderKind::WaitingApproval {
+            let open_label = payload.open_label.as_deref().unwrap_or("Open");
+            let open_action = UNNotificationAction::actionWithIdentifier_title_options(
+                &NSString::from_str("open"),
+                &NSString::from_str(open_label),
+                objc2_user_notifications::UNNotificationActionOptions::Foreground,
+            );
+            let actions = NSArray::from_vec(vec![open_action]);
+            let category =
+                UNNotificationCategory::categoryWithIdentifier_actions_intentIdentifiers_options(
+                    &NSString::from_str("touchai-open-only"),
+                    &actions,
+                    &NSArray::new(),
+                    objc2_user_notifications::UNNotificationCategoryOptions::empty(),
+                );
+            let mut all: Vec<UNNotificationCategory> = existing_categories
+                .to_vec()
+                .into_iter()
+                .filter(|category| category.identifier().to_string() != "touchai-open-only")
                 .collect();
             all.push(category);
             center.setNotificationCategories(&NSArray::from_vec(all));
@@ -996,8 +1022,12 @@ mod macos_notifications {
         content.setTitle(&NSString::from_str(&payload.title));
         content.setBody(&NSString::from_str(&payload.body));
 
-        let category_id = if payload.kind == SessionStatusReminderKind::WaitingApproval {
+        let category_id = if payload.kind == SessionStatusReminderKind::WaitingApproval
+            && payload.approval.is_some()
+        {
             "touchai-waiting-approval"
+        } else if payload.kind == SessionStatusReminderKind::WaitingApproval {
+            "touchai-open-only"
         } else {
             "touchai-completed-failed"
         };
@@ -1117,7 +1147,8 @@ mod linux_notifications {
             .appname("TouchAI")
             .timeout(notification_timeout(payload.kind));
 
-        if payload.kind == SessionStatusReminderKind::WaitingApproval {
+        if payload.kind == SessionStatusReminderKind::WaitingApproval && payload.approval.is_some()
+        {
             notification.action("approve", approve_label);
             notification.action("reject", reject_label);
         } else {
@@ -1285,5 +1316,27 @@ mod tests_windows {
         assert!(xml.contains("Approve"));
         assert!(xml.contains("Reject"));
         assert!(!xml.contains("Reply to TouchAI"));
+    }
+
+    #[test]
+    fn build_toast_xml_opens_waiting_reminder_without_approval_payload() {
+        let xml = build_toast_xml(&SessionStatusReminderNotificationPayload {
+            title: "Waiting for response".to_string(),
+            body: "Pick the deployment target".to_string(),
+            session_id: 11,
+            task_id: "task-question".to_string(),
+            kind: SessionStatusReminderKind::WaitingApproval,
+            approval: None,
+            open_label: Some("Open".to_string()),
+            reply_placeholder: None,
+            reply_label: None,
+        })
+        .expect("toast xml");
+
+        assert!(xml.contains("<actions>"));
+        assert!(xml.contains("Open"));
+        assert!(!xml.contains("Approve"));
+        assert!(!xml.contains("Reject"));
+        assert!(!xml.contains("input"));
     }
 }

--- a/apps/desktop/src/i18n/textMap.ts
+++ b/apps/desktop/src/i18n/textMap.ts
@@ -726,6 +726,8 @@ export const zhToEnTextMap = {
     任务已完成: 'Task completed',
     任务失败: 'Task failed',
     任务正在等待批准: 'Task is waiting for approval',
+    等待回复: 'Waiting for response',
+    任务正在等待用户回复: 'Task is waiting for a user response',
     '回复 TouchAI': 'Reply to TouchAI',
     回复: 'Reply',
 } as const;

--- a/apps/desktop/src/services/AgentService/task/center.ts
+++ b/apps/desktop/src/services/AgentService/task/center.ts
@@ -127,11 +127,17 @@ function buildWaitingApprovalBody(approval: PendingToolApproval): string {
     return `${summary}\n${commandPreview}`;
 }
 
+function buildWaitingUserQuestionBody(
+    question: NonNullable<SessionTaskSnapshot['pendingUserQuestion']>
+): string {
+    return summarizeReminderText(question.questions[0]?.question) ?? tt('任务正在等待用户回复');
+}
+
 /**
  * 根据任务快照构建状态提醒负载。
  * 仅在 completed、failed、waiting_approval 三种状态下生成提醒，其余返回 null。
  */
-function buildSessionStatusReminder(
+export function buildSessionStatusReminder(
     snapshot: SessionTaskSnapshot
 ): SessionStatusReminderPayload | null {
     if (snapshot.status === 'completed') {
@@ -161,7 +167,20 @@ function buildSessionStatusReminder(
         };
     }
 
-    if (snapshot.status !== 'waiting_approval' || !snapshot.pendingToolApproval) {
+    if (snapshot.status !== 'waiting_approval') {
+        return null;
+    }
+
+    if (snapshot.pendingUserQuestion && !snapshot.pendingToolApproval) {
+        return {
+            kind: 'waiting_approval',
+            title: tt('等待回复'),
+            body: buildWaitingUserQuestionBody(snapshot.pendingUserQuestion),
+            approval: null,
+        };
+    }
+
+    if (!snapshot.pendingToolApproval) {
         return null;
     }
 

--- a/apps/desktop/src/views/SearchView/composables/sessionStatusReminder.ts
+++ b/apps/desktop/src/views/SearchView/composables/sessionStatusReminder.ts
@@ -88,12 +88,15 @@ export function createSessionStatusReminderCoordinator(
 
         clearReminderState();
 
+        const hasInlineApprovalActions =
+            payload.reminder.kind === 'waiting_approval' && Boolean(payload.reminder.approval);
+
         showNativeStatusReminderNotification({
             ...payload.reminder,
             sessionId: payload.sessionId,
             taskId: payload.taskId,
             approval: payload.reminder.approval ?? null,
-            ...(payload.reminder.kind === 'waiting_approval' ? {} : { openLabel: tt('打开') }),
+            ...(hasInlineApprovalActions ? {} : { openLabel: tt('打开') }),
         });
         setTrayStatusIndicator(payload.reminder.kind);
         hasActiveReminder = true;

--- a/apps/desktop/tests/composables/SearchView/useSearchPage.test.ts
+++ b/apps/desktop/tests/composables/SearchView/useSearchPage.test.ts
@@ -192,6 +192,11 @@ function createStatusChangedPayload(
         previousStatus: 'running' | 'waiting_approval' | 'completed' | 'failed' | 'cancelled';
         body: string;
         title: string;
+        approval: {
+            callId: string;
+            approveLabel: string;
+            rejectLabel: string;
+        } | null;
     }> = {}
 ) {
     const defaultTitle =
@@ -207,13 +212,15 @@ function createStatusChangedPayload(
             title: overrides.title ?? defaultTitle,
             body: overrides.body ?? `${kind} body`,
             approval:
-                kind === 'waiting_approval'
-                    ? {
-                          callId: 'call-1',
-                          approveLabel: 'Approve',
-                          rejectLabel: 'Reject',
-                      }
-                    : null,
+                overrides.approval !== undefined
+                    ? overrides.approval
+                    : kind === 'waiting_approval'
+                      ? {
+                            callId: 'call-1',
+                            approveLabel: 'Approve',
+                            rejectLabel: 'Reject',
+                        }
+                      : null,
         },
     };
 }
@@ -478,6 +485,56 @@ describe('useSearchPageLifecycle', () => {
 
         expect(nativeMock.window.clearTrayStatusIndicator).toHaveBeenCalled();
         expect(nativeMock.window.clearSessionStatusReminderNotifications).toHaveBeenCalled();
+
+        mounted.unmount();
+    });
+
+    it('adds an open action for waiting reminders that have no approval buttons', async () => {
+        const controller = createController();
+        const interactionContext = createSearchInteractionContext();
+
+        const mounted = await mountComposable(() =>
+            useSearchPageLifecycle({
+                controller: controller as never,
+                viewReady: ref(true),
+                isDragging: ref(false),
+                isPinned: ref(false),
+                interactionContext,
+                syncWindowPinState: vi.fn().mockResolvedValue(false),
+                clearSession: vi.fn(),
+            })
+        );
+
+        await flushLifecycle();
+        const surfaceHiddenHandler = eventHandlers.get(AppEvent.SEARCH_SURFACE_HIDDEN);
+        expect(surfaceHiddenHandler).toBeDefined();
+        await surfaceHiddenHandler!({
+            sequence: 1,
+            reason: 'manual-dismiss',
+        });
+        await flushLifecycle();
+
+        const statusHandler = eventHandlers.get(AppEvent.SESSION_TASK_STATUS_CHANGED);
+        expect(statusHandler).toBeDefined();
+        await statusHandler!(
+            createStatusChangedPayload('waiting_approval', {
+                title: 'Waiting for response',
+                body: 'Pick the deployment target',
+                approval: null,
+            })
+        );
+        await flushLifecycle();
+
+        expect(nativeMock.window.showSessionStatusReminderNotification).toHaveBeenCalledWith({
+            title: 'Waiting for response',
+            body: 'Pick the deployment target',
+            sessionId: 1,
+            taskId: 'task-1',
+            kind: 'waiting_approval',
+            approval: null,
+            openLabel: '打开',
+        });
+        expect(nativeMock.window.setTrayStatusIndicator).toHaveBeenCalledWith('waiting_approval');
 
         mounted.unmount();
     });

--- a/apps/desktop/tests/services/AgentService/task/center-reminder.test.ts
+++ b/apps/desktop/tests/services/AgentService/task/center-reminder.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { setLocale } from '@/i18n';
+import { buildSessionStatusReminder } from '@/services/AgentService/task/center';
+import type { SessionTaskSnapshot } from '@/services/AgentService/task/types';
+
+function createSnapshot(overrides: Partial<SessionTaskSnapshot> = {}): SessionTaskSnapshot {
+    return {
+        taskId: 'task-1',
+        sessionId: 1,
+        turnId: null,
+        status: 'running',
+        executionMode: 'background',
+        prompt: 'Prompt',
+        sessionHistory: [],
+        pendingToolApproval: null,
+        pendingApprovals: [],
+        pendingUserQuestion: null,
+        error: null,
+        currentModel: null,
+        promptSnapshot: null,
+        lastCheckpoint: null,
+        startedAt: 1,
+        updatedAt: 1,
+        modelSwitchCount: 0,
+        ...overrides,
+    };
+}
+
+describe('SessionTaskCenter status reminders', () => {
+    beforeEach(() => {
+        setLocale('en-US');
+    });
+
+    it('creates an open reminder when a background task waits for a user question', () => {
+        const reminder = buildSessionStatusReminder(
+            createSnapshot({
+                status: 'waiting_approval',
+                pendingUserQuestion: {
+                    callId: 'question-call',
+                    sourceMessageId: 'assistant-1',
+                    createdAt: 1,
+                    questions: [
+                        {
+                            question: 'Pick the deployment target',
+                            header: 'Deploy',
+                            options: [{ label: 'Staging' }, { label: 'Production' }],
+                        },
+                    ],
+                },
+            })
+        );
+
+        expect(reminder).toEqual({
+            kind: 'waiting_approval',
+            title: 'Waiting for response',
+            body: 'Pick the deployment target',
+            approval: null,
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Fixes a background-session stall where `ask_user_question` could move a task into `waiting_approval` without producing a native reminder. When the search surface was hidden, the user could miss the structured question and the task would wait indefinitely.

This change adds a waiting-response reminder for pending user questions, sends it with an Open action instead of approval buttons, and updates Windows/macOS/Linux notification handling so `waiting_approval` reminders without approval payloads open the app instead of failing or showing invalid actions.

## Related issue or RFC

- Related to #26

## AI assistance disclosure

- Tool(s) used: local development assistant
- Scope of assistance: bug discovery, test-first patch, local verification, and PR preparation
- Human review or rewrite performed: reviewed the diff and command outputs before submission
- Architecture or boundary impact: no new architecture boundary; existing task reminder and native notification paths only

## Testing evidence

- `corepack pnpm --dir apps/desktop exec vitest run --configLoader runner tests/services/AgentService/task/center-reminder.test.ts tests/composables/SearchView/useSearchPage.test.ts` passed: 2 files, 10 tests
- `corepack pnpm --dir apps/desktop run test:typecheck` passed
- `corepack pnpm --dir apps/desktop exec prettier --check src/services/AgentService/task/center.ts src/views/SearchView/composables/sessionStatusReminder.ts src/i18n/textMap.ts tests/services/AgentService/task/center-reminder.test.ts tests/composables/SearchView/useSearchPage.test.ts` passed
- `corepack pnpm --dir apps/desktop exec eslint src/services/AgentService/task/center.ts src/views/SearchView/composables/sessionStatusReminder.ts src/i18n/textMap.ts tests/services/AgentService/task/center-reminder.test.ts tests/composables/SearchView/useSearchPage.test.ts` passed
- `cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml --check` passed
- `cargo test build_toast_xml_opens_waiting_reminder_without_approval_payload --manifest-path apps/desktop/src-tauri/Cargo.toml` passed, with existing unrelated warnings in `src/core/search/manager.rs`
- `corepack pnpm --dir apps/desktop exec vitest run --configLoader runner --passWithNoTests` passed: 134 files, 666 tests
- `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml` passed: 62 lib tests, 5 database command tests, 1 updater command test, 9 window command tests, with existing unrelated warnings in `src/core/search/manager.rs`

`pnpm test:pr` was not run directly because this machine does not expose a direct `pnpm` shim to nested package scripts; the equivalent checks above were run through `corepack pnpm` plus full Rust tests.

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: touches `AgentService` task reminder projection only; no runtime protocol or schema changes
- database baseline or migration impact: none
- release or packaging impact: none

## Screenshots or recordings

Not included; behavior is covered by task reminder and native notification tests.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [x] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [ ] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.