### PR TITLE
ci: support merge queue checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -458,6 +458,27 @@ jobs:
                   fi
 
                   failed=0
+                  observed=(
+                    "changes:$CHANGES_RESULT"
+                    "conventional-commits:$CONVENTIONAL_COMMITS_RESULT"
+                    "dependency-review:$DEPENDENCY_REVIEW_RESULT"
+                    "frontend-quality:$FRONTEND_QUALITY_RESULT"
+                    "frontend-tests:$FRONTEND_TESTS_RESULT"
+                    "site-build:$SITE_BUILD_RESULT"
+                    "rust-checks:$RUST_CHECKS_RESULT"
+                    "build-windows:$BUILD_WINDOWS_RESULT"
+                  )
+
+                  for check in "${observed[@]}"; do
+                    name="${check%%:*}"
+                    result="${check#*:}"
+
+                    if [ "$result" = "failure" ] || [ "$result" = "cancelled" ]; then
+                      echo "$name unexpectedly ended with $result."
+                      failed=1
+                    fi
+                  done
+
                   for check in "${required[@]}"; do
                     name="${check%%:*}"
                     result="${check#*:}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,13 +5,16 @@ on:
         branches:
             - main
     pull_request:
+    merge_group:
+        types:
+            - checks_requested
 
 permissions:
     contents: read
     pull-requests: read
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_sha || github.ref }}
     cancel-in-progress: true
 
 jobs:
@@ -396,3 +399,76 @@ jobs:
                   name: touchai-installer-windows-${{ steps.sha.outputs.short }}
                   path: apps/desktop/src-tauri/target/release/bundle/msi/*.msi
                   if-no-files-found: warn
+
+    ci-required:
+        name: CI Required
+        if: always()
+        needs:
+            - changes
+            - conventional-commits
+            - dependency-review
+            - frontend-quality
+            - frontend-tests
+            - site-build
+            - rust-checks
+            - build-windows
+        runs-on: ubuntu-latest
+        steps:
+            - name: Verify required CI jobs
+              env:
+                  EVENT_NAME: ${{ github.event_name }}
+                  DOCS_ONLY: ${{ needs.changes.outputs.docs_only }}
+                  DESKTOP_CHANGED: ${{ needs.changes.outputs.desktop_changed }}
+                  SITE_CHANGED: ${{ needs.changes.outputs.site_changed }}
+                  CHANGES_RESULT: ${{ needs.changes.result }}
+                  CONVENTIONAL_COMMITS_RESULT: ${{ needs['conventional-commits'].result }}
+                  DEPENDENCY_REVIEW_RESULT: ${{ needs['dependency-review'].result }}
+                  FRONTEND_QUALITY_RESULT: ${{ needs['frontend-quality'].result }}
+                  FRONTEND_TESTS_RESULT: ${{ needs['frontend-tests'].result }}
+                  SITE_BUILD_RESULT: ${{ needs['site-build'].result }}
+                  RUST_CHECKS_RESULT: ${{ needs['rust-checks'].result }}
+                  BUILD_WINDOWS_RESULT: ${{ needs['build-windows'].result }}
+              run: |
+                  required=()
+
+                  required+=("changes:$CHANGES_RESULT")
+
+                  if [ "$EVENT_NAME" = "pull_request" ]; then
+                    required+=("conventional-commits:$CONVENTIONAL_COMMITS_RESULT")
+                  fi
+
+                  if [ "$DOCS_ONLY" != "true" ]; then
+                    if [ "$EVENT_NAME" = "pull_request" ]; then
+                      required+=("dependency-review:$DEPENDENCY_REVIEW_RESULT")
+                    fi
+
+                    if [ "$DESKTOP_CHANGED" = "true" ]; then
+                      required+=("frontend-quality:$FRONTEND_QUALITY_RESULT")
+                      required+=("frontend-tests:$FRONTEND_TESTS_RESULT")
+                      required+=("rust-checks:$RUST_CHECKS_RESULT")
+                    fi
+
+                    if [ "$SITE_CHANGED" = "true" ]; then
+                      required+=("site-build:$SITE_BUILD_RESULT")
+                    fi
+
+                    if [ "$EVENT_NAME" = "push" ] && [ "$DESKTOP_CHANGED" = "true" ]; then
+                      required+=("build-windows:$BUILD_WINDOWS_RESULT")
+                    fi
+                  fi
+
+                  failed=0
+                  for check in "${required[@]}"; do
+                    name="${check%%:*}"
+                    result="${check#*:}"
+                    echo "$name -> $result"
+
+                    if [ "$result" != "success" ]; then
+                      failed=1
+                    fi
+                  done
+
+                  if [ "$failed" -ne 0 ]; then
+                    echo "One or more required CI jobs did not pass."
+                    exit 1
+                  fi

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -5,6 +5,9 @@ on:
         branches:
             - main
     pull_request:
+    merge_group:
+        types:
+            - checks_requested
     workflow_dispatch:
 
 permissions:
@@ -12,7 +15,7 @@ permissions:
     pull-requests: read
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_sha || github.ref }}
     cancel-in-progress: true
 
 jobs:
@@ -185,3 +188,40 @@ jobs:
 
             - name: Run desktop smoke tests
               run: pnpm test:e2e
+
+    e2e-required:
+        name: E2E Required
+        if: always()
+        needs:
+            - changes
+            - desktop-e2e-smoke-windows
+        runs-on: ubuntu-latest
+        steps:
+            - name: Verify required E2E jobs
+              env:
+                  DOCS_ONLY: ${{ needs.changes.outputs.docs_only }}
+                  DESKTOP_CHANGED: ${{ needs.changes.outputs.desktop_changed }}
+                  CHANGES_RESULT: ${{ needs.changes.result }}
+                  DESKTOP_E2E_RESULT: ${{ needs['desktop-e2e-smoke-windows'].result }}
+              run: |
+                  required=("changes:$CHANGES_RESULT")
+
+                  if [ "$DOCS_ONLY" != "true" ] && [ "$DESKTOP_CHANGED" = "true" ]; then
+                    required+=("desktop-e2e-smoke-windows:$DESKTOP_E2E_RESULT")
+                  fi
+
+                  failed=0
+                  for check in "${required[@]}"; do
+                    name="${check%%:*}"
+                    result="${check#*:}"
+                    echo "$name -> $result"
+
+                    if [ "$result" != "success" ]; then
+                      failed=1
+                    fi
+                  done
+
+                  if [ "$failed" -ne 0 ]; then
+                    echo "One or more required E2E jobs did not pass."
+                    exit 1
+                  fi

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -211,6 +211,21 @@ jobs:
                   fi
 
                   failed=0
+                  observed=(
+                    "changes:$CHANGES_RESULT"
+                    "desktop-e2e-smoke-windows:$DESKTOP_E2E_RESULT"
+                  )
+
+                  for check in "${observed[@]}"; do
+                    name="${check%%:*}"
+                    result="${check#*:}"
+
+                    if [ "$result" = "failure" ] || [ "$result" = "cancelled" ]; then
+                      echo "$name unexpectedly ended with $result."
+                      failed=1
+                    fi
+                  done
+
                   for check in "${required[@]}"; do
                     name="${check%%:*}"
                     result="${check#*:}"


### PR DESCRIPTION
## Summary

Adds GitHub merge queue support to the CI entry points that should be usable as branch protection checks.

- Adds `merge_group` triggers to the main CI and desktop E2E smoke workflows.
- Adds stable final gate jobs, `CI Required` and `E2E Required`, so branch protection can require one deterministic check per workflow instead of many conditional jobs.
- Keeps merge queue, PR, and main-branch push behavior aligned with the existing docs-only and path-based skip logic.

## Related issue or RFC

Link the issue or RFC:

- Closes #346

For code changes, link the tracking issue. Only documentation wording, link fixes, or comment-only cleanups may skip the issue-first flow.

## AI assistance disclosure

If AI tools materially assisted this contribution, disclose that here or point to the relevant commit trailer.

- Tool(s) used: Codex
- Scope of assistance: Updated GitHub Actions workflow triggers and required-check gate jobs; ran local workflow validation commands.
- Human review or rewrite performed: Maintainer requested and reviewed the change scope; diff and PR body were prepared for review.
- Architecture or boundary impact: None. This only changes repository CI workflow configuration.

## Testing evidence

List the commands you ran and the results you observed.

- `G:\TouchAI\tmp\issue-346-merge-queue-ci\actionlint\actionlint.exe .github/workflows/ci.yml .github/workflows/e2e-smoke.yml` — passed.
- `pnpm exec prettier --check .worktrees/issue-346-merge-queue-ci/.github/workflows/ci.yml .worktrees/issue-346-merge-queue-ci/.github/workflows/e2e-smoke.yml` — passed.
- `git diff --check` — passed.

`pnpm test:pr` was not run locally because this PR only changes GitHub Actions workflow configuration and does not touch application source, Rust behavior, or package outputs. CI should provide the first full repository proof for the workflow changes.

Did you follow TDD (test-first) for feature and fix work? Strongly recommended. See [docs/testing/testing.md](../docs/testing/testing.md).

```text
pnpm test:pr
pnpm test:coverage:rust
pnpm test:e2e
```

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: none.
- database baseline or migration impact: none.
- release or packaging impact: none. The `Build (Windows)` push-only job remains push-only and is only checked by the CI gate on main-branch pushes.

## Screenshots or recordings

Not applicable; this change does not affect UI.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [x] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [x] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.