### PR TITLE
fix(agent): abort stale startup requests

### DIFF
--- a/apps/desktop/src/composables/agent/useAgent.ts
+++ b/apps/desktop/src/composables/agent/useAgent.ts
@@ -98,6 +98,15 @@ export function useAgent(options: UseAiRequestOptions = {}) {
         isStartingTask.value = false;
     }
 
+    function abortTaskStartPending() {
+        const controller = startupAbortController;
+
+        startingRequestId = null;
+        startupAbortController = null;
+        isStartingTask.value = false;
+        controller?.abort();
+    }
+
     /**
      * 让当前页面停止接收旧请求的后续结果。
      */
@@ -105,9 +114,7 @@ export function useAgent(options: UseAiRequestOptions = {}) {
         // 页面一旦切会话、清空或卸载，旧请求后续即使完成，
         // 也不应该再驱动当前页面的 onComplete / onError 链路。
         requestId += 1;
-        startingRequestId = null;
-        startupAbortController = null;
-        isStartingTask.value = false;
+        abortTaskStartPending();
         currentTurn.value = null;
     }
 
@@ -288,7 +295,8 @@ export function useAgent(options: UseAiRequestOptions = {}) {
     function cancel() {
         if (!attachedTaskId.value) {
             if (startupAbortController) {
-                startupAbortController.abort();
+                requestId += 1;
+                abortTaskStartPending();
             }
             return;
         }

--- a/apps/desktop/tests/composables/useAgent.test.ts
+++ b/apps/desktop/tests/composables/useAgent.test.ts
@@ -49,6 +49,21 @@ function createTaskSnapshot(taskId: string) {
     };
 }
 
+function deferred<T>() {
+    let resolve!: (value: T) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+
+    return {
+        promise,
+        resolve,
+        reject,
+    };
+}
+
 describe('useAgent', () => {
     beforeEach(() => {
         vi.clearAllMocks();
@@ -87,6 +102,72 @@ describe('useAgent', () => {
             title: 'TouchAI - 请求失败',
             body: 'startup failed',
         });
+
+        mounted.unmount();
+    });
+
+    it('aborts pending task startup when the session is cleared before attach', async () => {
+        const startTask = deferred<{
+            taskId: string;
+            sessionId: number;
+            completion: Promise<never>;
+        }>();
+        let startupSignal: AbortSignal | undefined;
+        sessionTaskCenterMock.startTask.mockImplementation((options) => {
+            startupSignal = options.signal;
+            return startTask.promise;
+        });
+
+        const mounted = await mountComposable(() => useAgent());
+        const sendPromise = mounted.result.sendRequest('hello');
+
+        expect(startupSignal?.aborted).toBe(false);
+
+        mounted.result.clearSession();
+
+        expect(startupSignal?.aborted).toBe(true);
+        expect(mounted.result.isLoading.value).toBe(false);
+
+        startTask.resolve({
+            taskId: 'task-1',
+            sessionId: 1,
+            completion: new Promise<never>(() => undefined),
+        });
+        await sendPromise;
+
+        expect(sessionTaskCenterMock.subscribeTask).not.toHaveBeenCalled();
+
+        mounted.unmount();
+    });
+
+    it('invalidates pending task startup when cancelled before attach', async () => {
+        const startTask = deferred<{
+            taskId: string;
+            sessionId: number;
+            completion: Promise<never>;
+        }>();
+        let startupSignal: AbortSignal | undefined;
+        sessionTaskCenterMock.startTask.mockImplementation((options) => {
+            startupSignal = options.signal;
+            return startTask.promise;
+        });
+
+        const mounted = await mountComposable(() => useAgent());
+        const sendPromise = mounted.result.sendRequest('hello');
+
+        mounted.result.cancel();
+
+        expect(startupSignal?.aborted).toBe(true);
+        expect(mounted.result.isLoading.value).toBe(false);
+
+        startTask.resolve({
+            taskId: 'task-1',
+            sessionId: 1,
+            completion: new Promise<never>(() => undefined),
+        });
+        await sendPromise;
+
+        expect(sessionTaskCenterMock.subscribeTask).not.toHaveBeenCalled();
 
         mounted.unmount();
     });


### PR DESCRIPTION
## Summary

- Aborts pending task startup when request observation is invalidated by clear, session switch, or unmount.
- Invalidates startup cancellation so a late `startTask()` resolution cannot attach a stale task view.
- Adds regression coverage for clear-session and cancel-before-attach startup races.

## Related issue or RFC

- Closes #325

## AI assistance disclosure

- Tool(s) used: local development assistant
- Scope of assistance: Investigated the startup race, implemented the fix, added regression tests, and ran local validation commands.
- Human review or rewrite performed: Local diff reviewed before push.
- Architecture or boundary impact: Touches foreground agent view startup state only; no schema, MCP, persistence, or provider protocol change.

## Testing evidence

- `corepack pnpm --dir apps/desktop exec vitest run --configLoader runner tests/composables/useAgent.test.ts`: passed, 1 file and 4 tests.
- `corepack pnpm --dir apps/desktop exec eslint src/composables/agent/useAgent.ts tests/composables/useAgent.test.ts`: passed.
- `corepack pnpm --dir apps/desktop exec prettier --check src/composables/agent/useAgent.ts tests/composables/useAgent.test.ts`: passed.
- `corepack pnpm --dir apps/desktop run test:typecheck`: passed.
- `git diff --check`: passed.

Did you follow TDD (test-first) for feature and fix work? Strongly recommended. See [docs/testing/testing.md](../docs/testing/testing.md).

```text
pnpm test:pr
pnpm test:coverage:rust
pnpm test:e2e
```

## Risk notes

- AgentService/runtime/MCP/schema impact: Uses existing startup AbortSignal path earlier; running attached tasks still keep the prior detach-and-continue behavior.
- database baseline or migration impact: None.
- release or packaging impact: None.

## Screenshots or recordings

Not applicable; no UI change.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [ ] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [ ] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [ ] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [ ] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.