### PR TITLE
fix(search): ignore stale surface shown events

### DIFF
--- a/apps/desktop/src/views/SearchView/composables/useSearchPage.ts
+++ b/apps/desktop/src/views/SearchView/composables/useSearchPage.ts
@@ -627,7 +627,12 @@ export function useSearchPageLifecycle(options: UseSearchPageLifecycleOptions) {
         unlistenSearchSurfaceShown = await eventService.on(
             AppEvent.SEARCH_SURFACE_SHOWN,
             async (payload) => {
-                latestSurfaceSequence = Math.max(latestSurfaceSequence, payload.sequence ?? 0);
+                const sequence = payload.sequence ?? 0;
+                if (sequence > 0 && sequence < latestSurfaceSequence) {
+                    return;
+                }
+
+                latestSurfaceSequence = Math.max(latestSurfaceSequence, sequence);
                 interactionContext.markWindowVisible();
                 handleReminderSurfaceVisible();
                 await handleSearchWindowActivated(payload.source ?? 'shortcut');

--- a/apps/desktop/tests/composables/SearchView/useSearchPage.test.ts
+++ b/apps/desktop/tests/composables/SearchView/useSearchPage.test.ts
@@ -583,6 +583,63 @@ describe('useSearchPageLifecycle', () => {
         mounted.unmount();
     });
 
+    it('ignores stale surface shown events after a newer hidden event', async () => {
+        const controller = createController();
+        const interactionContext = createSearchInteractionContext();
+        const clearSession = vi.fn().mockResolvedValue(undefined);
+        const reconcilePopupSurfaces = vi.fn().mockResolvedValue(undefined);
+        const handleShortcutAutoPaste = vi.fn().mockResolvedValue(undefined);
+        const syncWindowPinState = vi.fn().mockResolvedValue(false);
+
+        const mounted = await mountComposable(() =>
+            useSearchPageLifecycle({
+                controller: controller as never,
+                viewReady: ref(true),
+                isDragging: ref(false),
+                isPinned: ref(false),
+                interactionContext,
+                syncWindowPinState,
+                clearSession,
+                reconcilePopupSurfaces,
+                handleShortcutAutoPaste,
+            })
+        );
+
+        await flushLifecycle();
+
+        const surfaceShownHandler = eventHandlers.get(AppEvent.SEARCH_SURFACE_SHOWN);
+        const surfaceHiddenHandler = eventHandlers.get(AppEvent.SEARCH_SURFACE_HIDDEN);
+        expect(surfaceShownHandler).toBeDefined();
+        expect(surfaceHiddenHandler).toBeDefined();
+
+        await surfaceShownHandler!({ source: 'shortcut', sequence: 2 });
+        await flushLifecycle();
+        await surfaceHiddenHandler!({ sequence: 3, reason: 'manual-dismiss' });
+        await flushLifecycle();
+
+        expect(interactionContext.state.windowVisible).toBe(false);
+
+        controller.focusSearchInput.mockClear();
+        controller.loadActiveModel.mockClear();
+        clearSession.mockClear();
+        reconcilePopupSurfaces.mockClear();
+        handleShortcutAutoPaste.mockClear();
+        syncWindowPinState.mockClear();
+
+        await surfaceShownHandler!({ source: 'shortcut', sequence: 2 });
+        await flushLifecycle();
+
+        expect(interactionContext.state.windowVisible).toBe(false);
+        expect(controller.focusSearchInput).not.toHaveBeenCalled();
+        expect(controller.loadActiveModel).not.toHaveBeenCalled();
+        expect(clearSession).not.toHaveBeenCalled();
+        expect(reconcilePopupSurfaces).not.toHaveBeenCalled();
+        expect(handleShortcutAutoPaste).not.toHaveBeenCalled();
+        expect(syncWindowPinState).not.toHaveBeenCalled();
+
+        mounted.unmount();
+    });
+
     it('clears timed-out sessions when the search surface is reopened after manual dismiss', async () => {
         const controller = createController();
         const interactionContext = createSearchInteractionContext();


### PR DESCRIPTION
## Summary

Fixes a SearchView lifecycle race where an older `SEARCH_SURFACE_SHOWN` event could be processed after a newer hidden event.

- Applies the existing surface sequence stale-event guard to shown events.
- Keeps hidden state authoritative when a stale shown event arrives later.
- Adds a regression test that verifies stale shown events do not refocus, reload model state, clear sessions, reconcile popups, or run shortcut auto-paste.

## Related issue or RFC

- Fixes #331

## AI assistance disclosure

- Tool(s) used: local development assistant
- Scope of assistance: bug discovery, duplicate search, regression test, local patch, validation, and PR preparation
- Human review or rewrite performed: reviewed duplicate search results, diff, and command outputs before submission
- Architecture or boundary impact: no architecture or boundary changes; lifecycle event ordering only

## Testing evidence

- `corepack pnpm --dir apps/desktop exec vitest run --configLoader runner tests/composables/SearchView/useSearchPage.test.ts` passed: 1 file, 12 tests
- `corepack pnpm --dir apps/desktop exec eslint src/views/SearchView/composables/useSearchPage.ts tests/composables/SearchView/useSearchPage.test.ts` passed
- `corepack pnpm --dir apps/desktop exec prettier --check src/views/SearchView/composables/useSearchPage.ts tests/composables/SearchView/useSearchPage.test.ts` passed
- `corepack pnpm --dir apps/desktop run test:typecheck` passed
- `git diff --check` passed
- Full `pnpm test:pr` and local `pnpm test:e2e` were not run locally; CI is covering the broader matrix and Windows native smoke path.

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: none.
- database baseline or migration impact: none.
- release or packaging impact: none.

## Screenshots or recordings

No UI rendering change; not applicable.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [x] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [x] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.