### PR TITLE
ci(workflows): disable setup-node cache for windows e2e smoke

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -128,7 +128,7 @@ jobs:
             - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
                   node-version: 22
-                  cache: pnpm
+                  package-manager-cache: false
 
             - name: Install Rust stable
               uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable


### PR DESCRIPTION
## Summary
This PR unblocks `Desktop E2E Smoke (Windows)` by disabling `actions/setup-node@v6` package-manager caching in the Windows smoke workflow.

The failing run never reached dependency installation or any TouchAI code. It failed during `setup-node` immediately after resolving the pnpm store path on the hosted Windows runner, so this change targets the workflow-level failure directly.

## Related issue or RFC
- Closes #370

## AI assistance disclosure
- Tool(s) used: Codex
- Scope of assistance: failure log analysis, workflow patch drafting, issue/PR authoring support
- Human review or rewrite performed: reviewed the failing job logs, inspected workflow usage patterns in the repo, verified the final one-line workflow diff before push
- Architecture or boundary impact: none; workflow-only change in CI configuration

## Testing evidence
Observed failure evidence:
- GitHub Actions run `26741039512`, job `Desktop E2E Smoke (Windows)` (`78804908540`)
- Failure occurs in `actions/setup-node@v6` after `pnpm/action-setup@v6`
- `pnpm.CMD store path --silent` resolves to `D:\.pnpm-store\v10`
- Job exits before dependency install or E2E steps

Local verification performed:
```text
python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/e2e-smoke.yml').read_text(encoding='utf-8')); print('YAML_OK')"
git diff --check
```

Local commands not completed:
- `pnpm test:pr`
- `pnpm test:e2e`
- `npx tsc --noEmit`

Blocker:
- local disk space exhaustion (`ENOSPC`) while resolving/installing Node package execution dependencies on this machine
- because this is a workflow-only CI fix and the original failure happens before project code runs, GitHub Actions is the first valid end-to-end proof for this change

Did you follow TDD (test-first) for feature and fix work? No. This is a workflow-only CI fix without an appropriate local automated regression seam.

## Risk notes
- `AgentService`, runtime, MCP, or schema impact: none
- database baseline or migration impact: none
- release or packaging impact: low; Windows E2E smoke job loses `setup-node` package-manager cache setup, trading some install speed for runner stability

## Screenshots or recordings
Not applicable.

## Checklist
- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [ ] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [ ] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.
