### PR TITLE
fix(settings): wrap MCP log search input

### DIFF
--- a/apps/desktop/src/views/SettingsView/components/McpTools/components/McpToolLogViewer.vue
+++ b/apps/desktop/src/views/SettingsView/components/McpTools/components/McpToolLogViewer.vue
@@ -86,9 +86,12 @@
     <div class="settings-page-wide">
         <div>
             <!-- 筛选和搜索栏 -->
-            <div class="mb-4 flex items-center justify-between gap-4">
+            <div
+                class="mb-4 flex flex-wrap items-center justify-between gap-4"
+                data-testid="mcp-tool-log-toolbar"
+            >
                 <!-- 筛选标签 -->
-                <div class="flex gap-2">
+                <div class="flex flex-wrap gap-2" data-testid="mcp-tool-log-filters">
                     <button
                         v-for="status in ['all', 'success', 'error', 'timeout', 'pending']"
                         :key="status"
@@ -105,7 +108,7 @@
                 </div>
 
                 <!-- 搜索框 -->
-                <div class="relative w-64">
+                <div class="relative w-full max-w-xs md:w-64" data-testid="mcp-tool-log-search">
                     <input
                         v-model="searchQuery"
                         type="text"

--- a/apps/desktop/tests/SettingsView/mcp-tools-i18n.test.ts
+++ b/apps/desktop/tests/SettingsView/mcp-tools-i18n.test.ts
@@ -301,6 +301,15 @@ describe('MCP settings i18n and long text layout', () => {
         expect(wrapper.text()).toContain('Success');
         expect(wrapper.text()).toContain('Pending');
         expect(wrapper.find('input[placeholder="Search logs..."]').exists()).toBe(true);
+        expect(wrapper.get('[data-testid="mcp-tool-log-toolbar"]').classes()).toContain(
+            'flex-wrap'
+        );
+        expect(wrapper.get('[data-testid="mcp-tool-log-filters"]').classes()).toContain(
+            'flex-wrap'
+        );
+        expect(wrapper.get('[data-testid="mcp-tool-log-search"]').classes()).toEqual(
+            expect.arrayContaining(['w-full', 'max-w-xs', 'md:w-64'])
+        );
         expect(wrapper.get('[data-testid="mcp-tool-log-header"]').classes()).toContain('flex-wrap');
         expect(wrapper.get('[data-testid="mcp-tool-log-name"]').text()).toBe('工具');
         expect(wrapper.get('[data-testid="mcp-tool-log-name"]').attributes('data-no-i18n')).toBe(


### PR DESCRIPTION
## Summary

- Updated the MCP tool log toolbar so status filters and the search input can wrap on constrained settings-panel widths.
- Matched the MCP log search box sizing to the built-in tools log viewer (`w-full max-w-xs md:w-64`) so it moves onto its own row instead of crowding filters.
- Added regression coverage for the MCP log toolbar, filter group, and responsive search-box classes.

## Related issue or RFC

Link the issue or RFC:

- Closes #352

For code changes, link the tracking issue. Only documentation wording, link fixes, or comment-only cleanups may skip the issue-first flow.

## AI assistance disclosure

If AI tools materially assisted this contribution, disclose that here or point to the relevant commit trailer.

- Tool(s) used: Codex
- Scope of assistance: Investigated the existing MCP and built-in tool log layouts, implemented the focused Vue layout fix, added regression test assertions, and prepared the PR description.
- Human review or rewrite performed: Diff reviewed locally; issue and PR templates were filled explicitly.
- Architecture or boundary impact: None. This is a frontend settings-view layout change only; it does not alter MCP runtime or integration behavior.

## Testing evidence

List the commands you ran and the results you observed.

- Targeted TDD red check: temporarily restored the old MCP toolbar layout and ran `node <vitest package>/vitest.mjs run --configLoader runner tests/SettingsView/mcp-tools-i18n.test.ts`; result: failed as expected, 1 failed / 4 passed, missing `[data-testid="mcp-tool-log-toolbar"]` in the old no-wrap layout.
- Targeted green check: `node <vitest package>/vitest.mjs run --configLoader runner tests/SettingsView/mcp-tools-i18n.test.ts`; result: 1 file passed, 5 tests passed.
- `node node_modules/prettier/bin/prettier.cjs --check apps/desktop/src/views/SettingsView/components/McpTools/components/McpToolLogViewer.vue apps/desktop/tests/SettingsView/mcp-tools-i18n.test.ts --ignore-path .prettierignore`; result: all matched files use Prettier code style.
- `node node_modules/eslint/bin/eslint.js apps/desktop/src/views/SettingsView/components/McpTools/components/McpToolLogViewer.vue apps/desktop/tests/SettingsView/mcp-tools-i18n.test.ts`; result: passed with no output.
- `git diff --check`; result: passed with no whitespace errors.
- `node node_modules/vue-tsc/bin/vue-tsc.js -p apps/desktop/tsconfig.vitest.json --noEmit`; result: could not complete in the reused local dependency environment because unrelated dependencies (`dompurify`, `motion-v`) were not resolvable.
- `pnpm test:pr`: not run locally because the isolated worktree dependency install could not complete: `E:` had 0 bytes free and `G:` had only a few MB free, causing `pnpm install --frozen-lockfile --store-dir E:\.pnpm-store` to fail with `ERR_PNPM_ENOSPC`. CI should run the full PR validation on a clean environment.
- `pnpm test:e2e`: not run locally for the same dependency/install disk-space blocker. This settings layout regression is covered by the targeted SettingsView unit DOM assertions; CI is the first valid E2E proof in this local environment.

Did you follow TDD (test-first) for feature and fix work? Strongly recommended. See [docs/testing/testing.md](../docs/testing/testing.md).

```text
pnpm test:pr
pnpm test:coverage:rust
pnpm test:e2e
```

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: No AgentService/runtime/schema impact. MCP impact is limited to the frontend settings log viewer layout.
- database baseline or migration impact: None.
- release or packaging impact: None.

## Screenshots or recordings

- Reporter screenshot in #352 shows the original crowded MCP logs toolbar.
- Automated DOM regression coverage now verifies the MCP log toolbar wraps like the built-in tools log viewer.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [x] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [x] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.