### PR TITLE
fix(site): refine portrait demo and glimm scope

### DIFF
--- a/apps/site/src/components/ComponentDemo.astro
+++ b/apps/site/src/components/ComponentDemo.astro
@@ -318,18 +318,35 @@ ${instanceSelector}.feature-reminder-frame.is-complete .chat-panel {
     height: 100% !important;
 }
 
+@media (max-width: 900px) {
+    ${instanceSelector}.component-frame {
+        width: min(60vw, 520px, 100%) !important;
+        height: auto !important;
+        min-height: 0 !important;
+        aspect-ratio: 760 / 657 !important;
+        max-height: min(62vh, 657px) !important;
+    }
+
+    ${instanceSelector}.component-frame .stage {
+        height: 100% !important;
+        min-height: 0 !important;
+    }
+}
+
 @media (max-width: 560px) {
     ${instanceSelector}.component-frame {
         width: min(calc(100vw - 56px), 360px, 100%) !important;
         max-width: min(calc(100vw - 56px), 360px, 100%) !important;
-        height: 560px !important;
-        min-height: 560px !important;
+        height: auto !important;
+        min-height: 0 !important;
+        aspect-ratio: 760 / 657 !important;
+        max-height: min(58vh, 420px) !important;
         overflow: visible !important;
     }
 
     ${instanceSelector}.component-frame .stage {
-        min-height: 560px !important;
-        height: 560px !important;
+        min-height: 0 !important;
+        height: 100% !important;
         padding: 0 !important;
         align-items: center !important;
         justify-content: center !important;

--- a/apps/site/src/pages/index.astro
+++ b/apps/site/src/pages/index.astro
@@ -1144,6 +1144,33 @@ const docsUrl = 'https://touch-ai.org/getting-started';
                     padding: 28px 18px 34px;
                 }
 
+                .visual-section {
+                    min-height: auto;
+                    padding: 48px 0 64px;
+                }
+
+                .visual-shell {
+                    min-height: auto;
+                    display: block;
+                    padding: 24px 0;
+                }
+
+                .visual-stage {
+                    height: auto;
+                    min-height: auto;
+                    display: grid;
+                    place-items: center;
+                    overflow: visible;
+                }
+
+                .component-frame {
+                    width: min(60vw, 520px, 100%);
+                    height: auto;
+                    aspect-ratio: 760 / 657;
+                    max-height: min(62vh, 657px);
+                    min-height: 0;
+                }
+
                 .feature-block-shell,
                 .scenario-grid,
                 .quote-row {
@@ -1296,7 +1323,7 @@ const docsUrl = 'https://touch-ai.org/getting-started';
 
                 .visual-stage {
                     height: auto;
-                    min-height: 560px;
+                    min-height: auto;
                     display: grid;
                     place-items: center;
                     overflow: visible;
@@ -1304,8 +1331,10 @@ const docsUrl = 'https://touch-ai.org/getting-started';
 
                 .component-frame {
                     width: min(100%, 360px);
-                    height: 560px;
-                    min-height: 560px;
+                    height: auto;
+                    aspect-ratio: 760 / 657;
+                    max-height: min(58vh, 420px);
+                    min-height: 0;
                     max-width: 360px;
                 }
 
@@ -2378,64 +2407,26 @@ const docsUrl = 'https://touch-ai.org/getting-started';
                     });
                 });
 
-                document.querySelectorAll('a.interactive-click').forEach((target) => {
-                    target.addEventListener('click', (event) => {
-                        const href = target.getAttribute('href');
-                        if (!href || target.dataset.glimmSkip === 'true') return;
-                        if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey)
-                            return;
-                        event.preventDefault();
-                        target.classList.remove('is-pressing');
-
-                        const isExternal = target.target === '_blank' || /^https?:\/\//.test(href);
-                        playGlimmSweep(() => {
-                            if (href.startsWith('#')) {
-                                const destination = document.querySelector(href);
-                                if (destination) {
-                                    destination.scrollIntoView({
-                                        behavior: 'smooth',
-                                        block: 'start',
-                                    });
-                                }
-                                if (history.replaceState) {
-                                    history.replaceState(null, '', href);
-                                }
-                                return;
-                            }
-                            if (isExternal) {
-                                window.open(href, target.target || '_blank', 'noopener,noreferrer');
-                                return;
-                            }
-                            window.location.href = href;
-                        });
-                    });
-                });
-
-                document.querySelectorAll('button.interactive-click').forEach((target) => {
+                document.querySelectorAll('.theme-toggle, .lang-toggle').forEach((target) => {
                     target.addEventListener(
                         'click',
                         (event) => {
-                            if (target.dataset.glimmBound === 'true') return;
-                            if (target.closest('.theme-toggle') || target.closest('.lang-toggle')) {
-                                event.stopImmediatePropagation();
-                                event.preventDefault();
-                                target.classList.remove('is-pressing');
-                                playGlimmSweep(() => {
-                                    if (target.classList.contains('theme-toggle')) {
-                                        setTheme(
-                                            document.documentElement.dataset.theme === 'dark'
-                                                ? 'light'
-                                                : 'dark'
-                                        );
-                                        return;
-                                    }
-                                    if (target.classList.contains('lang-toggle')) {
-                                        const nextLanguage =
-                                            document.documentElement.lang === 'en' ? 'zh' : 'en';
-                                        setLanguage(nextLanguage);
-                                    }
-                                });
-                            }
+                            event.stopImmediatePropagation();
+                            event.preventDefault();
+                            target.classList.remove('is-pressing');
+                            playGlimmSweep(() => {
+                                if (target.classList.contains('theme-toggle')) {
+                                    setTheme(
+                                        document.documentElement.dataset.theme === 'dark'
+                                            ? 'light'
+                                            : 'dark'
+                                    );
+                                    return;
+                                }
+                                const nextLanguage =
+                                    document.documentElement.lang === 'en' ? 'zh' : 'en';
+                                setLanguage(nextLanguage);
+                            });
                         },
                         true
                     );

--- a/apps/site/src/scripts/component-demo-runtime.ts
+++ b/apps/site/src/scripts/component-demo-runtime.ts
@@ -160,18 +160,35 @@ touchai-component-demo[data-demo-id="${id}"].feature-reminder-frame.is-complete 
     height: 100% !important;
 }
 
+@media (max-width: 900px) {
+    touchai-component-demo[data-demo-id="${id}"].component-frame {
+        width: min(60vw, 520px, 100%) !important;
+        height: auto !important;
+        min-height: 0 !important;
+        aspect-ratio: 760 / 657 !important;
+        max-height: min(62vh, 657px) !important;
+    }
+
+    touchai-component-demo[data-demo-id="${id}"].component-frame .stage {
+        height: 100% !important;
+        min-height: 0 !important;
+    }
+}
+
 @media (max-width: 560px) {
     touchai-component-demo[data-demo-id="${id}"].component-frame {
         width: min(calc(100vw - 56px), 360px, 100%) !important;
         max-width: min(calc(100vw - 56px), 360px, 100%) !important;
-        height: 560px !important;
-        min-height: 560px !important;
+        height: auto !important;
+        min-height: 0 !important;
+        aspect-ratio: 760 / 657 !important;
+        max-height: min(58vh, 420px) !important;
         overflow: visible !important;
     }
 
     touchai-component-demo[data-demo-id="${id}"].component-frame .stage {
-        min-height: 560px !important;
-        height: 560px !important;
+        min-height: 0 !important;
+        height: 100% !important;
         padding: 0 !important;
         align-items: center !important;
         justify-content: center !important;


### PR DESCRIPTION
## Summary

Refines the TouchAI site follow-up after PR #374:

- constrains the intro demo height on portrait/tablet layouts so it keeps the same 760:657 visual ratio as the feature demos
- keeps the existing glimm sweep configuration, but limits sweep activation to theme and language toggles only
- lets ordinary links and buttons use normal navigation/click behavior without the glimm page sweep

## Related issue or RFC

Link the issue or RFC:

- Related to #374

## AI assistance disclosure

- Tool(s) used: Codex
- Scope of assistance: implemented the site CSS/runtime follow-up, verified responsive sizing and glimm trigger scope, prepared this PR
- Human review or rewrite performed: pending maintainer review
- Architecture or boundary impact: none; scoped to `apps/site`

## Testing evidence

```text
pnpm exec prettier --check "apps/site/src/pages/index.astro" "apps/site/src/components/ComponentDemo.astro" "apps/site/src/scripts/component-demo-runtime.ts" --ignore-path .prettierignore
# pass

pnpm exec eslint apps/site/src/scripts/component-demo-runtime.ts
# pass

pnpm run site:build
# pass
```

Browser verification on `http://127.0.0.1:4322/`:

- portrait intro demo frame measured around `377x326`, matching the 760:657 ratio with no horizontal overflow
- expanded intro demo stayed within the constrained frame while scrolling
- ordinary logo link did not create a glimm canvas or transition state
- theme and language toggles created the glimm canvas, entered the transition state, switched state/language, and later cleared `is-glimm-transitioning`

`pnpm test:pr` was not run locally because this change is limited to the site package and does not touch desktop/runtime behavior; CI remains the broader proof.

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: none
- database baseline or migration impact: none
- release or packaging impact: none

## Screenshots or recordings

No static screenshot attached; browser measurements above cover the affected responsive and interaction behavior.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [x] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [x] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.