### PR TITLE
fix(tauri): migrate macOS reminder delegate to objc2 0.6

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -6858,9 +6858,10 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "touchai"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "base64 0.22.1",
+ "block2 0.6.2",
  "cc",
  "clipboard-rs",
  "flate2",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -117,6 +117,7 @@ webview2-com = "0.38.0"
 windows-core = "0.61.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
+block2 = "0.6"
 objc2 = "0.6"
 objc2-foundation = "0.3"
 objc2-user-notifications = "0.3"

--- a/apps/desktop/src-tauri/src/core/window/status_reminder.rs
+++ b/apps/desktop/src-tauri/src/core/window/status_reminder.rs
@@ -706,8 +706,8 @@ mod macos_notifications {
     use std::sync::{Mutex, OnceLock};
 
     use log::warn;
-    use objc2::declare_class;
-    use objc2_foundation::{NSArray, NSObject, NSString};
+    use objc2::{define_class, msg_send, rc::Retained, runtime::ProtocolObject, MainThreadOnly};
+    use objc2_foundation::{MainThreadMarker, NSArray, NSObject, NSObjectProtocol, NSString};
     use objc2_user_notifications::{
         UNMutableNotificationContent, UNNotificationAction, UNNotificationCategory,
         UNNotificationRequest, UNNotificationResponse, UNTextInputNotificationResponse,
@@ -724,7 +724,7 @@ mod macos_notifications {
     type ActionCallback = Box<dyn Fn(&str) + Send>;
 
     static ACTION_CALLBACK: OnceLock<Mutex<Option<ActionCallback>>> = OnceLock::new();
-    static DELEGATE_INSTANCE: OnceLock<TouchAINotificationDelegate> = OnceLock::new();
+    static DELEGATE_INSTANCE: OnceLock<Retained<TouchAINotificationDelegate>> = OnceLock::new();
 
     /// Register the callback invoked from the notification-center delegate when
     /// the user interacts with a delivered notification.
@@ -740,7 +740,7 @@ mod macos_notifications {
     fn ensure_delegate_registered(center: &UNUserNotificationCenter) {
         DELEGATE_INSTANCE.get_or_init(|| {
             let delegate = TouchAINotificationDelegate::new();
-            center.setDelegate(&delegate);
+            center.setDelegate(Some(ProtocolObject::from_ref(&*delegate)));
             delegate
         });
     }
@@ -748,20 +748,22 @@ mod macos_notifications {
     /// Objective-C delegate that translates `UNUserNotificationCenter` action
     /// responses into serialised Rust payloads and forwards them through the
     /// registered callback.
-    declare_class!(
+    define_class!(
+        #[unsafe(super(NSObject))]
+        #[thread_kind = MainThreadOnly]
         pub(crate) struct TouchAINotificationDelegate;
 
-        unsafe impl ClassType for TouchAINotificationDelegate {
-            type Super = NSObject;
-        }
+        unsafe impl NSObjectProtocol for TouchAINotificationDelegate {}
 
         unsafe impl UNUserNotificationCenterDelegate for TouchAINotificationDelegate {
-            #[method(userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:)]
+            #[unsafe(method(
+                userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:
+            ))]
             fn did_receive_response(
                 &self,
                 _center: &UNUserNotificationCenter,
                 response: &UNNotificationResponse,
-                completion_handler: &objc2_foundation::Block<dyn Fn()>,
+                completion_handler: &block2::DynBlock<dyn Fn()>,
             ) {
                 let action_id = response.actionIdentifier().to_string();
                 let request = response.notification().request();
@@ -797,10 +799,19 @@ mod macos_notifications {
                     }
                 }
 
-                completion_handler.call();
+                completion_handler.call(());
             }
         }
     );
+
+    impl TouchAINotificationDelegate {
+        fn new() -> Retained<Self> {
+            let mtm = MainThreadMarker::new()
+                .expect("macOS notification delegate must be created on the main thread");
+            let delegate = Self::alloc(mtm);
+            unsafe { msg_send![delegate, init] }
+        }
+    }
 
     /// Enrich the base payload JSON with the action identifier and optional
     /// reply text so that the frontend receives a complete action payload.


### PR DESCRIPTION
## Summary

- Fix the macOS notification delegate to compile with `objc2` 0.6 by switching to the new `define_class!` pattern.
- Keep the `block2` dependency scoped to macOS only so Windows/Linux checks stay platform-correct.

## Related issue or RFC

- Closes #356

## AI assistance disclosure

- Tool(s) used: OpenAI Codex
- Scope of assistance: diagnosed the CI failure, implemented the compatibility fix, and validated the result locally
- Human review or rewrite performed: I reviewed the code and kept the change scoped to compile compatibility
- Architecture or boundary impact: none beyond the macOS notification binding layer

## Testing evidence

- `cargo fmt --check --manifest-path apps/desktop/src-tauri/Cargo.toml --` ✅
- `cargo metadata --locked --format-version 1 --no-deps` ✅
- `pnpm test:pr` ✅ locally, with repo-wide lint warnings and non-fatal Rust warnings still present
- `pnpm test:pr` initially failed only because the worktree lacked `node_modules`; after `pnpm install --frozen-lockfile`, it completed

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: none
- database baseline or migration impact: none
- release or packaging impact: minimal; this is a compile-compatibility fix for macOS release assets

## Screenshots or recordings

- Not applicable

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [x] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [x] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [x] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.