### PR TITLE
docs(readme): update site links

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -18,7 +18,7 @@
 </p>
 
 <p align="center">
-  On demand · Desktop context · MCP · BYOK
+  <a href="https://touch-ai.org/">Website</a> · <a href="https://hub.touch-ai.org/">Hub</a>
 </p>
 
 <p align="center">
@@ -30,9 +30,6 @@
 <p align="center">
   <img src="docs/images/touchai-mimo.en.png" alt="TouchAI × Xiaomi MIMO" />
 </p>
-
-> [!WARNING]
-> Many features are still pending merge and may undergo breaking changes. Version 1.0 will be released when the June 1 free token event officially launches.
 
 ### Features
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 </p>
 
 <p align="center">
-  随叫随到 · 桌面上下文 · MCP · BYOK
+  <a href="https://touch-ai.org/">官网</a> · <a href="https://hub.touch-ai.org/">Hub 站</a>
 </p>
 
 <p align="center">
@@ -30,9 +30,6 @@
 <p align="center">
   <img src="docs/images/touchai-mimo.png" alt="TouchAI × 小米 MIMO" />
 </p>
-
-> [!WARNING]
-> 当前尚有大量功能未合并，可能会破坏性升级。6.1 限免活动正式启动后将推送 1.0 正式版。
 
 ### 功能特性
 


### PR DESCRIPTION
## Summary

- Replace the README tagline row with links to the official website and TouchAI Hub in both Chinese and English READMEs.
- Remove the outdated warning block about pending features and the June 1 free token event.

## Related issue or RFC

No issue is required for this documentation wording/link cleanup. Repository link: https://github.com/TouchAI-org/TouchAI

## AI assistance disclosure

- Tool(s) used: Codex
- Scope of assistance: Edited README link and warning text, verified the resulting diff, prepared this PR.
- Human review or rewrite performed: Requested and reviewed by maintainer in this thread.
- Architecture or boundary impact: None.

## Testing evidence

```text
git diff --check -- README.md README.en.md
pnpm exec prettier --check README.md README.en.md
```

Both commands passed locally.

`npx tsc --noEmit` was attempted from the repository root before commit, but the root has no `tsconfig.json`, so TypeScript printed help and exited 1. This PR is docs-only and does not require TypeScript compilation.

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: none
- database baseline or migration impact: none
- release or packaging impact: none

## Screenshots or recordings

Not applicable; README text/link update only.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [x] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [x] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [x] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.