### PR TITLE
fix(quicksearch): reset context menu close state

### DIFF
--- a/apps/desktop/src/composables/useContextMenu.ts
+++ b/apps/desktop/src/composables/useContextMenu.ts
@@ -15,7 +15,8 @@ type ContextMenuItemsSource = ContextMenuItem[] | (() => ContextMenuItem[]);
 
 export function useContextMenu<T = void>(
     items: ContextMenuItemsSource,
-    onSelect: (key: string, context: T) => void
+    onSelect: (key: string, context: T) => void,
+    onClose?: () => void
 ) {
     const context = ref<T | undefined>(undefined) as { value: T | undefined };
     let mountedApp: App | null = null;
@@ -23,7 +24,8 @@ export function useContextMenu<T = void>(
     let keydownHandler: ((e: KeyboardEvent) => void) | null = null;
     let activeIndex = 0;
 
-    const cleanup = () => {
+    const cleanup = (options: { notify?: boolean } = {}) => {
+        const hadMenu = keydownHandler !== null || mountedApp !== null || container !== null;
         if (keydownHandler) {
             document.removeEventListener('keydown', keydownHandler, true);
             keydownHandler = null;
@@ -37,6 +39,10 @@ export function useContextMenu<T = void>(
             container = null;
         }
         activeIndex = 0;
+
+        if (hadMenu && options.notify !== false) {
+            onClose?.();
+        }
     };
 
     /** 获取当前菜单项元素列表。 */
@@ -78,7 +84,7 @@ export function useContextMenu<T = void>(
 
     const open = (event: MouseEvent, ctx?: T) => {
         event.preventDefault();
-        cleanup();
+        cleanup({ notify: false });
 
         context.value = ctx;
         activeIndex = 0;

--- a/apps/desktop/src/views/SearchView/components/QuickSearchPanel/composables/useQuickSearchLogic.ts
+++ b/apps/desktop/src/views/SearchView/components/QuickSearchPanel/composables/useQuickSearchLogic.ts
@@ -381,6 +381,9 @@ function useQuickSearchFlow(
         async (key, item) => {
             isContextMenuOpen.value = false;
             await handleContextMenuAction(key, item);
+        },
+        () => {
+            isContextMenuOpen.value = false;
         }
     );
 

--- a/apps/desktop/tests/composables/SearchView/QuickSearchPanel/useQuickSearchLogic.test.ts
+++ b/apps/desktop/tests/composables/SearchView/QuickSearchPanel/useQuickSearchLogic.test.ts
@@ -5,36 +5,60 @@ import { ref } from 'vue';
 
 import { useQuickSearchLogic } from '@/views/SearchView/components/QuickSearchPanel/composables/useQuickSearchLogic';
 
-const { assetLoaderMock, clickStatsMock, layoutMock } = vi.hoisted(() => ({
-    assetLoaderMock: {
-        iconMap: { value: {} as Record<string, string> },
-        imagePreviewMap: { value: {} as Record<string, string> },
-        isImageItem: vi.fn(() => false),
-        getItemHoverTitle: vi.fn((item: QuickShortcutItem) => item.path),
-        handleScroll: vi.fn(),
-        scheduleIconLoad: vi.fn(),
-        scheduleImageLoad: vi.fn(),
-        flushPendingLoads: vi.fn(),
-        resetLoadingState: vi.fn(),
-        pruneIconMaps: vi.fn(),
-    },
-    clickStatsMock: {
-        rankResults: vi.fn(async (_query: string, items: QuickShortcutItem[]) => items),
-        recordClick: vi.fn(),
-    },
-    layoutMock: {
-        scrollStyle: { value: {} },
-        gridStyle: { value: {} },
-        gridColumns: { value: 3 },
-        gridGap: { value: 8 },
-        selectionMaxHeight: { value: 320 },
-        moveSelection: vi.fn(),
-        setVisibleRows: vi.fn(),
-        syncLayout: vi.fn().mockResolvedValue(undefined),
-        updateLayout: vi.fn(),
-        resetLayoutState: vi.fn(),
-    },
-}));
+const {
+    assetLoaderMock,
+    clickStatsMock,
+    contextMenuCloseHandler,
+    contextMenuOpenMock,
+    layoutMock,
+    useContextMenuMock,
+} = vi.hoisted(() => {
+    const closeHandler = {
+        current: null as null | (() => void),
+    };
+    const openMock = vi.fn();
+    const closeMock = vi.fn();
+
+    return {
+        assetLoaderMock: {
+            iconMap: { value: {} as Record<string, string> },
+            imagePreviewMap: { value: {} as Record<string, string> },
+            isImageItem: vi.fn(() => false),
+            getItemHoverTitle: vi.fn((item: QuickShortcutItem) => item.path),
+            handleScroll: vi.fn(),
+            scheduleIconLoad: vi.fn(),
+            scheduleImageLoad: vi.fn(),
+            flushPendingLoads: vi.fn(),
+            resetLoadingState: vi.fn(),
+            pruneIconMaps: vi.fn(),
+        },
+        clickStatsMock: {
+            rankResults: vi.fn(async (_query: string, items: QuickShortcutItem[]) => items),
+            recordClick: vi.fn(),
+        },
+        layoutMock: {
+            scrollStyle: { value: {} },
+            gridStyle: { value: {} },
+            gridColumns: { value: 3 },
+            gridGap: { value: 8 },
+            selectionMaxHeight: { value: 320 },
+            moveSelection: vi.fn(),
+            setVisibleRows: vi.fn(),
+            syncLayout: vi.fn().mockResolvedValue(undefined),
+            updateLayout: vi.fn(),
+            resetLayoutState: vi.fn(),
+        },
+        contextMenuCloseHandler: closeHandler,
+        contextMenuOpenMock: openMock,
+        useContextMenuMock: vi.fn((_items: unknown, _onSelect: unknown, onClose?: () => void) => {
+            closeHandler.current = onClose ?? null;
+            return {
+                open: openMock,
+                close: closeMock,
+            };
+        }),
+    };
+});
 
 vi.mock('@/views/SearchView/components/QuickSearchPanel/composables/useAssetLoader', () => ({
     useAssetLoader: vi.fn(() => assetLoaderMock),
@@ -51,6 +75,10 @@ vi.mock(
         useQuickSearchClickStats: vi.fn(() => clickStatsMock),
     })
 );
+
+vi.mock('@composables/useContextMenu', () => ({
+    useContextMenu: useContextMenuMock,
+}));
 
 function createShortcut(name: string, path = `D:/${name}.lnk`): QuickShortcutItem {
     return {
@@ -96,6 +124,7 @@ describe('useQuickSearchLogic', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         vi.useFakeTimers();
+        contextMenuCloseHandler.current = null;
         clickStatsMock.rankResults.mockImplementation(async (_query, items) => items);
         delete (window as Window & { __TOUCHAI_E2E__?: unknown }).__TOUCHAI_E2E__;
     });
@@ -661,6 +690,67 @@ describe('useQuickSearchLogic', () => {
         mounted.result.handleContextMenu(event, 0);
 
         expect(mounted.result.highlightedIndex.value).toBe(0);
+
+        mounted.unmount();
+    });
+
+    it('resets context menu state when the shared menu closes itself', async () => {
+        const open = ref(false);
+        const searchQuery = ref('');
+        const quickSearchDeps = {
+            quickSearch: {
+                getStatus: vi.fn().mockResolvedValue({
+                    provider: 'everything',
+                    db_loaded: true,
+                    index_warmed: true,
+                    last_refresh_ms: null,
+                    last_error: null,
+                }),
+                prepareIndex: vi.fn().mockResolvedValue(undefined),
+                searchShortcuts: vi
+                    .fn()
+                    .mockResolvedValue(createSearchResult([createShortcut('App')])),
+            },
+            window: {
+                hideSearchWindow: vi.fn().mockResolvedValue(undefined),
+            },
+            openPath: vi.fn().mockResolvedValue(undefined),
+        };
+
+        const mounted = await mountComposable(() =>
+            useQuickSearchLogic(
+                {
+                    open,
+                    searchQuery,
+                    enabled: ref(true),
+                    emitOpenUpdate: (value) => {
+                        open.value = value;
+                    },
+                },
+                quickSearchDeps
+            )
+        );
+
+        searchQuery.value = 'app';
+        mounted.result.triggerSearch('app');
+        await vi.advanceTimersByTimeAsync(80);
+        await flushAsyncWork();
+
+        mounted.result.handleContextMenu(
+            new MouseEvent('contextmenu', {
+                clientX: 100,
+                clientY: 100,
+                bubbles: true,
+            }),
+            0
+        );
+
+        expect(mounted.result.isContextMenuOpen.value).toBe(true);
+        expect(contextMenuOpenMock).toHaveBeenCalled();
+
+        contextMenuCloseHandler.current?.();
+
+        expect(mounted.result.isContextMenuOpen.value).toBe(false);
 
         mounted.unmount();
     });


### PR DESCRIPTION
## Summary

- Adds a close callback to the shared context menu composable so callers can observe menu-owned close paths.
- Resets QuickSearch `isContextMenuOpen` when the shared menu closes itself through Escape or outside-click behavior.
- Adds regression coverage for the QuickSearch state handoff.

## Related issue or RFC

- Closes #323

## AI assistance disclosure

- Tool(s) used: local development assistant
- Scope of assistance: Investigated the QuickSearch context menu state path, implemented the fix, added a regression test, and ran local validation commands.
- Human review or rewrite performed: Local diff reviewed before push.
- Architecture or boundary impact: Touches shared context menu close notification and QuickSearch state handling only; no schema, runtime, MCP, or persistence change.

## Testing evidence

- `corepack pnpm --dir apps/desktop exec vitest run --configLoader runner tests/composables/SearchView/QuickSearchPanel/useQuickSearchLogic.test.ts`: passed, 1 file and 13 tests.
- `corepack pnpm --dir apps/desktop exec eslint src/composables/useContextMenu.ts src/views/SearchView/components/QuickSearchPanel/composables/useQuickSearchLogic.ts tests/composables/SearchView/QuickSearchPanel/useQuickSearchLogic.test.ts`: passed.
- `corepack pnpm --dir apps/desktop exec prettier --check src/composables/useContextMenu.ts src/views/SearchView/components/QuickSearchPanel/composables/useQuickSearchLogic.ts tests/composables/SearchView/QuickSearchPanel/useQuickSearchLogic.test.ts`: passed.
- `corepack pnpm --dir apps/desktop run test:typecheck`: passed.
- `git diff --check`: passed.

Did you follow TDD (test-first) for feature and fix work? Strongly recommended. See [docs/testing/testing.md](../docs/testing/testing.md).

```text
pnpm test:pr
pnpm test:coverage:rust
pnpm test:e2e
```

## Risk notes

- AgentService/runtime/MCP/schema impact: None.
- database baseline or migration impact: None.
- release or packaging impact: None.

## Screenshots or recordings

Not applicable; no visual change.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [ ] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [ ] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [ ] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [ ] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.