### PR TITLE
ci(release): deploy update proxy as custom domain

### DIFF
--- a/apps/desktop/product.json
+++ b/apps/desktop/product.json
@@ -19,8 +19,7 @@
                 "provider": "cloudflare-r2",
                 "bucketName": "touchai-updates",
                 "workerName": "touchai-update-proxy",
-                "routePattern": "updates.touch-ai.org/touchai-app/v1/*",
-                "zoneName": "touch-ai.org",
+                "hostname": "updates.touch-ai.org",
                 "compatibilityDate": "2026-05-29",
                 "r2HotAssetVersions": {
                     "stable": 3,

--- a/apps/desktop/scripts/ci/write-cloudflare-update-worker-config.mjs
+++ b/apps/desktop/scripts/ci/write-cloudflare-update-worker-config.mjs
@@ -27,8 +27,7 @@ export function buildCloudflareUpdateWorkerConfig(product, options) {
 
     assertNonEmptyString(deployment.workerName, 'services.updates.deployment.workerName');
     assertNonEmptyString(deployment.bucketName, 'services.updates.deployment.bucketName');
-    assertNonEmptyString(deployment.routePattern, 'services.updates.deployment.routePattern');
-    assertNonEmptyString(deployment.zoneName, 'services.updates.deployment.zoneName');
+    assertNonEmptyString(deployment.hostname, 'services.updates.deployment.hostname');
     assertNonEmptyString(
         deployment.compatibilityDate,
         'services.updates.deployment.compatibilityDate'
@@ -40,11 +39,9 @@ export function buildCloudflareUpdateWorkerConfig(product, options) {
         `main = ${tomlString(normalizePath(options.workerScriptPath))}`,
         `compatibility_date = ${tomlString(deployment.compatibilityDate)}`,
         '',
-        'routes = [',
-        `    { pattern = ${tomlString(deployment.routePattern)}, zone_name = ${tomlString(
-            deployment.zoneName
-        )} },`,
-        ']',
+        '[[routes]]',
+        `pattern = ${tomlString(deployment.hostname)}`,
+        'custom_domain = true',
         '',
         '[[r2_buckets]]',
         'binding = "UPDATE_BUCKET"',

--- a/apps/desktop/tests/ci/write-cloudflare-update-worker-config.test.ts
+++ b/apps/desktop/tests/ci/write-cloudflare-update-worker-config.test.ts
@@ -41,6 +41,9 @@ describe('writeCloudflareUpdateWorkerConfig', () => {
         expect(config).toContain(`binding = "UPDATE_BUCKET"`);
         expect(config).toContain(`UPDATE_BASE_PATH = "touchai-app/v1"`);
         expect(config).toContain(`GITHUB_REPOSITORY = "TouchAI-org/TouchAI"`);
+        expect(config).toContain(`[[routes]]`);
+        expect(config).toContain(`pattern = "updates.touch-ai.org"`);
+        expect(config).toContain(`custom_domain = true`);
     });
 
     it('writes a config whose Worker main path is relative to the output file', async () => {


### PR DESCRIPTION
﻿## Summary

- Switch the Cloudflare update proxy deployment from a route pattern to a Worker custom domain on `updates.touch-ai.org`.
- Keep the R2 binding and update path filtering in the Worker, so `/touchai-app/v1/*` remains the public update namespace.
- Update the worker config generation test to assert the custom-domain trigger.

## Related issue or RFC

- Related to #48

## AI assistance disclosure

- Tool(s) used: Codex
- Scope of assistance: Implemented the deployment config change, deployed it with Wrangler, and verified the live update endpoint.
- Human review or rewrite performed: Maintainer review required before merge.
- Architecture or boundary impact: None. This changes Cloudflare deployment wiring only.

## Testing evidence

```text
node scripts/ci/write-cloudflare-update-worker-config.mjs E:\TouchAI\tmp\wrangler-update-custom-domain.toml
# Pass. Generated config contains [[routes]], pattern = "updates.touch-ai.org", custom_domain = true.

pnpm dlx wrangler@3.90.0 deploy --config E:\TouchAI\tmp\wrangler-update-custom-domain.toml --dry-run
# Pass. Worker bundles with UPDATE_BUCKET R2 binding and update vars.

pnpm dlx wrangler@3.90.0 deploy --config E:\TouchAI\tmp\wrangler-update-custom-domain.toml
# Pass. Deployed touchai-update-proxy, trigger: updates.touch-ai.org (custom domain), version 2069bd15-43c5-40e0-9b9e-90bedbd193aa.

gh workflow run release.yml --ref main -f channel=beta -f version=1.0.0-beta.4
# Pass. Run https://github.com/TouchAI-org/TouchAI/actions/runs/26747550583 completed successfully.

curl.exe -I -L https://updates.touch-ai.org/touchai-app/v1/releases.beta.json
# Pass. HTTP 200, cache-control public max-age=60.

curl.exe -I -L https://updates.touch-ai.org/touchai-app/v1/TouchAI-beta-1.0.0-beta.4-windows.msi
# Pass. HTTP 200, content-length 19726336, accept-ranges bytes.

curl.exe -I -L -H "Range: bytes=0-1023" https://updates.touch-ai.org/touchai-app/v1/TouchAI-beta-1.0.0-beta.4-windows-full.nupkg
# Pass. HTTP 206, content-range bytes 0-1023/18195694.

git diff --check -- apps/desktop/product.json apps/desktop/scripts/ci/write-cloudflare-update-worker-config.mjs apps/desktop/tests/ci/write-cloudflare-update-worker-config.test.ts
# Pass.
```

Local `prettier`, `eslint`, `tsc`, and `vitest` commands could not run in this worktree because the local dependency installation is incomplete: `prettier-plugin-astro`, `eslint`, `tsc`, and `vitest` executables/packages are missing. CI should provide those checks.

TDD: No. This is deployment configuration repair. The existing generator test was updated for the new trigger shape.

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: none
- database baseline or migration impact: none
- release or packaging impact: deployment wiring only; live Cloudflare update endpoint has already been deployed and verified

## Screenshots or recordings

N/A. Verification is via live endpoint and workflow logs above.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [ ] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [x] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [x] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.
