### PR TITLE
fix(search): remeasure window height on activation

### DIFF
--- a/apps/desktop/src/views/SearchView/composables/useSearchPage.ts
+++ b/apps/desktop/src/views/SearchView/composables/useSearchPage.ts
@@ -382,6 +382,7 @@ interface UseSearchPageLifecycleOptions {
     clearSession: () => void | Promise<void>;
     shouldClearSessionAfterTimeout?: () => boolean | Promise<boolean>;
     reconcilePopupSurfaces?: () => Promise<void>;
+    remeasureSearchWindowHeight?: () => void | Promise<void>;
     onSurfaceHidden?: () => void | Promise<void>;
     handleSearchSurfaceCommand?: (payload: {
         command: 'toggle-model-dropdown';
@@ -406,6 +407,7 @@ export function useSearchPageLifecycle(options: UseSearchPageLifecycleOptions) {
         clearSession,
         shouldClearSessionAfterTimeout,
         reconcilePopupSurfaces,
+        remeasureSearchWindowHeight,
         onSurfaceHidden,
         handleSearchSurfaceCommand,
         handleSessionStatusReminderAction,
@@ -492,6 +494,7 @@ export function useSearchPageLifecycle(options: UseSearchPageLifecycleOptions) {
         await controller.focusSearchInput();
         await controller.loadActiveModel();
         await syncWindowPinStateSafely('focus');
+        await remeasureSearchWindowHeightSafely('activation');
 
         if (surfaceSource !== 'shortcut') {
             return;
@@ -583,6 +586,17 @@ export function useSearchPageLifecycle(options: UseSearchPageLifecycleOptions) {
             await syncWindowPinState();
         } catch (error) {
             console.error(`[SearchView] Failed to sync window pin state on ${reason}:`, error);
+        }
+    }
+
+    async function remeasureSearchWindowHeightSafely(reason: 'activation') {
+        try {
+            await Promise.resolve(remeasureSearchWindowHeight?.());
+        } catch (error) {
+            console.error(
+                `[SearchView] Failed to remeasure search window height on ${reason}:`,
+                error
+            );
         }
     }
 

--- a/apps/desktop/src/views/SearchView/index.vue
+++ b/apps/desktop/src/views/SearchView/index.vue
@@ -409,6 +409,7 @@
         clearSession: clearSessionToIdle,
         shouldClearSessionAfterTimeout,
         reconcilePopupSurfaces: hideAllPopups,
+        remeasureSearchWindowHeight: remeasureTargetHeight,
         onSurfaceHidden: clearSurfaceUiAfterHidden,
         handleSearchSurfaceCommand: async (payload) => {
             if (payload.command === 'toggle-model-dropdown') {

--- a/apps/desktop/tests/composables/SearchView/useSearchPage.test.ts
+++ b/apps/desktop/tests/composables/SearchView/useSearchPage.test.ts
@@ -725,4 +725,62 @@ describe('useSearchPageLifecycle', () => {
 
         mounted.unmount();
     });
+
+    it('remeasures the search window height when a hidden completed session is reopened', async () => {
+        const controller = createController();
+        const interactionContext = createSearchInteractionContext();
+        const clearSession = vi.fn().mockResolvedValue(undefined);
+        const reconcilePopupSurfaces = vi.fn().mockResolvedValue(undefined);
+        const handleShortcutAutoPaste = vi.fn().mockResolvedValue(undefined);
+        const syncWindowPinState = vi.fn().mockResolvedValue(false);
+        const remeasureSearchWindowHeight = vi.fn().mockResolvedValue(undefined);
+
+        const mounted = await mountComposable(() =>
+            useSearchPageLifecycle({
+                controller: controller as never,
+                viewReady: ref(true),
+                isDragging: ref(false),
+                isPinned: ref(false),
+                interactionContext,
+                syncWindowPinState,
+                clearSession,
+                shouldClearSessionAfterTimeout: () => false,
+                reconcilePopupSurfaces,
+                handleShortcutAutoPaste,
+                remeasureSearchWindowHeight,
+            })
+        );
+
+        await flushLifecycle();
+
+        const surfaceHiddenHandler = eventHandlers.get(AppEvent.SEARCH_SURFACE_HIDDEN);
+        const statusHandler = eventHandlers.get(AppEvent.SESSION_TASK_STATUS_CHANGED);
+        const surfaceShownHandler = eventHandlers.get(AppEvent.SEARCH_SURFACE_SHOWN);
+        expect(surfaceHiddenHandler).toBeDefined();
+        expect(statusHandler).toBeDefined();
+        expect(surfaceShownHandler).toBeDefined();
+
+        await surfaceHiddenHandler!({
+            sequence: 1,
+            reason: 'app-blur-hide',
+        });
+        await flushLifecycle();
+        await statusHandler!(createStatusChangedPayload('completed'));
+        await flushLifecycle();
+
+        remeasureSearchWindowHeight.mockClear();
+
+        await surfaceShownHandler!({
+            source: 'notification',
+            sequence: 2,
+        });
+        await flushLifecycle();
+
+        expect(remeasureSearchWindowHeight).toHaveBeenCalledTimes(1);
+        expect(reconcilePopupSurfaces).toHaveBeenCalledTimes(1);
+        expect(controller.focusSearchInput).toHaveBeenCalledTimes(1);
+        expect(controller.loadActiveModel).toHaveBeenCalledTimes(1);
+
+        mounted.unmount();
+    });
 });


### PR DESCRIPTION
## Summary

- Re-measures the SearchView-managed window height whenever the search surface is activated again.
- Routes activation restore through the existing `remeasureTargetHeight` path, so a completed background session expands to its content height after wake instead of keeping the pre-blur collapsed height.
- Adds a lifecycle regression test for reopening a hidden completed session.

## Related issue or RFC

- Closes #378

## AI assistance disclosure

- Tool(s) used: OpenAI Codex
- Scope of assistance: Root-cause tracing, implementation, regression test, local verification, and PR preparation.
- Human review or rewrite performed: Pending maintainer review.
- Architecture or boundary impact: None; this is frontend SearchView lifecycle wiring only.

## Testing evidence

Passed locally after rebasing onto `origin/main`:

```text
pnpm --filter @touchai/desktop exec vitest run tests/composables/SearchView/useSearchPage.test.ts tests/composables/SearchView/useSearchWindowResize.test.ts tests/SearchView/windowSizing.test.ts --configLoader runner
# 3 test files passed, 34 tests passed

pnpm --filter @touchai/desktop type:check
# passed

pnpm --filter @touchai/desktop test:typecheck
# passed

pnpm --filter @touchai/desktop exec eslint src/views/SearchView/composables/useSearchPage.ts src/views/SearchView/index.vue tests/composables/SearchView/useSearchPage.test.ts
# passed

pnpm exec prettier --check apps/desktop/src/views/SearchView/composables/useSearchPage.ts apps/desktop/src/views/SearchView/index.vue apps/desktop/tests/composables/SearchView/useSearchPage.test.ts --ignore-path .prettierignore
# passed
```

Not fully completed locally:

```text
pnpm test:pr
# attempted twice; local runs timed out before returning a pass/fail result

pnpm --filter @touchai/desktop test:unit
# 117 files passed; 667/673 tests passed
# remaining 6 failures were 5s timeouts in CI/release script tests unrelated to this SearchView change
```

TDD note: the new lifecycle regression test failed first because activation did not call `remeasureSearchWindowHeight`; after wiring the activation path, it passed.

## Risk notes

- AgentService, runtime, MCP, or schema impact: none.
- Database baseline or migration impact: none.
- Release or packaging impact: none.

## Screenshots or recordings

Not included; this behavior is covered by SearchView lifecycle regression tests and CI E2E.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] AI assistance is disclosed above.
- [x] This does not touch AgentService, runtime, MCP, schema, or cross-boundary architecture.
- [ ] `pnpm test:pr` completed locally. It timed out twice; relying on CI for the full aggregate result.
- [x] Desktop window/search coverage is documented above; CI E2E is also being monitored.
- [x] I added a regression test for the bug.
- [x] No docs update is needed for this behavior fix.