### PR TITLE
fix(models): avoid prefix metadata matches

### DIFF
--- a/apps/desktop/src/database/queries/models.ts
+++ b/apps/desktop/src/database/queries/models.ts
@@ -48,6 +48,32 @@ export const modelWithProviderSelection = {
     provider_logo: sql<string>`${providers.logo}`.as('provider_logo'),
 };
 
+const metadataMatchCondition = `
+                (
+                    lower(m2.model_id) = lower(models.model_id)
+                    OR (
+                        length(models.model_id) > 0
+                        AND length(m2.model_id) > length(models.model_id)
+                        AND substr(lower(m2.model_id), 1, length(models.model_id)) = lower(models.model_id)
+                        AND (
+                            substr(m2.model_id, length(models.model_id) + 1) GLOB '-[0-9][0-9][0-9][0-9]'
+                            OR substr(m2.model_id, length(models.model_id) + 1) GLOB '-[0-9][0-9][0-9][0-9][0-9][0-9]'
+                            OR substr(m2.model_id, length(models.model_id) + 1) GLOB '-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]'
+                            OR substr(m2.model_id, length(models.model_id) + 1) GLOB '-[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'
+                            OR lower(substr(m2.model_id, length(models.model_id) + 1)) = '-latest'
+                        )
+                    )
+                )
+`;
+
+const metadataMatchOrder = `
+                    CASE WHEN lower(m2.model_id) = lower(models.model_id) THEN 1 ELSE 0 END DESC,
+                    (m2.attachment + m2.open_weights + m2.reasoning + m2.temperature + m2.tool_call +
+                        CASE WHEN m2.modalities IS NOT NULL AND m2.modalities <> '' THEN 1 ELSE 0 END
+                    ) DESC,
+                    length(m2.model_id) DESC
+`;
+
 /**
  * 查找全局默认模型。
  */
@@ -211,111 +237,81 @@ export const syncAllModelsMetadata = async (database: DatabaseExecutor = db): Pr
             attachment = COALESCE((
                 SELECT m2.attachment
                 FROM llm_metadata AS m2
-                WHERE lower(m2.model_id) LIKE '%' || lower(models.model_id) || '%'
+                WHERE ${metadataMatchCondition}
                 ORDER BY
-                    (m2.attachment + m2.open_weights + m2.reasoning + m2.temperature + m2.tool_call +
-                        CASE WHEN m2.modalities IS NOT NULL AND m2.modalities <> '' THEN 1 ELSE 0 END
-                    ) DESC,
-                    length(m2.model_id) DESC
+                    ${metadataMatchOrder}
                 LIMIT 1
             ), attachment),
             modalities = COALESCE((
                 SELECT m2.modalities
                 FROM llm_metadata AS m2
-                WHERE lower(m2.model_id) LIKE '%' || lower(models.model_id) || '%'
+                WHERE ${metadataMatchCondition}
                 ORDER BY
-                    (m2.attachment + m2.open_weights + m2.reasoning + m2.temperature + m2.tool_call +
-                        CASE WHEN m2.modalities IS NOT NULL AND m2.modalities <> '' THEN 1 ELSE 0 END
-                    ) DESC,
-                    length(m2.model_id) DESC
+                    ${metadataMatchOrder}
                 LIMIT 1
             ), modalities),
             open_weights = COALESCE((
                 SELECT m2.open_weights
                 FROM llm_metadata AS m2
-                WHERE lower(m2.model_id) LIKE '%' || lower(models.model_id) || '%'
+                WHERE ${metadataMatchCondition}
                 ORDER BY
-                    (m2.attachment + m2.open_weights + m2.reasoning + m2.temperature + m2.tool_call +
-                        CASE WHEN m2.modalities IS NOT NULL AND m2.modalities <> '' THEN 1 ELSE 0 END
-                    ) DESC,
-                    length(m2.model_id) DESC
+                    ${metadataMatchOrder}
                 LIMIT 1
             ), open_weights),
             reasoning = COALESCE((
                 SELECT m2.reasoning
                 FROM llm_metadata AS m2
-                WHERE lower(m2.model_id) LIKE '%' || lower(models.model_id) || '%'
+                WHERE ${metadataMatchCondition}
                 ORDER BY
-                    (m2.attachment + m2.open_weights + m2.reasoning + m2.temperature + m2.tool_call +
-                        CASE WHEN m2.modalities IS NOT NULL AND m2.modalities <> '' THEN 1 ELSE 0 END
-                    ) DESC,
-                    length(m2.model_id) DESC
+                    ${metadataMatchOrder}
                 LIMIT 1
             ), reasoning),
             release_date = COALESCE((
                 SELECT m2.release_date
                 FROM llm_metadata AS m2
-                WHERE lower(m2.model_id) LIKE '%' || lower(models.model_id) || '%'
+                WHERE ${metadataMatchCondition}
                 ORDER BY
-                    (m2.attachment + m2.open_weights + m2.reasoning + m2.temperature + m2.tool_call +
-                        CASE WHEN m2.modalities IS NOT NULL AND m2.modalities <> '' THEN 1 ELSE 0 END
-                    ) DESC,
-                    length(m2.model_id) DESC
+                    ${metadataMatchOrder}
                 LIMIT 1
             ), release_date),
             temperature = COALESCE((
                 SELECT m2.temperature
                 FROM llm_metadata AS m2
-                WHERE lower(m2.model_id) LIKE '%' || lower(models.model_id) || '%'
+                WHERE ${metadataMatchCondition}
                 ORDER BY
-                    (m2.attachment + m2.open_weights + m2.reasoning + m2.temperature + m2.tool_call +
-                        CASE WHEN m2.modalities IS NOT NULL AND m2.modalities <> '' THEN 1 ELSE 0 END
-                    ) DESC,
-                    length(m2.model_id) DESC
+                    ${metadataMatchOrder}
                 LIMIT 1
             ), temperature),
             tool_call = COALESCE((
                 SELECT m2.tool_call
                 FROM llm_metadata AS m2
-                WHERE lower(m2.model_id) LIKE '%' || lower(models.model_id) || '%'
+                WHERE ${metadataMatchCondition}
                 ORDER BY
-                    (m2.attachment + m2.open_weights + m2.reasoning + m2.temperature + m2.tool_call +
-                        CASE WHEN m2.modalities IS NOT NULL AND m2.modalities <> '' THEN 1 ELSE 0 END
-                    ) DESC,
-                    length(m2.model_id) DESC
+                    ${metadataMatchOrder}
                 LIMIT 1
             ), tool_call),
             knowledge = COALESCE((
                 SELECT m2.knowledge
                 FROM llm_metadata AS m2
-                WHERE lower(m2.model_id) LIKE '%' || lower(models.model_id) || '%'
+                WHERE ${metadataMatchCondition}
                 ORDER BY
-                    (m2.attachment + m2.open_weights + m2.reasoning + m2.temperature + m2.tool_call +
-                        CASE WHEN m2.modalities IS NOT NULL AND m2.modalities <> '' THEN 1 ELSE 0 END
-                    ) DESC,
-                    length(m2.model_id) DESC
+                    ${metadataMatchOrder}
                 LIMIT 1
             ), knowledge),
             context_limit = COALESCE((
                 SELECT json_extract(m2."limit", '$.context')
                 FROM llm_metadata AS m2
-                WHERE lower(m2.model_id) LIKE '%' || lower(models.model_id) || '%'
+                WHERE ${metadataMatchCondition}
                 ORDER BY
-                    (m2.attachment + m2.open_weights + m2.reasoning + m2.temperature + m2.tool_call +
-                        CASE WHEN m2.modalities IS NOT NULL AND m2.modalities <> '' THEN 1 ELSE 0 END
-                    ) DESC,
-                    length(m2.model_id) DESC
+                    ${metadataMatchOrder}
                 LIMIT 1
             ), context_limit),
             output_limit = COALESCE((
                 SELECT json_extract(m2."limit", '$.output')
                 FROM llm_metadata AS m2
-                WHERE lower(m2.model_id) LIKE '%' || lower(models.model_id) || '%'
+                WHERE ${metadataMatchCondition}
                 ORDER BY
-                    (m2.attachment + m2.open_weights + m2.reasoning + m2.temperature + m2.tool_call +
-                        CASE WHEN m2.modalities IS NOT NULL AND m2.modalities <> '' THEN 1 ELSE 0 END
-                    ) DESC,
-                    length(m2.model_id) DESC
+                    ${metadataMatchOrder}
                 LIMIT 1
             ), output_limit),
             updated_at = datetime('now')
@@ -323,7 +319,7 @@ export const syncAllModelsMetadata = async (database: DatabaseExecutor = db): Pr
           AND EXISTS (
             SELECT 1
             FROM llm_metadata AS m2
-            WHERE lower(m2.model_id) LIKE '%' || lower(models.model_id) || '%'
+            WHERE ${metadataMatchCondition}
         )
     `);
 

--- a/apps/desktop/src/services/AgentService/infrastructure/modelMetadata.ts
+++ b/apps/desktop/src/services/AgentService/infrastructure/modelMetadata.ts
@@ -134,22 +134,23 @@ function parseRawData(rawData: RawModelData): NewLlmMetadata[] {
 }
 
 /**
- * 去重并合并包含关系的元数据。
+ * 去重同一模型 ID 的元数据。
  */
 function deduplicateMetadata(metadataList: NewLlmMetadata[]): NewLlmMetadata[] {
-    const sortedByLength = [...metadataList].sort((a, b) => b.model_id.length - a.model_id.length);
-    const filteredList: NewLlmMetadata[] = [];
+    const metadataMap = new Map<string, NewLlmMetadata>();
 
-    for (const item of sortedByLength) {
-        const target = filteredList.find((existing) => existing.model_id.includes(item.model_id));
-        if (!target) {
-            filteredList.push(item);
-        } else {
-            mergeCapabilities(target, item);
+    for (const item of metadataList) {
+        const key = item.model_id.toLowerCase();
+        const existing = metadataMap.get(key);
+        if (existing) {
+            mergeCapabilities(existing, item);
+            continue;
         }
+
+        metadataMap.set(key, { ...item });
     }
 
-    return filteredList;
+    return Array.from(metadataMap.values());
 }
 
 /**

--- a/apps/desktop/tests/database/models.test.ts
+++ b/apps/desktop/tests/database/models.test.ts
@@ -1,4 +1,4 @@
-import { setDefaultModel } from '@database/queries/models';
+import { setDefaultModel, syncAllModelsMetadata } from '@database/queries/models';
 import type { InvokeArgs } from '@tauri-apps/api/core';
 import { getTauriInvokeCalls, interceptTauriInvoke } from '@tests/utils/tauri';
 import { describe, expect, it } from 'vitest';
@@ -58,5 +58,35 @@ describe('model database queries', () => {
             [0, 1],
             [1, 211],
         ]);
+    });
+
+    it('does not sync metadata from unrelated prefix model ids', async () => {
+        interceptTauriInvoke((call) => {
+            if (call.cmd === 'database_query') {
+                return { rows: [], rowsAffected: 1, lastInsertId: null };
+            }
+
+            return undefined;
+        });
+
+        await expect(syncAllModelsMetadata()).resolves.toBeUndefined();
+
+        const request = getTauriInvokeCalls('database_query')
+            .map((call) => getRequest(call.payload))
+            .find((candidate) => candidate?.method === 'run');
+        const normalizedSql = request?.sql.replace(/\s+/g, ' ').trim() ?? '';
+
+        expect(normalizedSql).toContain(
+            'CASE WHEN lower(m2.model_id) = lower(models.model_id) THEN 1 ELSE 0 END DESC'
+        );
+        expect(normalizedSql).toContain(
+            "substr(m2.model_id, length(models.model_id) + 1) GLOB '-[0-9][0-9][0-9][0-9]'"
+        );
+        expect(normalizedSql).toContain(
+            "lower(substr(m2.model_id, length(models.model_id) + 1)) = '-latest'"
+        );
+        expect(normalizedSql).not.toContain(
+            "lower(m2.model_id) LIKE '%' || lower(models.model_id) || '%'"
+        );
     });
 });

--- a/apps/desktop/tests/services/AgentService/infrastructure/model-metadata.test.ts
+++ b/apps/desktop/tests/services/AgentService/infrastructure/model-metadata.test.ts
@@ -1,0 +1,83 @@
+import { updateModelMetadata } from '@services/AgentService/infrastructure/modelMetadata';
+import type { InvokeArgs } from '@tauri-apps/api/core';
+import { getTauriInvokeCalls, interceptTauriInvoke } from '@tests/utils/tauri';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+function getRequest(payload: InvokeArgs | undefined) {
+    return (payload as { request?: { sql: string; params?: unknown[]; method: string } })?.request;
+}
+
+describe('model metadata refresh', () => {
+    let originalFetch: typeof fetch;
+
+    beforeEach(() => {
+        originalFetch = globalThis.fetch;
+    });
+
+    afterEach(() => {
+        globalThis.fetch = originalFetch;
+    });
+
+    it('keeps prefix-distinct model ids when storing remote metadata', async () => {
+        globalThis.fetch = vi.fn(async () => ({
+            ok: true,
+            json: async () => ({
+                openai: {
+                    models: {
+                        'gpt-4': {
+                            id: 'gpt-4',
+                            name: 'GPT-4',
+                            attachment: false,
+                            open_weights: false,
+                            reasoning: false,
+                            temperature: true,
+                            tool_call: true,
+                        },
+                        'gpt-4o': {
+                            id: 'gpt-4o',
+                            name: 'GPT-4o',
+                            attachment: true,
+                            open_weights: false,
+                            reasoning: true,
+                            temperature: true,
+                            tool_call: true,
+                        },
+                    },
+                },
+            }),
+        })) as unknown as typeof fetch;
+
+        interceptTauriInvoke((call) => {
+            if (call.cmd === 'database_tx_begin') {
+                return 'tx_model_metadata';
+            }
+
+            if (call.cmd === 'database_tx_commit' || call.cmd === 'database_tx_rollback') {
+                return undefined;
+            }
+
+            if (call.cmd === 'database_tx_query') {
+                const request = getRequest(call.payload);
+                if (request?.sql.includes('insert into "statistics"')) {
+                    return {
+                        rows: [{ key: 'model_metadata_last_updated_at' }],
+                        rowsAffected: 1,
+                        lastInsertId: 1,
+                    };
+                }
+
+                return { rows: [], rowsAffected: 1, lastInsertId: null };
+            }
+
+            return undefined;
+        });
+
+        await expect(updateModelMetadata()).resolves.toBeUndefined();
+
+        const insertRequest = getTauriInvokeCalls('database_tx_query')
+            .map((call) => getRequest(call.payload))
+            .find((request) => request?.sql.includes('insert into "llm_metadata"'));
+
+        expect(insertRequest?.params).toEqual(expect.arrayContaining(['gpt-4', 'gpt-4o']));
+    });
+});


### PR DESCRIPTION
## Summary
- Keep prefix-distinct model IDs as separate metadata rows during refresh instead of merging by substring containment.
- Replace broad metadata sync matching with exact matching plus explicit date/latest alias suffixes, with exact IDs ranked first.
- Add regression coverage for refresh storage and sync SQL generation.

## Related issue or RFC
Closes #336

## AI assistance disclosure
A local development assistant helped prepare and validate this change.

## Testing evidence
- `corepack pnpm --dir apps/desktop exec vitest run --configLoader runner tests/services/AgentService/infrastructure/model-metadata.test.ts tests/database/models.test.ts`
- `corepack pnpm --dir apps/desktop exec eslint src/database/queries/models.ts src/services/AgentService/infrastructure/modelMetadata.ts tests/database/models.test.ts tests/services/AgentService/infrastructure/model-metadata.test.ts`
- `corepack pnpm --dir apps/desktop exec prettier --check src/database/queries/models.ts src/services/AgentService/infrastructure/modelMetadata.ts tests/database/models.test.ts tests/services/AgentService/infrastructure/model-metadata.test.ts`
- `corepack pnpm --dir apps/desktop run test:typecheck`
- `git diff --check`

## Risk notes
- Narrows model metadata matching, so prefix-only fallback matches that are not exact/date/latest aliases will no longer apply.
- Existing exact metadata rows continue to sync, and exact matches are preferred when both exact and alias rows exist.

## Screenshots or recordings
Not applicable; this is database metadata logic.

## Checklist
- [x] Linked issue is included.
- [x] Tests or validation commands are listed.
- [x] User-facing behavior and risk are described.
- [x] No screenshots are needed for this change.