### PR TITLE
fix(widget): render Chart.js widget initializers

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -35,7 +35,7 @@
             "csp": {
                 "default-src": "'self' tauri: asset: https: http:",
                 "connect-src": "'self' tauri: asset: https: http: ws: wss:",
-                "script-src": "'self' 'unsafe-inline' 'unsafe-eval'",
+                "script-src": "'self' 'unsafe-inline' 'unsafe-eval' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net https://unpkg.com https://esm.sh",
                 "style-src": "'self' 'unsafe-inline'",
                 "img-src": "'self' data: asset: https: http:",
                 "font-src": "'self' data: asset:"

--- a/apps/desktop/src/prompts/show-widget/charts_chart_js.md
+++ b/apps/desktop/src/prompts/show-widget/charts_chart_js.md
@@ -3,16 +3,16 @@
 <div style="position: relative; width: 100%; height: 300px;">
   <canvas id="myChart"></canvas>
 </div>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.js" onload="initChart()"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.js"></script>
 <script>
-  function initChart() {
-    new Chart(document.getElementById('myChart'), {
+  const chartEl = document.getElementById('myChart');
+  if (window.Chart && chartEl) {
+    new Chart(chartEl, {
       type: 'bar',
       data: { labels: ['Q1','Q2','Q3','Q4'], datasets: [{ label: 'Revenue', data: [12,19,8,15] }] },
       options: { responsive: true, maintainAspectRatio: false }
     });
   }
-  if (window.Chart) initChart();
 </script>
 ```
 
@@ -22,7 +22,7 @@
 - **Canvas sizing**: set height ONLY on the wrapper div, never on the canvas element itself. Use position: relative on the wrapper and responsive: true, maintainAspectRatio: false in Chart.js options. Never set CSS height directly on canvas — this causes wrong dimensions, especially for horizontal bar charts.
 - For horizontal bar charts: wrapper div height should be at least (number_of_bars * 40) + 80 pixels.
 - Load UMD build via `<script src="https://cdnjs.cloudflare.com/ajax/libs/...">` — sets `window.Chart` global. Follow with plain `<script>` (no `type="module"`).
-- **Script load ordering**: CDN scripts may not be loaded when the next `<script>` runs (especially during streaming). Always use `onload="initChart()"` on the CDN script tag, define your chart init in a named function, and add `if (window.Chart) initChart();` as a fallback at the end of your inline script. This guarantees charts render regardless of load order.
+- **Script load ordering**: TouchAI executes final script tags in document order after streaming completes, and waits for each external script before running the next inline initializer. Do not use event-handler attributes on script tags; put the CDN script immediately before a plain `<script>` that checks `window.Chart` and initializes the chart.
 - Multiple charts: use unique IDs (`myChart1`, `myChart2`). Each gets its own canvas+div pair.
 - For bubble and scatter charts: bubble radii extend past their center points, so points near axis boundaries get clipped. Pad the scale range — set `scales.y.min` and `scales.y.max` ~10% beyond your data range (same for x). Or use `layout: { padding: 20 }` as a blunt fallback.
 - Chart.js auto-skips x-axis labels when they'd overlap. If you have ≤12 categories and need all labels visible (waterfall, monthly series), set `scales.x.ticks: { autoSkip: false, maxRotation: 45 }` — missing labels make bars unidentifiable.

--- a/apps/desktop/src/services/BuiltInToolService/tools/widgetTool/showWidget/runtime.ts
+++ b/apps/desktop/src/services/BuiltInToolService/tools/widgetTool/showWidget/runtime.ts
@@ -51,6 +51,7 @@ export interface WidgetRenderer {
 }
 
 type MorphdomFunction = typeof morphdom;
+const SHOW_WIDGET_EXTERNAL_SCRIPT_TIMEOUT_MS = 8000;
 type ShowWidgetRenderPayload = Pick<
     ShowWidgetPayload,
     'widgetId' | 'title' | 'description' | 'html' | 'phase'
@@ -610,6 +611,30 @@ function copyScriptAttributes(source: HTMLScriptElement, target: HTMLScriptEleme
     }
 }
 
+function waitForExternalScript(
+    node: HTMLScriptElement,
+    parent: Node,
+    oldNode: HTMLScriptElement
+): Promise<void> {
+    return new Promise<void>((resolve) => {
+        const timeoutId = window.setTimeout(
+            settle,
+            SHOW_WIDGET_EXTERNAL_SCRIPT_TIMEOUT_MS
+        );
+
+        function settle(): void {
+            window.clearTimeout(timeoutId);
+            node.removeEventListener('load', settle);
+            node.removeEventListener('error', settle);
+            resolve();
+        }
+
+        node.addEventListener('load', settle);
+        node.addEventListener('error', settle);
+        parent.replaceChild(node, oldNode);
+    });
+}
+
 /**
  * 简化后的脚本执行策略直接重新插入 `<script>` 节点。
  *
@@ -647,11 +672,7 @@ async function runInlineScripts(
         }
 
         if (oldNode.src) {
-            await new Promise<void>((resolve) => {
-                newNode.addEventListener('load', () => resolve(), { once: true });
-                newNode.addEventListener('error', () => resolve(), { once: true });
-                parent.replaceChild(newNode, oldNode);
-            });
+            await waitForExternalScript(newNode, parent, oldNode);
             continue;
         }
 

--- a/apps/desktop/src/services/BuiltInToolService/tools/widgetTool/showWidget/runtime.ts
+++ b/apps/desktop/src/services/BuiltInToolService/tools/widgetTool/showWidget/runtime.ts
@@ -617,10 +617,7 @@ function waitForExternalScript(
     oldNode: HTMLScriptElement
 ): Promise<void> {
     return new Promise<void>((resolve) => {
-        const timeoutId = window.setTimeout(
-            settle,
-            SHOW_WIDGET_EXTERNAL_SCRIPT_TIMEOUT_MS
-        );
+        const timeoutId = window.setTimeout(settle, SHOW_WIDGET_EXTERNAL_SCRIPT_TIMEOUT_MS);
 
         function settle(): void {
             window.clearTimeout(timeoutId);

--- a/apps/desktop/src/services/BuiltInToolService/tools/widgetTool/showWidget/runtime.ts
+++ b/apps/desktop/src/services/BuiltInToolService/tools/widgetTool/showWidget/runtime.ts
@@ -517,29 +517,19 @@ function parseRenderTree(rawHtml: string, phase: ShowWidgetPhase = 'ready'): Par
     const normalizedHtml = sanitizedHtml || '<div></div>';
     const isFullDocument = /<(?:!doctype|html|head|body)\b/i.test(normalizedHtml);
 
-    // Allow <script src="..."> tags so runInlineScripts can re-execute external
-    // scripts after morphdom patching. Inline script content is stripped via the
-    // uponSanitizeElement hook to prevent XSS. DOMPurify still strips event-handler
-    // attributes (onclick, onerror, etc.) and javascript: URIs by default.
-    const purifyInstance = DOMPurify(window);
-    purifyInstance.addHook('uponSanitizeElement', (node, data) => {
-        if (data.tagName === 'script' && !(node as HTMLScriptElement).src) {
-            (node as HTMLScriptElement).textContent = '';
-        }
-    });
+    // Explicit <script> blocks are executable widget code. DOMPurify still
+    // sanitizes surrounding markup, event-handler attributes, and javascript:
+    // URIs before runInlineScripts re-inserts scripts in document order.
+    const purifyConfig = { ADD_TAGS: ['script'] };
 
     if (isFullDocument) {
         const parser = new DOMParser();
         const parsed = parser.parseFromString(normalizedHtml, 'text/html');
         template.innerHTML = String(
-            purifyInstance.sanitize(parsed.body.innerHTML || '<div></div>', {
-                ADD_TAGS: ['script'],
-            })
+            DOMPurify.sanitize(parsed.body.innerHTML || '<div></div>', purifyConfig)
         );
     } else {
-        template.innerHTML = String(
-            purifyInstance.sanitize(normalizedHtml, { ADD_TAGS: ['script'] })
-        );
+        template.innerHTML = String(DOMPurify.sanitize(normalizedHtml, purifyConfig));
         if (!template.content.childNodes.length) {
             template.innerHTML = '<div></div>';
         }

--- a/apps/desktop/tests/ci/show-widget-csp.test.ts
+++ b/apps/desktop/tests/ci/show-widget-csp.test.ts
@@ -1,0 +1,20 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { SHOW_WIDGET_ALLOWED_RESOURCE_HOSTS } from '@/services/BuiltInToolService/tools/widgetTool';
+
+describe('ShowWidget CSP', () => {
+    it('allows documented widget CDN script hosts', async () => {
+        const configPath = join(process.cwd(), 'src-tauri', 'tauri.conf.json');
+        const tauriConfig = JSON.parse(await readFile(configPath, 'utf8')) as {
+            app?: { security?: { csp?: { 'script-src'?: string } } };
+        };
+        const scriptSrc = tauriConfig.app?.security?.csp?.['script-src'] ?? '';
+
+        for (const host of SHOW_WIDGET_ALLOWED_RESOURCE_HOSTS) {
+            expect(scriptSrc).toContain(`https://${host}`);
+        }
+    });
+});

--- a/apps/desktop/tests/ci/show-widget-csp.test.ts
+++ b/apps/desktop/tests/ci/show-widget-csp.test.ts
@@ -12,9 +12,10 @@ describe('ShowWidget CSP', () => {
             app?: { security?: { csp?: { 'script-src'?: string } } };
         };
         const scriptSrc = tauriConfig.app?.security?.csp?.['script-src'] ?? '';
+        const scriptSrcTokens = new Set(scriptSrc.split(/\s+/).filter(Boolean));
 
         for (const host of SHOW_WIDGET_ALLOWED_RESOURCE_HOSTS) {
-            expect(scriptSrc).toContain(`https://${host}`);
+            expect(scriptSrcTokens.has(`https://${host}`)).toBe(true);
         }
     });
 });

--- a/apps/desktop/tests/services/BuiltInToolService/tools/widgetTool/runtime-i18n.test.ts
+++ b/apps/desktop/tests/services/BuiltInToolService/tools/widgetTool/runtime-i18n.test.ts
@@ -2,6 +2,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { createWidgetRenderer } from '@/services/BuiltInToolService/tools/widgetTool/showWidget/runtime';
 
+const nativeReplaceChild = Node.prototype.replaceChild;
+
 async function waitForWidgetRender(): Promise<void> {
     for (let attempt = 0; attempt < 20; attempt += 1) {
         await new Promise((resolve) => window.setTimeout(resolve, 0));
@@ -9,8 +11,6 @@ async function waitForWidgetRender(): Promise<void> {
 }
 
 function installScriptExecutionMock(): void {
-    const nativeReplaceChild = Node.prototype.replaceChild;
-
     vi.spyOn(Node.prototype, 'replaceChild').mockImplementation(function (
         this: Node,
         newChild: Node,
@@ -41,6 +41,8 @@ function installScriptExecutionMock(): void {
 
 describe('show widget renderer i18n opt-out', () => {
     afterEach(() => {
+        vi.restoreAllMocks();
+        Node.prototype.replaceChild = nativeReplaceChild;
         document.body.innerHTML = '';
         delete (window as Window & { __touchaiWidgetInitRan?: boolean }).__touchaiWidgetInitRan;
         delete (window as Window & { Chart?: unknown }).Chart;

--- a/apps/desktop/tests/services/BuiltInToolService/tools/widgetTool/runtime-i18n.test.ts
+++ b/apps/desktop/tests/services/BuiltInToolService/tools/widgetTool/runtime-i18n.test.ts
@@ -1,10 +1,51 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { createWidgetRenderer } from '@/services/BuiltInToolService/tools/widgetTool/showWidget/runtime';
+
+async function waitForWidgetRender(): Promise<void> {
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+        await new Promise((resolve) => window.setTimeout(resolve, 0));
+    }
+}
+
+function installScriptExecutionMock(): void {
+    const nativeReplaceChild = Node.prototype.replaceChild;
+
+    vi.spyOn(Node.prototype, 'replaceChild').mockImplementation(function (
+        this: Node,
+        newChild: Node,
+        oldChild: Node
+    ) {
+        const replacedNode = nativeReplaceChild.call(this, newChild, oldChild);
+
+        if (newChild instanceof HTMLScriptElement) {
+            if (newChild.src) {
+                window.setTimeout(() => {
+                    if (newChild.src.includes('chart.umd.js')) {
+                        (window as Window & { Chart?: unknown }).Chart = function Chart() {
+                            (
+                                window as Window & { __touchaiChartConstructed?: boolean }
+                            ).__touchaiChartConstructed = true;
+                        };
+                    }
+                    newChild.dispatchEvent(new Event('load'));
+                }, 0);
+            } else {
+                new Function(newChild.textContent || '')();
+            }
+        }
+
+        return replacedNode;
+    } as typeof Node.prototype.replaceChild);
+}
 
 describe('show widget renderer i18n opt-out', () => {
     afterEach(() => {
         document.body.innerHTML = '';
+        delete (window as Window & { __touchaiWidgetInitRan?: boolean }).__touchaiWidgetInitRan;
+        delete (window as Window & { Chart?: unknown }).Chart;
+        delete (window as Window & { __touchaiChartConstructed?: boolean })
+            .__touchaiChartConstructed;
     });
 
     it('marks the renderer host and root as not eligible for global DOM localization', () => {
@@ -18,6 +59,69 @@ describe('show widget renderer i18n opt-out', () => {
         expect(host.getAttribute('translate')).toBe('no');
         expect(root?.getAttribute('data-no-i18n')).toBe('true');
         expect(root?.getAttribute('translate')).toBe('no');
+
+        renderer.destroy();
+    });
+
+    it('executes ready-phase inline widget initializers after sanitizing the inert markup', async () => {
+        installScriptExecutionMock();
+
+        const host = document.createElement('div');
+        document.body.appendChild(host);
+
+        const renderer = createWidgetRenderer(host);
+        renderer.render({
+            widgetId: 'chart-widget',
+            title: 'Chart widget',
+            description: '',
+            phase: 'ready',
+            html: [
+                '<div id="chart-probe"></div>',
+                '<script>',
+                'window.__touchaiWidgetInitRan = true;',
+                'document.getElementById("chart-probe").dataset.initialized = "true";',
+                '</script>',
+            ].join(''),
+        });
+
+        await waitForWidgetRender();
+
+        expect(
+            (window as Window & { __touchaiWidgetInitRan?: boolean }).__touchaiWidgetInitRan
+        ).toBe(true);
+        expect(host.querySelector('#chart-probe')?.getAttribute('data-initialized')).toBe('true');
+
+        renderer.destroy();
+    });
+
+    it('waits for an allowed external widget script before running the following initializer', async () => {
+        installScriptExecutionMock();
+
+        const host = document.createElement('div');
+        document.body.appendChild(host);
+
+        const renderer = createWidgetRenderer(host);
+        renderer.render({
+            widgetId: 'chart-widget',
+            title: 'Chart widget',
+            description: '',
+            phase: 'ready',
+            html: [
+                '<div style="position: relative; width: 100%; height: 300px;">',
+                '<canvas id="myChart"></canvas>',
+                '</div>',
+                '<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.js"></script>',
+                '<script>',
+                'if (window.Chart) new window.Chart(document.getElementById("myChart"), {});',
+                '</script>',
+            ].join(''),
+        });
+
+        await waitForWidgetRender();
+
+        expect(
+            (window as Window & { __touchaiChartConstructed?: boolean }).__touchaiChartConstructed
+        ).toBe(true);
 
         renderer.destroy();
     });

--- a/apps/desktop/tests/services/BuiltInToolService/tools/widgetTool/show-widget-summary-i18n.test.ts
+++ b/apps/desktop/tests/services/BuiltInToolService/tools/widgetTool/show-widget-summary-i18n.test.ts
@@ -6,6 +6,7 @@ import { showWidgetTool } from '@/services/BuiltInToolService/tools/widgetTool/s
 import { buildShowWidgetSummary } from '@/services/BuiltInToolService/tools/widgetTool/showWidget/helper';
 import { buildShowWidgetDraftFromArgumentsBuffer } from '@/services/BuiltInToolService/tools/widgetTool/showWidget/runtime';
 import { visualizeReadMeTool } from '@/services/BuiltInToolService/tools/widgetTool/visualizeReadMe';
+import { readShowWidgetGuidelines } from '@/services/BuiltInToolService/tools/widgetTool/visualizeReadMe/guidelines';
 
 function createPayload(overrides: Partial<ShowWidgetEventPayload> = {}): ShowWidgetEventPayload {
     return {
@@ -85,5 +86,12 @@ describe('ShowWidget generated summaries i18n', () => {
             action: 'render',
             target: 'Visualization',
         });
+    });
+
+    it('does not instruct Chart.js widgets to rely on stripped onload attributes', () => {
+        const guidelines = readShowWidgetGuidelines(['chart']);
+
+        expect(guidelines.markdown).toContain('Chart.js');
+        expect(guidelines.markdown).not.toContain('onload=');
     });
 });


### PR DESCRIPTION
﻿> First external contributors may need to complete the `CLA Assistant` check before merge.
> For code changes, this PR must link the related issue or RFC in the section below.

## Summary

Fix ShowWidget Chart.js visualizations that rendered as a blank panel in desktop conversations.

The failure had two parts: Tauri CSP blocked the documented Chart.js CDN before DOMPurify was involved, and after sanitization DOMPurify stripped inline widget initialization scripts so the canvas never initialized. This change allows the documented widget CDNs in CSP, preserves explicit widget `<script>` blocks for runtime execution while still sanitizing the surrounding markup, and updates the Chart.js prompt template to avoid `onload` handlers.

## Related issue or RFC

Link the issue or RFC:

- Closes #319
- Related to #

For code changes, link the tracking issue. Only documentation wording, link fixes, or comment-only cleanups may skip the issue-first flow.

## AI assistance disclosure

If AI tools materially assisted this contribution, disclose that here or point to the relevant commit trailer.

- Tool(s) used: OpenAI Codex.
- Scope of assistance: diagnosis, implementation, regression tests, local validation, PR preparation.
- Human review or rewrite performed: reviewed generated changes, scoped them to the ShowWidget runtime, CSP, prompt template, and targeted tests.
- Architecture or boundary impact: no new cross-boundary abstraction; updates existing widget rendering behavior and desktop CSP for documented widget CDN usage.

## Testing evidence

List the commands you ran and the results you observed.

- Cloud CI: requested for this PR and will be used as the authoritative merge check.
- `pnpm test:pr` passed locally after rebasing onto current `origin/main`; observed desktop type check, test typecheck, lint check, format check, Rust check, 114 Vitest files / 619 tests, Rust tests, coverage run, and site build complete. Existing warnings observed: 20 ESLint warnings in unrelated files and 2 pre-existing Rust warnings in `core::search::manager`.

Did you follow TDD (test-first) for feature and fix work? Strongly recommended. See [docs/testing/testing.md](../docs/testing/testing.md).

```text
pnpm test:pr
pnpm test:coverage:rust
pnpm test:e2e
```

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: touches the built-in ShowWidget runtime only; no AgentService, MCP, database schema, or persistence changes.
- database baseline or migration impact: none.
- release or packaging impact: Tauri CSP now allows documented widget script CDNs (`cdnjs.cloudflare.com`, `cdn.jsdelivr.net`, `unpkg.com`, `esm.sh`) so generated widgets can load Chart.js and similar examples.

## Screenshots or recordings

Not included. The regression is covered by unit/CI checks for script preservation, CSP allowlist coverage, and Chart.js prompt output shape.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [x] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [x] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [x] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.
