### PR TITLE
fix(scheduler): clone reactive trigger input

### DIFF
--- a/apps/desktop/src/services/SchedulerService/scheduler.ts
+++ b/apps/desktop/src/services/SchedulerService/scheduler.ts
@@ -34,7 +34,11 @@ export interface UpdateScheduledTaskInput {
 
 function cloneValue<T>(value: T): T {
     if (typeof structuredClone === 'function') {
-        return structuredClone(value);
+        try {
+            return structuredClone(value);
+        } catch {
+            // Scheduler inputs can come from Vue state; JSON fallback handles serializable proxies.
+        }
     }
 
     return JSON.parse(JSON.stringify(value)) as T;

--- a/apps/desktop/tests/services/SchedulerService/scheduler.test.ts
+++ b/apps/desktop/tests/services/SchedulerService/scheduler.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { reactive } from 'vue';
+
+import type { IntervalTrigger, ScheduleTrigger } from '@/services/SchedulerService';
+import { TaskScheduler } from '@/services/SchedulerService';
+
+describe('TaskScheduler', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('accepts reactive trigger objects when adding a scheduled task', async () => {
+        const scheduler = new TaskScheduler();
+        const trigger = reactive<IntervalTrigger>({
+            type: 'interval',
+            milliseconds: 1_000,
+        });
+
+        const task = await scheduler.addTask({
+            name: 'Daily digest',
+            prompt: 'Summarize recent work',
+            trigger,
+        });
+
+        expect(task.trigger).toEqual({
+            type: 'interval',
+            milliseconds: 1_000,
+        });
+
+        trigger.milliseconds = 2_000;
+
+        expect(scheduler.getTask(task.id)?.trigger).toEqual({
+            type: 'interval',
+            milliseconds: 1_000,
+        });
+
+        await scheduler.removeTask(task.id);
+    });
+
+    it('accepts reactive trigger objects when updating a scheduled task', async () => {
+        const scheduler = new TaskScheduler();
+        const task = await scheduler.addTask({
+            name: 'Daily digest',
+            prompt: 'Summarize recent work',
+            trigger: {
+                type: 'interval',
+                milliseconds: 1_000,
+            },
+        });
+        const trigger = reactive<IntervalTrigger>({
+            type: 'interval',
+            milliseconds: 2_000,
+        });
+
+        const updatedTask = await scheduler.updateTask(task.id, {
+            trigger: trigger as ScheduleTrigger,
+        });
+
+        expect(updatedTask?.trigger).toEqual({
+            type: 'interval',
+            milliseconds: 2_000,
+        });
+
+        trigger.milliseconds = 3_000;
+
+        expect(scheduler.getTask(task.id)?.trigger).toEqual({
+            type: 'interval',
+            milliseconds: 2_000,
+        });
+
+        await scheduler.removeTask(task.id);
+    });
+});


### PR DESCRIPTION
## Summary

- Falls back to JSON cloning when scheduler trigger snapshots cannot be cloned with `structuredClone()`.
- Keeps scheduled task trigger snapshots isolated from later mutations to the source object.
- Adds regression coverage for reactive trigger input on add and update paths.

## Related issue or RFC

- Closes #327

## AI assistance disclosure

- Tool(s) used: local development assistant
- Scope of assistance: Investigated scheduler trigger cloning, implemented the fallback, added regression tests, and ran local validation commands.
- Human review or rewrite performed: Local diff reviewed before push.
- Architecture or boundary impact: Touches in-memory scheduler input cloning only; no schema, AgentService runtime, MCP, or provider protocol change.

## Testing evidence

- `corepack pnpm --dir apps/desktop exec vitest run --configLoader runner tests/services/SchedulerService/scheduler.test.ts`: passed, 1 file and 2 tests.
- `corepack pnpm --dir apps/desktop exec eslint src/services/SchedulerService/scheduler.ts tests/services/SchedulerService/scheduler.test.ts`: passed.
- `corepack pnpm --dir apps/desktop exec prettier --check src/services/SchedulerService/scheduler.ts tests/services/SchedulerService/scheduler.test.ts`: passed.
- `corepack pnpm --dir apps/desktop run test:typecheck`: passed.
- `git diff --check`: passed.

Did you follow TDD (test-first) for feature and fix work? Strongly recommended. See [docs/testing/testing.md](../docs/testing/testing.md).

```text
pnpm test:pr
pnpm test:coverage:rust
pnpm test:e2e
```

## Risk notes

- AgentService/runtime/MCP/schema impact: None.
- database baseline or migration impact: None.
- release or packaging impact: None.

## Screenshots or recordings

Not applicable; no UI change.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [ ] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [ ] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [ ] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [ ] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.