### PR TITLE
fix(updater): ignore stale download results

### DIFF
--- a/apps/desktop/src/services/AppUpdateService/state.ts
+++ b/apps/desktop/src/services/AppUpdateService/state.ts
@@ -141,6 +141,10 @@ export function reduceAppUpdateState(
                 downloadProgress: clampProgress(action.progress),
             };
         case 'download-completed':
+            if (state.status !== 'downloading') {
+                return state;
+            }
+
             return {
                 ...state,
                 status: 'downloaded',
@@ -155,6 +159,14 @@ export function reduceAppUpdateState(
                 error: null,
             };
         case 'failed':
+            if (
+                state.status !== 'checking' &&
+                state.status !== 'downloading' &&
+                state.status !== 'installing'
+            ) {
+                return state;
+            }
+
             return {
                 ...state,
                 status: 'failed',

--- a/apps/desktop/tests/services/AppUpdateService/service.test.ts
+++ b/apps/desktop/tests/services/AppUpdateService/service.test.ts
@@ -99,6 +99,17 @@ function createController(
     };
 }
 
+function createDeferred<T>() {
+    let resolve!: (value: T | PromiseLike<T>) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+        resolve = resolvePromise;
+        reject = rejectPromise;
+    });
+
+    return { promise, resolve, reject };
+}
+
 describe('AppUpdateController', () => {
     it('loads persisted settings before checking manually', async () => {
         const { controller, checkForUpdates, updateAppUpdateLastCheckedAt } = createController();
@@ -185,6 +196,56 @@ describe('AppUpdateController', () => {
         expect(downloadUpdate).toHaveBeenCalledTimes(1);
         expect(installUpdate).toHaveBeenCalledTimes(1);
         expect(controller.getState().status).toBe('installing');
+    });
+
+    it('does not let stale download completion overwrite a changed channel', async () => {
+        const deferredDownload = createDeferred<AppUpdateInfo>();
+        const { controller, downloadUpdate } = createController();
+        downloadUpdate.mockReturnValueOnce(deferredDownload.promise);
+
+        await controller.initialize();
+        await controller.checkNow('manual');
+        const downloadPromise = controller.download();
+        await Promise.resolve();
+
+        expect(controller.getState().status).toBe('downloading');
+        await controller.setChannel('nightly');
+
+        deferredDownload.resolve(availableUpdate);
+        await expect(downloadPromise).resolves.toBe(true);
+
+        expect(controller.getState()).toMatchObject({
+            status: 'idle',
+            channel: 'nightly',
+            downloadedUpdate: null,
+            downloadProgress: null,
+            error: null,
+        });
+    });
+
+    it('does not let stale download failure overwrite a changed channel', async () => {
+        const deferredDownload = createDeferred<AppUpdateInfo>();
+        const { controller, downloadUpdate } = createController();
+        downloadUpdate.mockReturnValueOnce(deferredDownload.promise);
+
+        await controller.initialize();
+        await controller.checkNow('manual');
+        const downloadPromise = controller.download();
+        await Promise.resolve();
+
+        expect(controller.getState().status).toBe('downloading');
+        await controller.setChannel('nightly');
+
+        deferredDownload.reject(new Error('download failed'));
+        await expect(downloadPromise).resolves.toBe(false);
+
+        expect(controller.getState()).toMatchObject({
+            status: 'idle',
+            channel: 'nightly',
+            downloadedUpdate: null,
+            downloadProgress: null,
+            error: null,
+        });
     });
 
     it('persists auto-check changes', async () => {

--- a/apps/desktop/tests/services/AppUpdateService/state.test.ts
+++ b/apps/desktop/tests/services/AppUpdateService/state.test.ts
@@ -213,6 +213,51 @@ describe('AppUpdateService state reducer', () => {
         });
     });
 
+    it('ignores stale download completion after the user switches channels', () => {
+        const switched = reduceAppUpdateState(
+            {
+                ...createInitialAppUpdateState(),
+                status: 'idle',
+                channel: 'nightly',
+                availableUpdate: null,
+                downloadedUpdate: null,
+                downloadProgress: null,
+            },
+            {
+                type: 'download-completed',
+                update: availableUpdate.update,
+            }
+        );
+
+        expect(switched).toMatchObject({
+            status: 'idle',
+            channel: 'nightly',
+            downloadedUpdate: null,
+            downloadProgress: null,
+        });
+    });
+
+    it('ignores stale failures after the user leaves an in-flight updater operation', () => {
+        const switched = reduceAppUpdateState(
+            {
+                ...createInitialAppUpdateState(),
+                status: 'idle',
+                channel: 'nightly',
+                error: null,
+            },
+            {
+                type: 'failed',
+                error: 'download failed',
+            }
+        );
+
+        expect(switched).toMatchObject({
+            status: 'idle',
+            channel: 'nightly',
+            error: null,
+        });
+    });
+
     it('records installing and failed states', () => {
         const installing = reduceAppUpdateState(createInitialAppUpdateState(), {
             type: 'install-started',


### PR DESCRIPTION
## Summary

Fixes a stale updater race where an in-flight download could finish or fail after the user switched update channels. The old async result was still applied to the new channel state, which could incorrectly show a downloaded package or an error for a channel the user had already left.

The reducer now only accepts download completion while the updater is still downloading, and only accepts failures while a check, download, or install operation is active. Controller tests cover both stale success and stale failure after channel changes.

## Related issue or RFC

- Related to #270

## AI assistance disclosure

- Tool(s) used: local development assistant
- Scope of assistance: bug discovery, test-first patch, local verification, and PR preparation
- Human review or rewrite performed: reviewed the diff and command outputs before submission
- Architecture or boundary impact: no architecture or boundary changes; reducer behavior only

## Testing evidence

- `corepack pnpm --dir apps/desktop exec vitest run --configLoader runner tests/services/AppUpdateService/state.test.ts tests/services/AppUpdateService/service.test.ts` passed: 2 files, 23 tests
- `corepack pnpm --dir apps/desktop exec eslint src/services/AppUpdateService/state.ts tests/services/AppUpdateService/state.test.ts tests/services/AppUpdateService/service.test.ts` passed
- `corepack pnpm --dir apps/desktop exec prettier --check src/services/AppUpdateService/state.ts tests/services/AppUpdateService/state.test.ts tests/services/AppUpdateService/service.test.ts` passed
- `corepack pnpm --dir apps/desktop run test:typecheck` passed

`pnpm test:pr` was not run directly because this machine does not expose a direct `pnpm` shim to nested package scripts; the focused checks above were run through `corepack pnpm`.

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: none
- database baseline or migration impact: none
- release or packaging impact: none

## Screenshots or recordings

Not included; behavior is covered by reducer and controller tests.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [x] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [x] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.