### PR TITLE
fix(settings): roll back failed setting updates

### DIFF
--- a/apps/desktop/src/stores/settings.ts
+++ b/apps/desktop/src/stores/settings.ts
@@ -112,6 +112,15 @@ export const useSettingsStore = defineStore('settings', () => {
         };
     }
 
+    function cloneSettingsSnapshot(): GeneralSettingsData {
+        return {
+            ...settings.value,
+            searchWindowDefaultSize: {
+                ...settings.value.searchWindowDefaultSize,
+            },
+        };
+    }
+
     function applySetting(key: GeneralSettingKey, value: GeneralSettingValue): void {
         switch (key) {
             case 'global_shortcut':
@@ -293,8 +302,14 @@ export const useSettingsStore = defineStore('settings', () => {
             return;
         }
 
+        const previousSettings = cloneSettingsSnapshot();
         applySetting(key, value);
-        await setSetting({ key, value: serializeSetting(key) });
+        try {
+            await setSetting({ key, value: serializeSetting(key) });
+        } catch (error) {
+            settings.value = previousSettings;
+            throw error;
+        }
         if (broadcast) {
             await broadcastUpdate(key);
         }

--- a/apps/desktop/tests/stores/settings-language.test.ts
+++ b/apps/desktop/tests/stores/settings-language.test.ts
@@ -177,6 +177,26 @@ describe('settings language state', () => {
         expect(eventServiceMock.emit).not.toHaveBeenCalled();
     });
 
+    it('rolls back non-language setting state when persisting the update fails', async () => {
+        mockSettings({
+            output_scroll_behavior: 'follow_output',
+        });
+
+        const { useSettingsStore } = await import('@/stores/settings');
+        const store = useSettingsStore();
+        await store.initialize();
+
+        const failure = new Error('database unavailable');
+        setSettingMock.mockRejectedValueOnce(failure);
+
+        await expect(store.updateOutputScrollBehavior('stay_position')).rejects.toThrow(
+            'database unavailable'
+        );
+
+        expect(store.settings.outputScrollBehavior).toBe('follow_output');
+        expect(eventServiceMock.emit).not.toHaveBeenCalled();
+    });
+
     it('applies language changes from another window without rebroadcasting', async () => {
         mockSettings({
             language: 'zh-CN',


### PR DESCRIPTION
## Summary

Fixes a settings persistence bug where non-language general settings could update local Pinia state before the database write succeeded.

- Captures a settings snapshot before applying non-language updates.
- Restores the previous snapshot if `setSetting` rejects.
- Keeps failed writes from broadcasting a value that was not persisted.
- Adds a regression test for failed output scroll behavior persistence.

## Related issue or RFC

- Fixes #333

## AI assistance disclosure

- Tool(s) used: local development assistant
- Scope of assistance: bug discovery, duplicate search, regression test, local patch, validation, and PR preparation
- Human review or rewrite performed: reviewed duplicate search results, diff, and command outputs before submission
- Architecture or boundary impact: no architecture or boundary changes; store state rollback only

## Testing evidence

- `corepack pnpm --dir apps/desktop exec vitest run --configLoader runner tests/stores/settings-language.test.ts` passed: 1 file, 8 tests
- `corepack pnpm --dir apps/desktop exec eslint src/stores/settings.ts tests/stores/settings-language.test.ts` passed
- `corepack pnpm --dir apps/desktop exec prettier --check src/stores/settings.ts tests/stores/settings-language.test.ts` passed
- `corepack pnpm --dir apps/desktop run test:typecheck` passed
- `git diff --check` passed
- Full `pnpm test:pr` was not run locally; CI is covering the broader matrix.

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: none.
- database baseline or migration impact: none.
- release or packaging impact: none.

## Screenshots or recordings

No UI rendering change; not applicable.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [x] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [x] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.