### PR TITLE
fix(search): add click stats conflict index

### DIFF
--- a/apps/desktop/src-tauri/tests/database_commands.rs
+++ b/apps/desktop/src-tauri/tests/database_commands.rs
@@ -112,6 +112,58 @@ fn database_transaction_commands_persist_changes_after_commit() {
 }
 
 #[test]
+fn quick_search_click_stats_upsert_uses_declared_conflict_target() {
+    let test_app = build_test_app(TestAppOptions::with_database_runtime()).expect("test app");
+    let upsert_sql = "INSERT INTO quick_search_click_stats (query_norm, path_norm, click_count) \
+        VALUES (?, ?, 1) \
+        ON CONFLICT(query_norm, path_norm) DO UPDATE SET \
+        click_count = quick_search_click_stats.click_count + 1";
+
+    for _ in 0..2 {
+        let response: serde_json::Value = invoke_command_ok(
+            &test_app.main_webview,
+            "database_query",
+            json!({
+                "request": {
+                    "sql": upsert_sql,
+                    "params": ["touch ai", "d:\\tool.lnk"],
+                    "method": "run"
+                }
+            }),
+        );
+
+        assert_eq!(response["rowsAffected"], 1);
+    }
+
+    let row: serde_json::Value = invoke_command_ok(
+        &test_app.main_webview,
+        "database_query",
+        json!({
+            "request": {
+                "sql": "SELECT query_norm, path_norm, click_count FROM quick_search_click_stats WHERE query_norm = ? AND path_norm = ?",
+                "params": ["touch ai", "d:\\tool.lnk"],
+                "method": "get"
+            }
+        }),
+    );
+
+    assert_eq!(
+        row,
+        json!({
+            "rows": [
+                {
+                    "query_norm": "touch ai",
+                    "path_norm": "d:\\tool.lnk",
+                    "click_count": 2
+                }
+            ],
+            "rowsAffected": 0,
+            "lastInsertId": null
+        })
+    );
+}
+
+#[test]
 fn database_tx_query_reports_missing_transactions() {
     let test_app = build_test_app(TestAppOptions::with_database_runtime()).expect("test app");
 

--- a/apps/desktop/src/database/drizzle/0002_quick_search_click_stats_unique.sql
+++ b/apps/desktop/src/database/drizzle/0002_quick_search_click_stats_unique.sql
@@ -1,0 +1,33 @@
+CREATE TEMP TABLE quick_search_click_stats_dedup AS
+SELECT
+    MIN(id) AS id,
+    query_norm,
+    path_norm,
+    SUM(click_count) AS click_count,
+    MIN(created_at) AS created_at,
+    MAX(updated_at) AS updated_at
+FROM quick_search_click_stats
+GROUP BY query_norm, path_norm;
+--> statement-breakpoint
+DELETE FROM quick_search_click_stats;
+--> statement-breakpoint
+INSERT INTO quick_search_click_stats (
+    id,
+    query_norm,
+    path_norm,
+    click_count,
+    created_at,
+    updated_at
+)
+SELECT
+    id,
+    query_norm,
+    path_norm,
+    click_count,
+    created_at,
+    updated_at
+FROM quick_search_click_stats_dedup;
+--> statement-breakpoint
+DROP TABLE quick_search_click_stats_dedup;
+--> statement-breakpoint
+CREATE UNIQUE INDEX `quick_search_click_stats_query_path_unique` ON `quick_search_click_stats` (`query_norm`,`path_norm`);

--- a/apps/desktop/src/database/drizzle/meta/0000_snapshot.json
+++ b/apps/desktop/src/database/drizzle/meta/0000_snapshot.json
@@ -1389,7 +1389,16 @@
           "default": "(datetime('now'))"
         }
       },
-      "indexes": {},
+      "indexes": {
+        "quick_search_click_stats_query_path_unique": {
+          "name": "quick_search_click_stats_query_path_unique",
+          "columns": [
+            "query_norm",
+            "path_norm"
+          ],
+          "isUnique": true
+        }
+      },
       "foreignKeys": {},
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},

--- a/apps/desktop/src/database/drizzle/meta/_journal.json
+++ b/apps/desktop/src/database/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1778889600000,
       "tag": "0001_silent_reasoning",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1780185600000,
+      "tag": "0002_quick_search_click_stats_unique",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/desktop/src/database/schema.ts
+++ b/apps/desktop/src/database/schema.ts
@@ -529,18 +529,27 @@ export const builtInToolLogs = sqliteTable('built_in_tool_logs', {
 /**
  * 快速搜索点击统计表
  */
-export const quickSearchClickStats = sqliteTable('quick_search_click_stats', {
-    id: integer('id').primaryKey({ autoIncrement: true }),
-    query_norm: text('query_norm').notNull(),
-    path_norm: text('path_norm').notNull(),
-    click_count: integer('click_count').notNull().default(0),
-    created_at: text('created_at')
-        .notNull()
-        .default(sql`(datetime('now'))`),
-    updated_at: text('updated_at')
-        .notNull()
-        .default(sql`(datetime('now'))`),
-});
+export const quickSearchClickStats = sqliteTable(
+    'quick_search_click_stats',
+    {
+        id: integer('id').primaryKey({ autoIncrement: true }),
+        query_norm: text('query_norm').notNull(),
+        path_norm: text('path_norm').notNull(),
+        click_count: integer('click_count').notNull().default(0),
+        created_at: text('created_at')
+            .notNull()
+            .default(sql`(datetime('now'))`),
+        updated_at: text('updated_at')
+            .notNull()
+            .default(sql`(datetime('now'))`),
+    },
+    (table) => [
+        uniqueIndex('quick_search_click_stats_query_path_unique').on(
+            table.query_norm,
+            table.path_norm
+        ),
+    ]
+);
 
 // ==================== 类型别名 ====================
 


### PR DESCRIPTION
## Summary
- Add a unique `(query_norm, path_norm)` index for QuickSearch click stats so the existing upsert conflict target is valid.
- Add a migration that deduplicates any existing rows before creating the unique index.
- Add a database runtime test that inserts the same query/path pair twice through the real SQLite command path.

## Related issue or RFC
Closes #340

## AI assistance disclosure
A local development assistant helped prepare and validate this change.

## Testing evidence
- `cargo fmt --check`
- `cargo test quick_search_click_stats_upsert_uses_declared_conflict_target`
- `corepack pnpm --dir apps/desktop exec eslint src/database/schema.ts`
- `corepack pnpm --dir apps/desktop exec prettier --check src/database/schema.ts`
- `corepack pnpm --dir apps/desktop run test:typecheck`
- `git diff --check`

## Risk notes
- Low risk. The migration only touches QuickSearch click ranking data.
- Existing duplicate rows are merged by summing click counts and keeping the latest update timestamp before the unique index is added.

## Screenshots or recordings
Not applicable; this is database persistence logic.

## Checklist
- [x] Linked issue is included.
- [x] Tests or validation commands are listed.
- [x] User-facing behavior and risk are described.
- [x] No screenshots are needed for this change.