### PR TITLE
fix(agent-service): avoid ambiguous tool log restore

### DIFF
--- a/apps/desktop/src/database/queries/messages.ts
+++ b/apps/desktop/src/database/queries/messages.ts
@@ -44,6 +44,26 @@ function toNamespacedToolName(toolLog: ToolLogHistoryRow): string {
     return toolLog.tool_name;
 }
 
+export function findUnambiguousToolLogByStoredReference(
+    toolLogByIdentity: ReadonlyMap<string, ToolLogHistoryRow>,
+    toolLogId: number | null,
+    toolLogKind?: ToolLogHistoryRow['source'] | null
+): ToolLogHistoryRow | undefined {
+    if (toolLogId === null) {
+        return undefined;
+    }
+
+    if (toolLogKind) {
+        return toolLogByIdentity.get(`${toolLogKind}:${toolLogId}`);
+    }
+
+    const matches = (['mcp', 'builtin'] as const)
+        .map((source) => toolLogByIdentity.get(`${source}:${toolLogId}`))
+        .filter((toolLog): toolLog is ToolLogHistoryRow => Boolean(toolLog));
+
+    return matches.length === 1 ? matches[0] : undefined;
+}
+
 function buildMessageRow(
     row: MessageEntity,
     attachments: MessageAttachmentRow[],
@@ -168,11 +188,11 @@ export const findMessagesBySessionId = async (sessionId: number): Promise<Messag
         }
 
         if (row.role === 'tool_result') {
-            const toolSource = row.tool_log_kind ?? 'mcp';
-            const resolvedById =
-                row.tool_log_id !== null
-                    ? toolLogByIdentity.get(`${toolSource}:${row.tool_log_id}`)
-                    : undefined;
+            const resolvedById = findUnambiguousToolLogByStoredReference(
+                toolLogByIdentity,
+                row.tool_log_id,
+                row.tool_log_kind
+            );
             if (resolvedById) {
                 removeQueuedToolLog(resolvedById);
             }

--- a/apps/desktop/src/services/AgentService/session/transport.ts
+++ b/apps/desktop/src/services/AgentService/session/transport.ts
@@ -3,6 +3,7 @@
 import {
     findMessagesBySessionId,
     findToolLogRowsBySessionId,
+    findUnambiguousToolLogByStoredReference,
     type ToolLogHistoryRow,
 } from '@database/queries/messages';
 
@@ -164,11 +165,11 @@ export async function loadSessionTransportMessages(options: {
         }
 
         if (row.role === 'tool_result') {
-            const toolSource = row.tool_log_kind ?? 'mcp';
-            const toolLog =
-                row.tool_log_id !== null
-                    ? toolLogByIdentity.get(`${toolSource}:${row.tool_log_id}`)
-                    : undefined;
+            const toolLog = findUnambiguousToolLogByStoredReference(
+                toolLogByIdentity,
+                row.tool_log_id,
+                row.tool_log_kind
+            );
             const resolvedToolName =
                 row.tool_name ?? (toolLog ? toTransportToolName(toolLog) : undefined);
             const pendingToolCall = takePendingResultToolCall(

--- a/apps/desktop/tests/database/messages.test.ts
+++ b/apps/desktop/tests/database/messages.test.ts
@@ -1,0 +1,67 @@
+import {
+    findUnambiguousToolLogByStoredReference,
+    type ToolLogHistoryRow,
+} from '@database/queries/messages';
+import { describe, expect, it } from 'vitest';
+
+const BASE_TIME = '2026-05-31T10:00:00.000Z';
+
+function createToolLog(overrides: Partial<ToolLogHistoryRow>): ToolLogHistoryRow {
+    return {
+        source: 'builtin',
+        log_id: 1,
+        tool_call_id: 'call_1',
+        tool_name: 'bash',
+        tool_input: '{}',
+        message_id: 1,
+        created_at: BASE_TIME,
+        tool_status: 'success',
+        tool_duration_ms: 1,
+        server_id: null,
+        ...overrides,
+    };
+}
+
+describe('message query tool log references', () => {
+    it('does not treat a missing tool log kind as MCP when ids collide across log tables', () => {
+        const builtInLog = createToolLog({
+            source: 'builtin',
+            log_id: 7,
+            tool_call_id: 'call_builtin',
+        });
+        const mcpLog = createToolLog({
+            source: 'mcp',
+            log_id: 7,
+            tool_call_id: 'call_mcp',
+            tool_name: 'lookup',
+            server_id: 42,
+        });
+        const toolLogsByIdentity = new Map([
+            [`${builtInLog.source}:${builtInLog.log_id}`, builtInLog],
+            [`${mcpLog.source}:${mcpLog.log_id}`, mcpLog],
+        ]);
+
+        expect(
+            findUnambiguousToolLogByStoredReference(toolLogsByIdentity, 7, null)
+        ).toBeUndefined();
+        expect(findUnambiguousToolLogByStoredReference(toolLogsByIdentity, 7, 'builtin')).toBe(
+            builtInLog
+        );
+        expect(findUnambiguousToolLogByStoredReference(toolLogsByIdentity, 7, 'mcp')).toBe(mcpLog);
+    });
+
+    it('keeps legacy references when only one log table has the stored id', () => {
+        const builtInLog = createToolLog({
+            source: 'builtin',
+            log_id: 8,
+            tool_call_id: 'call_builtin',
+        });
+        const toolLogsByIdentity = new Map([
+            [`${builtInLog.source}:${builtInLog.log_id}`, builtInLog],
+        ]);
+
+        expect(findUnambiguousToolLogByStoredReference(toolLogsByIdentity, 8, null)).toBe(
+            builtInLog
+        );
+    });
+});

--- a/apps/desktop/tests/services/AgentService/session-transport.test.ts
+++ b/apps/desktop/tests/services/AgentService/session-transport.test.ts
@@ -10,10 +10,15 @@ const mocks = vi.hoisted(() => ({
     findToolLogRowsBySessionId: vi.fn<() => Promise<ToolLogHistoryRow[]>>(),
 }));
 
-vi.mock('@database/queries/messages', () => ({
-    findMessagesBySessionId: mocks.findMessagesBySessionId,
-    findToolLogRowsBySessionId: mocks.findToolLogRowsBySessionId,
-}));
+vi.mock('@database/queries/messages', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@database/queries/messages')>();
+
+    return {
+        ...actual,
+        findMessagesBySessionId: mocks.findMessagesBySessionId,
+        findToolLogRowsBySessionId: mocks.findToolLogRowsBySessionId,
+    };
+});
 
 function createMessageRow(overrides: Partial<MessageRow>): MessageRow {
     return {
@@ -34,6 +39,22 @@ function createMessageRow(overrides: Partial<MessageRow>): MessageRow {
         tool_log_kind: null,
         created_at: BASE_TIME,
         updated_at: BASE_TIME,
+        ...overrides,
+    };
+}
+
+function createToolLog(overrides: Partial<ToolLogHistoryRow>): ToolLogHistoryRow {
+    return {
+        source: 'builtin',
+        log_id: 1,
+        tool_call_id: 'call_1',
+        tool_name: 'bash',
+        tool_input: '{}',
+        message_id: 1,
+        created_at: BASE_TIME,
+        tool_status: 'success',
+        tool_duration_ms: 1,
+        server_id: null,
         ...overrides,
     };
 }
@@ -154,6 +175,112 @@ describe('AgentService session transport', () => {
             {
                 role: 'assistant',
                 content: '未执行删除。',
+            },
+        ]);
+    });
+
+    it('does not resolve legacy tool results to MCP when built-in and MCP log ids collide', async () => {
+        mocks.findToolLogRowsBySessionId.mockResolvedValue([
+            createToolLog({
+                source: 'builtin',
+                log_id: 1,
+                tool_call_id: 'call_builtin',
+                tool_name: 'bash',
+                tool_input: JSON.stringify({ command: 'echo builtin' }),
+                message_id: 31,
+                server_id: null,
+            }),
+            createToolLog({
+                source: 'mcp',
+                log_id: 1,
+                tool_call_id: 'call_mcp',
+                tool_name: 'lookup',
+                tool_input: JSON.stringify({ query: 'mcp' }),
+                message_id: 31,
+                server_id: 9,
+            }),
+        ]);
+        mocks.findMessagesBySessionId.mockResolvedValue([
+            createMessageRow({
+                id: 30,
+                role: 'user',
+                content: 'run both tools',
+            }),
+            createMessageRow({
+                id: 31,
+                role: 'tool_call',
+                content: '',
+                tool_call_id: 'call_builtin',
+                tool_name: 'builtin__bash',
+                tool_input: JSON.stringify({ command: 'echo builtin' }),
+            }),
+            createMessageRow({
+                id: 31,
+                role: 'tool_call',
+                content: '',
+                tool_call_id: 'call_mcp',
+                tool_name: 'mcp__9__lookup',
+                tool_input: JSON.stringify({ query: 'mcp' }),
+            }),
+            createMessageRow({
+                id: 32,
+                role: 'tool_result',
+                content: 'builtin result',
+                tool_log_id: 1,
+                tool_log_kind: null,
+            }),
+            createMessageRow({
+                id: 33,
+                role: 'tool_result',
+                content: 'mcp result',
+                tool_log_id: 1,
+                tool_log_kind: null,
+            }),
+            createMessageRow({
+                id: 34,
+                role: 'assistant',
+                content: 'done',
+            }),
+        ]);
+
+        const messages = await loadSessionTransportMessages({ sessionId: 1 });
+
+        expect(messages).toEqual([
+            {
+                role: 'user',
+                content: 'run both tools',
+            },
+            {
+                role: 'assistant',
+                content: '',
+                tool_calls: [
+                    {
+                        id: 'call_builtin',
+                        name: 'builtin__bash',
+                        arguments: JSON.stringify({ command: 'echo builtin' }),
+                    },
+                    {
+                        id: 'call_mcp',
+                        name: 'mcp__9__lookup',
+                        arguments: JSON.stringify({ query: 'mcp' }),
+                    },
+                ],
+            },
+            {
+                role: 'tool',
+                tool_call_id: 'call_builtin',
+                name: 'builtin__bash',
+                content: 'builtin result',
+            },
+            {
+                role: 'tool',
+                tool_call_id: 'call_mcp',
+                name: 'mcp__9__lookup',
+                content: 'mcp result',
+            },
+            {
+                role: 'assistant',
+                content: 'done',
             },
         ]);
     });


### PR DESCRIPTION
## Summary

- Resolves stored tool log references only when the source/id pair is known or the legacy id is unique across log tables.
- Falls back to pending tool-call order when legacy `tool_result` rows have no source kind and MCP/built-in numeric log ids collide.
- Adds regression coverage for database reference matching and restored model-facing transport history.

## Related issue or RFC

- Closes #321

## AI assistance disclosure

- Tool(s) used: local development assistant
- Scope of assistance: Investigated the restore path, implemented the fix, added regression tests, and ran local validation commands.
- Human review or rewrite performed: Local diff reviewed before push.
- Architecture or boundary impact: Touches AgentService session history restore and database message query matching only; no schema change or new cross-boundary abstraction.

## Testing evidence

- `corepack pnpm --dir apps/desktop exec vitest run --configLoader runner tests/services/AgentService/session-transport.test.ts tests/database/messages.test.ts`: passed, 2 files and 5 tests.
- `corepack pnpm --dir apps/desktop exec eslint src/database/queries/messages.ts src/services/AgentService/session/transport.ts tests/services/AgentService/session-transport.test.ts tests/database/messages.test.ts`: passed.
- `corepack pnpm --dir apps/desktop exec prettier --check src/database/queries/messages.ts src/services/AgentService/session/transport.ts tests/services/AgentService/session-transport.test.ts tests/database/messages.test.ts`: passed.
- `corepack pnpm --dir apps/desktop run test:typecheck`: passed after refreshing dependencies with `corepack pnpm install --frozen-lockfile`.
- `git diff --check`: passed.

Did you follow TDD (test-first) for feature and fix work? Strongly recommended. See [docs/testing/testing.md](../docs/testing/testing.md).

```text
pnpm test:pr
pnpm test:coverage:rust
pnpm test:e2e
```

## Risk notes

- AgentService/runtime/MCP/schema impact: Restored history now avoids guessing MCP for legacy null-kind tool results when the numeric id is ambiguous across log tables.
- database baseline or migration impact: None.
- release or packaging impact: None.

## Screenshots or recordings

Not applicable; no UI changes.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [ ] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [ ] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [ ] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [ ] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.