### PR TITLE
fix(agent): sync switched model on active reattach

### DIFF
--- a/apps/desktop/src/composables/agent/useAgentState.ts
+++ b/apps/desktop/src/composables/agent/useAgentState.ts
@@ -172,7 +172,6 @@ export function useAgentState(options: UseAgentStateOptions = {}) {
         detachTaskView();
 
         if (initialSnapshot) {
-            lastObservedModelSwitchCount = initialSnapshot.modelSwitchCount;
             applyTaskSnapshot(initialSnapshot);
         }
 

--- a/apps/desktop/tests/composables/useAgent.test.ts
+++ b/apps/desktop/tests/composables/useAgent.test.ts
@@ -2,8 +2,10 @@ import { mountComposable } from '@tests/utils/composables';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useAgent } from '@/composables/agent/useAgent';
+import type { SessionTaskSnapshot } from '@/services/AgentService';
 
-const { notifyMock, sessionTaskCenterMock } = vi.hoisted(() => ({
+const { findSessionByIdMock, notifyMock, sessionTaskCenterMock } = vi.hoisted(() => ({
+    findSessionByIdMock: vi.fn(),
     notifyMock: vi.fn(),
     sessionTaskCenterMock: {
         attachSessionView: vi.fn(),
@@ -13,6 +15,10 @@ const { notifyMock, sessionTaskCenterMock } = vi.hoisted(() => ({
         startTask: vi.fn(),
         subscribeTask: vi.fn(),
     },
+}));
+
+vi.mock('@database/queries/sessions', () => ({
+    findSessionById: findSessionByIdMock,
 }));
 
 vi.mock('@services/NotificationService', () => ({
@@ -28,8 +34,11 @@ vi.mock('@/services/AgentService', async () => {
     };
 });
 
-function createTaskSnapshot(taskId: string) {
-    return {
+function createTaskSnapshot(
+    taskId: string,
+    overrides: Partial<SessionTaskSnapshot> = {}
+): SessionTaskSnapshot {
+    const snapshot: SessionTaskSnapshot = {
         taskId,
         sessionId: 1,
         turnId: 1,
@@ -39,6 +48,7 @@ function createTaskSnapshot(taskId: string) {
         sessionHistory: [],
         pendingToolApproval: null,
         pendingApprovals: [],
+        pendingUserQuestion: null,
         error: null,
         currentModel: null,
         promptSnapshot: null,
@@ -47,6 +57,8 @@ function createTaskSnapshot(taskId: string) {
         updatedAt: 1,
         modelSwitchCount: 0,
     };
+
+    return Object.assign(snapshot, overrides);
 }
 
 function deferred<T>() {
@@ -67,6 +79,7 @@ function deferred<T>() {
 describe('useAgent', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        findSessionByIdMock.mockResolvedValue({ id: 1, title: 'Active session' });
         sessionTaskCenterMock.attachSessionView.mockReturnValue(null);
         sessionTaskCenterMock.subscribeTask.mockImplementation((_taskId, listener) => {
             listener(createTaskSnapshot('task-1'));
@@ -87,6 +100,45 @@ describe('useAgent', () => {
 
         expect(notifyMock).not.toHaveBeenCalled();
         expect(mounted.result.error.value?.message).toBe('task failed');
+
+        mounted.unmount();
+    });
+
+    it('syncs the selected model when reopening an active session after a model switch', async () => {
+        const switchedSnapshot = createTaskSnapshot('task-1', {
+            currentModel: {
+                modelDbId: 7,
+                providerId: 9,
+                providerName: 'Provider',
+                modelId: 'upgraded-model',
+                modelName: 'Upgraded Model',
+            },
+            modelSwitchCount: 1,
+        });
+        const onModelSelected = vi.fn();
+
+        sessionTaskCenterMock.attachSessionView.mockReturnValue({
+            taskId: 'task-1',
+            snapshot: switchedSnapshot,
+        });
+        sessionTaskCenterMock.subscribeTask.mockImplementation((_taskId, listener) => {
+            listener(switchedSnapshot);
+            return () => undefined;
+        });
+
+        const mounted = await mountComposable(() => useAgent({ onModelSelected }));
+
+        const loadedSession = await mounted.result.openSession(1);
+
+        expect(loadedSession).toMatchObject({
+            modelId: 'upgraded-model',
+            providerId: 9,
+        });
+        expect(onModelSelected).toHaveBeenCalledTimes(1);
+        expect(onModelSelected).toHaveBeenCalledWith({
+            modelId: 'upgraded-model',
+            providerId: 9,
+        });
 
         mounted.unmount();
     });


### PR DESCRIPTION
> First external contributors may need to complete the `CLA Assistant` check before merge.
> For code changes, this PR must link the related issue or RFC in the section below.

## Summary

Fix active session reattach so the initial task snapshot can still emit the selected model when the task has already switched models.

Root cause: `attachTaskView()` seeded `lastObservedModelSwitchCount` from the initial snapshot before applying that snapshot. If the active task had already switched models, the UI treated the switch as already observed and skipped `onModelSelected`.

User-facing impact:

- Reopening a running session now syncs the search view to the model/provider the task is actually using.
- Follow-up requests from that view are less likely to continue with stale model selection after an automatic model switch.
- Duplicate immediate task snapshots still do not emit duplicate model-selection callbacks.

## Related issue or RFC

Closes #365

## AI assistance disclosure

- Tool(s) used: Local development assistant
- Scope of assistance: codebase navigation, bug isolation, implementation, test addition, local validation
- Human review or rewrite performed: I reviewed the affected logic and validated the regression path locally.
- Architecture or boundary impact: No architecture or cross-boundary changes.

## Testing evidence

- `corepack pnpm --dir apps/desktop exec vitest run --configLoader runner tests/composables/useAgent.test.ts` passed.
- `corepack pnpm --dir apps/desktop run type:check` passed.
- `corepack pnpm --dir apps/desktop run test:typecheck` passed.
- `corepack pnpm --dir apps/desktop run lint:check` passed with 0 errors and existing warnings.
- `corepack pnpm --dir apps/desktop run format:check` passed.
- `cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml --all -- --check` passed.
- `corepack pnpm --dir apps/desktop run check:rust` passed with existing Rust warnings.
- `corepack pnpm --dir apps/desktop run test:unit` passed: 117 files, 634 tests.
- `corepack pnpm --dir apps/desktop run test:rust` passed.
- `corepack pnpm --dir apps/desktop run test:coverage` passed: 117 files, 634 tests.
- `corepack pnpm --filter @touchai/site build` passed.

`corepack pnpm test:pr` and `corepack pnpm --filter @touchai/desktop test:pr` could not complete because the repository scripts call `pnpm` directly, while this shell only exposes it through `corepack pnpm`. The underlying steps were run manually as listed above.

Did you follow TDD (test-first) for feature and fix work? Yes. The regression test failed before the fix and passed after the logic change.

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: Only the task-view observer state in the agent composable changes.
- database baseline or migration impact: None.
- release or packaging impact: None.

## Screenshots or recordings

Not applicable; this is a task-state synchronization fix covered by tests.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC or the change is a narrow bug fix that does not alter boundaries.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC or no such change was made.
- [x] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [x] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence, or no Rust behavior changed.
- [x] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof, or those paths were not changed.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed, or no docs update was needed.