### PR TITLE
fix(updater): avoid wrong-platform downloads

### DIFF
--- a/apps/desktop/src/services/AppUpdateService/downloads.ts
+++ b/apps/desktop/src/services/AppUpdateService/downloads.ts
@@ -138,6 +138,10 @@ export function preferredAppUpdateDownload(
         return bestForPlatform.download;
     }
 
+    if (platform.os !== 'unknown') {
+        return null;
+    }
+
     return downloads
         .map((download, index) => ({
             download,

--- a/apps/desktop/tests/components/AppUpdateRequiredGate.test.ts
+++ b/apps/desktop/tests/components/AppUpdateRequiredGate.test.ts
@@ -131,11 +131,15 @@ describe('AppUpdateRequiredGate', () => {
         expect(appUpdateServiceMock.download).toHaveBeenCalledTimes(1);
     });
 
-    it('opens the direct installer when the channel has no satisfying update', async () => {
+    it('opens the release page when no direct download is selected', async () => {
+        const latestUpdateWithoutDirectDownload = {
+            ...latestUpdate,
+            downloads: [],
+        };
         appUpdateServiceMock.state = {
             ...baseState,
             status: 'not_available',
-            latestUpdate,
+            latestUpdate: latestUpdateWithoutDirectDownload,
             updateRequirement: {
                 ...requiredRequirement,
                 targetSatisfiesRequirement: false,
@@ -149,7 +153,7 @@ describe('AppUpdateRequiredGate', () => {
         expect(wrapper.text()).toContain('修复问题');
         await wrapper.get('[data-testid="app-update-required-primary"]').trigger('click');
 
-        expect(openUrl).toHaveBeenCalledWith(latestUpdate.downloads[0]!.url);
+        expect(openUrl).toHaveBeenCalledWith(latestUpdateWithoutDirectDownload.releaseUrl);
     });
 
     it('renders raw update errors only as localized details', async () => {

--- a/apps/desktop/tests/services/AppUpdateService/downloads.test.ts
+++ b/apps/desktop/tests/services/AppUpdateService/downloads.test.ts
@@ -88,6 +88,26 @@ describe('preferredAppUpdateDownload', () => {
         );
     });
 
+    it('returns null for known platforms when no matching download is available', () => {
+        const windowsOnlyDownloads: AppUpdateDownload[] = [
+            {
+                kind: 'installer',
+                name: 'TouchAI-0.2.0-windows.msi',
+                url: 'https://example.com/TouchAI-0.2.0-windows.msi',
+                sizeBytes: 1,
+            },
+            {
+                kind: 'updatePackage',
+                name: 'TouchAI-0.2.0-windows-full.nupkg',
+                url: 'https://example.com/TouchAI-0.2.0-windows-full.nupkg',
+                sizeBytes: 1,
+            },
+        ];
+
+        expect(preferredAppUpdateDownload(windowsOnlyDownloads, { os: 'linux' })).toBeNull();
+        expect(preferredAppUpdateDownload(windowsOnlyDownloads, { os: 'macos' })).toBeNull();
+    });
+
     it('returns null when there are no downloads', () => {
         expect(preferredAppUpdateDownload([], { os: 'windows' })).toBeNull();
     });

--- a/apps/desktop/tests/views/SettingsView/navigationSidebar.test.ts
+++ b/apps/desktop/tests/views/SettingsView/navigationSidebar.test.ts
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import { enableAutoUnmount, mount } from '@vue/test-utils';
 import { afterEach, beforeEach, vi } from 'vitest';
 
 import NavigationSidebar from '@/views/SettingsView/components/NavigationSidebar.vue';
@@ -24,6 +24,8 @@ vi.mock('@components/AppIcon.vue', () => ({
 vi.mock('@tauri-apps/plugin-opener', () => ({
     openUrl: openUrlMock,
 }));
+
+enableAutoUnmount(afterEach);
 
 function createPointerEvent(type: string, clientX: number, pointerId = 11) {
     const event = new Event(type, { bubbles: true, cancelable: true });


### PR DESCRIPTION
## Summary

- Return `null` when the runtime OS is known but no release asset matches that OS.
- Keep the generic direct-download fallback only for unknown platforms so known-platform users land on the release page instead of a wrong installer.

## Related issue or RFC

- Closes #363

## AI assistance disclosure

- Tool(s) used: Local development assistant.
- Scope of assistance: Identified the wrong-platform fallback path, implemented the fix, and ran validation.
- Human review or rewrite performed: Reviewed the selector behavior and regression test before submission.
- Architecture or boundary impact: No new boundary or schema change.

## Testing evidence

- `corepack pnpm --dir apps/desktop exec vitest run --configLoader runner tests/services/AppUpdateService/downloads.test.ts` passed.
- `corepack pnpm --dir apps/desktop exec eslint src/services/AppUpdateService/downloads.ts tests/services/AppUpdateService/downloads.test.ts` passed.
- `corepack pnpm --dir apps/desktop exec prettier --check src/services/AppUpdateService/downloads.ts tests/services/AppUpdateService/downloads.test.ts` passed.
- `corepack pnpm --dir apps/desktop run test:typecheck` passed.
- `git diff --check` passed.
- `pnpm test:pr` was not run locally; targeted checks cover the changed update download selector and CI should run the full suite.

Did you follow TDD (test-first) for feature and fix work? A regression test was added with the fix.

```text
corepack pnpm --dir apps/desktop exec vitest run --configLoader runner tests/services/AppUpdateService/downloads.test.ts
corepack pnpm --dir apps/desktop exec eslint src/services/AppUpdateService/downloads.ts tests/services/AppUpdateService/downloads.test.ts
corepack pnpm --dir apps/desktop exec prettier --check src/services/AppUpdateService/downloads.ts tests/services/AppUpdateService/downloads.test.ts
corepack pnpm --dir apps/desktop run test:typecheck
git diff --check
```

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: None.
- database baseline or migration impact: None.
- release or packaging impact: Direct update links now fall back to release page when the current OS has no matching asset.

## Screenshots or recordings

Not UI-facing.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC. (N/A.)
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC. (N/A.)
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [x] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence. (N/A.)
- [x] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof. (N/A.)
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed. (N/A.)