### PR TITLE
fix(agent-service): refresh model metadata on startup

### DIFF
--- a/apps/desktop/src/bootstrap.ts
+++ b/apps/desktop/src/bootstrap.ts
@@ -1,5 +1,6 @@
 // Copyright (c) 2026. 千诚. Licensed under GPL v3.
 
+import { isLlmMetadataEmpty, syncAllModelsMetadata } from '@database/queries';
 import { appUpdateService } from '@services/AppUpdateService';
 import { completeManagedLogin, initializeManagedProviderState } from '@services/AuthService';
 import {
@@ -18,6 +19,7 @@ import { createApp } from 'vue';
 import App from './App.vue';
 import { installI18n } from './i18n';
 import router from './router';
+import { updateModelMetadata } from './services/AgentService/infrastructure/modelMetadata';
 import { useSettingsStore } from './stores/settings';
 import { initializeFontLoader } from './utils/font';
 
@@ -166,12 +168,26 @@ async function setupDeepLinkListener(): Promise<void> {
     }
 }
 
+async function initializeModelMetadata(): Promise<void> {
+    try {
+        if (await isLlmMetadataEmpty()) {
+            await updateModelMetadata();
+            return;
+        }
+
+        await syncAllModelsMetadata();
+    } catch (error) {
+        console.warn('[Bootstrap] Failed to initialize model metadata:', error);
+    }
+}
+
 export async function initializeApp() {
     initializeLogger();
     setupLinkInterceptor();
     document.addEventListener('contextmenu', (event) => event.preventDefault());
     initializeFontLoader();
     await initializeManagedProviderState();
+    await initializeModelMetadata();
     await setupDeepLinkListener();
 
     const app = createApp(App);

--- a/apps/desktop/src/services/AgentService/catalog/models.ts
+++ b/apps/desktop/src/services/AgentService/catalog/models.ts
@@ -1,61 +1,13 @@
 // Copyright (c) 2026. Qian Cheng. Licensed under GPL v3
 
-import {
-    findDefaultModelWithProvider,
-    findModelByProviderAndModelId,
-    findModelsWithProvider,
-    findProviderById,
-} from '@database/queries';
+import { findDefaultModelWithProvider, findModelByProviderAndModelId } from '@database/queries';
 import type { ModelWithProvider } from '@database/queries/models';
 
 import { AiError, AiErrorCode } from '../contracts/errors';
-import {
-    isTouchAiManagedMode,
-    isTouchAiManagedModel,
-    parseProviderConfigJson,
-    TOUCHAI_HUB_MANAGED_MODELS,
-} from '../infrastructure/providers/config';
 
 export interface GetModelOptions {
     providerId?: number;
     modelId?: string;
-}
-
-async function resolveManagedTouchAiModel(
-    providerId: number,
-    requestedModelId?: string
-): Promise<ModelWithProvider | null> {
-    const provider = await findProviderById({ id: providerId });
-    if (
-        !provider ||
-        provider.driver !== 'mimo' ||
-        provider.is_builtin !== 1 ||
-        !isTouchAiManagedMode(parseProviderConfigJson(provider.config_json), provider.api_endpoint)
-    ) {
-        return null;
-    }
-
-    const models = await findModelsWithProvider({ providerId });
-    const managedModels = models.filter((model) => isTouchAiManagedModel(model.model_id));
-    if (managedModels.length === 0) {
-        return null;
-    }
-
-    if (requestedModelId) {
-        const exactMatch = managedModels.find((model) => model.model_id === requestedModelId);
-        if (exactMatch) {
-            return exactMatch;
-        }
-    }
-
-    for (const supportedModelId of TOUCHAI_HUB_MANAGED_MODELS) {
-        const matchedModel = managedModels.find((model) => model.model_id === supportedModelId);
-        if (matchedModel) {
-            return matchedModel;
-        }
-    }
-
-    return managedModels[0] ?? null;
 }
 
 /**
@@ -63,12 +15,10 @@ async function resolveManagedTouchAiModel(
  */
 export async function getModel(options?: GetModelOptions): Promise<ModelWithProvider> {
     if (options?.providerId != null && options.modelId) {
-        const model =
-            (await resolveManagedTouchAiModel(options.providerId, options.modelId)) ??
-            (await findModelByProviderAndModelId({
-                providerId: options.providerId,
-                modelId: options.modelId,
-            }));
+        const model = await findModelByProviderAndModelId({
+            providerId: options.providerId,
+            modelId: options.modelId,
+        });
 
         if (!model) {
             throw new AiError(AiErrorCode.MODEL_NOT_FOUND, {
@@ -88,18 +38,11 @@ export async function getModel(options?: GetModelOptions): Promise<ModelWithProv
     }
 
     const defaultModel = await findDefaultModelWithProvider();
-    const resolvedDefaultModel =
-        defaultModel == null
-            ? null
-            : ((await resolveManagedTouchAiModel(
-                  defaultModel.provider_id,
-                  defaultModel.model_id
-              )) ?? defaultModel);
 
-    if (!resolvedDefaultModel) {
+    if (!defaultModel) {
         console.warn('[Catalog] No default model found or provider disabled');
         throw new AiError(AiErrorCode.NO_ACTIVE_MODEL);
     }
 
-    return resolvedDefaultModel;
+    return defaultModel;
 }

--- a/apps/desktop/src/services/AgentService/infrastructure/modelMetadata.ts
+++ b/apps/desktop/src/services/AgentService/infrastructure/modelMetadata.ts
@@ -3,6 +3,7 @@
  */
 
 import { db } from '@database';
+import { syncAllModelsMetadata } from '@database/queries/models.ts';
 import { setStatistic } from '@database/queries/statistics.ts';
 import { llmMetadata, type NewLlmMetadata, StatisticKey } from '@database/schema.ts';
 
@@ -177,6 +178,8 @@ export async function updateModelMetadata(): Promise<void> {
                     .onConflictDoNothing({ target: llmMetadata.model_id })
                     .run();
             }
+
+            await syncAllModelsMetadata(tx);
 
             await setStatistic({
                 key: StatisticKey.MODEL_METADATA_LAST_UPDATED_AT,

--- a/apps/desktop/src/services/AgentService/infrastructure/providers/adapters/mimo.ts
+++ b/apps/desktop/src/services/AgentService/infrastructure/providers/adapters/mimo.ts
@@ -6,12 +6,7 @@ import { z } from '@/utils/zod';
 
 import { AiError, AiErrorCode } from '../../../contracts/errors';
 import { AiSdkProviderBase, buildUrlWithQueryParams } from '../ai-sdk/base';
-import {
-    isTouchAiManagedMode,
-    TOUCHAI_HUB_GATEWAY_BASE_URL,
-    TOUCHAI_HUB_MANAGED_MODEL_SET,
-    TOUCHAI_HUB_MANAGED_MODELS,
-} from '../config';
+import { isTouchAiManagedMode, TOUCHAI_HUB_GATEWAY_BASE_URL } from '../config';
 import type { ModelInfo, ProviderApiTargets } from '../types';
 import { resolveOpenAiStyleSdkBaseUrl } from '../utils';
 
@@ -87,10 +82,6 @@ export class MiMoProviderAdapter extends AiSdkProviderBase {
     });
 
     protected createLanguageModel(modelId: string) {
-        if (this.managedMode) {
-            this.assertSupportedModelId(modelId);
-        }
-
         return this.sdkProvider.chatModel(modelId);
     }
 
@@ -117,11 +108,6 @@ export class MiMoProviderAdapter extends AiSdkProviderBase {
     }
 
     protected parseModelList(payload: unknown) {
-        if (this.managedMode) {
-            void payload;
-            return this.getSupportedModels();
-        }
-
         const parsed = openAiCompatibleModelsSchema.parse(payload);
         return parsed.data.map((model) => ({
             id: model.id,
@@ -130,11 +116,21 @@ export class MiMoProviderAdapter extends AiSdkProviderBase {
     }
 
     async listModels(): Promise<ModelInfo[]> {
-        if (this.managedMode) {
-            return this.getSupportedModels();
+        if (!this.managedMode) {
+            return await super.listModels();
         }
 
-        return await super.listModels();
+        const { discoveryTarget } = this.getApiTargets();
+        if (!discoveryTarget) {
+            throw new Error('Provider base URL is empty');
+        }
+
+        const response = await this.gatewayFetch(discoveryTarget, {
+            method: 'GET',
+            headers: this.getDiscoveryHeaders(),
+        });
+        const payload = await this.readJsonResponse(response);
+        return this.parseModelList(payload);
     }
 
     protected classifyApiCallError(statusCode: number | undefined, data: unknown): AiError | null {
@@ -214,28 +210,6 @@ export class MiMoProviderAdapter extends AiSdkProviderBase {
             'X-TouchAI-Client': 'desktop',
             ...this.getCustomHeaders(),
         };
-    }
-
-    private getSupportedModels(): ModelInfo[] {
-        return TOUCHAI_HUB_MANAGED_MODELS.map((modelId) => ({
-            id: modelId,
-            name: modelId,
-        }));
-    }
-
-    private assertSupportedModelId(modelId: string): void {
-        if (TOUCHAI_HUB_MANAGED_MODEL_SET.has(modelId)) {
-            return;
-        }
-
-        throw new AiError(
-            AiErrorCode.MODEL_NOT_FOUND,
-            {
-                modelId,
-                supportedModels: [...TOUCHAI_HUB_MANAGED_MODELS],
-            },
-            'TouchAI Hub only supports mimo-v2.5 and mimo-v2.5-pro.'
-        );
     }
 
     private createGatewayFetch(): typeof fetch {

--- a/apps/desktop/src/services/AgentService/infrastructure/providers/config.ts
+++ b/apps/desktop/src/services/AgentService/infrastructure/providers/config.ts
@@ -5,8 +5,7 @@ import { safeParseJsonWithSchema, z } from '@/utils/zod';
 import type { ProviderConfigJson } from './types';
 
 export const TOUCHAI_HUB_GATEWAY_BASE_URL = 'https://hub.touch-ai.org/api/v1';
-export const TOUCHAI_HUB_MANAGED_MODELS = ['mimo-v2.5', 'mimo-v2.5-pro'] as const;
-export const TOUCHAI_HUB_MANAGED_MODEL_SET = new Set<string>(TOUCHAI_HUB_MANAGED_MODELS);
+export const MIMO_CUSTOM_API_BASE_URL = 'https://token-plan-cn.xiaomimimo.com/v1';
 
 const providerConfigJsonSchema = z.object({
     headers: z.record(z.string(), z.string()).optional(),
@@ -46,8 +45,4 @@ export function isTouchAiManagedMode(config: ProviderConfigJson, baseUrl: string
     }
 
     return isHubEndpoint;
-}
-
-export function isTouchAiManagedModel(modelId: string): boolean {
-    return TOUCHAI_HUB_MANAGED_MODEL_SET.has(modelId);
 }

--- a/apps/desktop/src/services/AgentService/infrastructure/providers/drivers.ts
+++ b/apps/desktop/src/services/AgentService/infrastructure/providers/drivers.ts
@@ -16,6 +16,7 @@ import { OpenAIProviderAdapter } from './adapters/openai';
 import { OpenAICompatibleProviderAdapter } from './adapters/openai-compatible';
 import { XaiProviderAdapter } from './adapters/xai';
 import { ZhipuProviderAdapter } from './adapters/zhipu';
+import { MIMO_CUSTOM_API_BASE_URL } from './config';
 import type { AiProvider, AiProviderConfig } from './types';
 
 export interface ProviderDriverDefinition {
@@ -115,7 +116,7 @@ const providerDrivers: ProviderDriverEntry[] = [
         driver: 'mimo',
         label: 'Xiaomi MiMo',
         logo: 'mimo.png',
-        placeholder: 'https://token-plan-cn.xiaomimimo.com/v1',
+        placeholder: MIMO_CUSTOM_API_BASE_URL,
         create: (config) => new MiMoProviderAdapter(config),
     },
 ];

--- a/apps/desktop/src/services/AgentService/infrastructure/providers/index.ts
+++ b/apps/desktop/src/services/AgentService/infrastructure/providers/index.ts
@@ -5,6 +5,7 @@ export { createTauriFetch } from './ai-sdk/tauriFetch';
 export { getProviderAttachmentCapabilities } from './capabilities';
 export {
     isTouchAiManagedMode,
+    MIMO_CUSTOM_API_BASE_URL,
     parseProviderConfigJson,
     TOUCHAI_HUB_GATEWAY_BASE_URL,
 } from './config';

--- a/apps/desktop/src/services/AuthService/index.ts
+++ b/apps/desktop/src/services/AuthService/index.ts
@@ -10,6 +10,7 @@ import {
     findModelsWithProvider,
     reassignModelsAndDeleteProvider,
     setDefaultModel,
+    syncAllModelsMetadata,
     updateProvider,
 } from '@/database/queries';
 import {
@@ -233,6 +234,8 @@ async function ensureManagedProviderModels(providerId: number): Promise<void> {
     if (missingModels.length > 0) {
         await createModels(missingModels);
     }
+
+    await syncAllModelsMetadata();
 
     const defaultModel = await findDefaultModel();
     if (

--- a/apps/desktop/src/services/AuthService/index.ts
+++ b/apps/desktop/src/services/AuthService/index.ts
@@ -4,20 +4,13 @@ import { fetch } from '@tauri-apps/plugin-http';
 import { openUrl } from '@tauri-apps/plugin-opener';
 
 import {
-    createModels,
     findAllProvidersSorted,
-    findDefaultModel,
-    findModelsWithProvider,
     reassignModelsAndDeleteProvider,
-    setDefaultModel,
-    syncAllModelsMetadata,
     updateProvider,
 } from '@/database/queries';
 import {
-    isTouchAiManagedModel,
     parseProviderConfigJson,
     TOUCHAI_HUB_GATEWAY_BASE_URL,
-    TOUCHAI_HUB_MANAGED_MODELS,
 } from '@/services/AgentService/infrastructure/providers/config';
 import type { ProviderConfigJson } from '@/services/AgentService/infrastructure/providers/types';
 import { AppEvent, eventService } from '@/services/EventService';
@@ -203,57 +196,6 @@ function buildNormalizedManagedProviderPatch(provider: ManagedProviderRow) {
     };
 }
 
-function getPreferredManagedModelId(
-    models: Array<{
-        id: number;
-        model_id: string;
-    }>
-): number | null {
-    for (const managedModelId of TOUCHAI_HUB_MANAGED_MODELS) {
-        const matchedModel = models.find((model) => model.model_id === managedModelId);
-        if (matchedModel) {
-            return matchedModel.id;
-        }
-    }
-
-    return null;
-}
-
-async function ensureManagedProviderModels(providerId: number): Promise<void> {
-    const existingModels = await findModelsWithProvider({ providerId });
-    const existingModelIds = new Set(existingModels.map((model) => model.model_id));
-    const missingModels = TOUCHAI_HUB_MANAGED_MODELS.filter(
-        (modelId) => !existingModelIds.has(modelId)
-    ).map((modelId) => ({
-        provider_id: providerId,
-        name: modelId,
-        model_id: modelId,
-        is_default: 0,
-    }));
-
-    if (missingModels.length > 0) {
-        await createModels(missingModels);
-    }
-
-    await syncAllModelsMetadata();
-
-    const defaultModel = await findDefaultModel();
-    if (
-        !defaultModel ||
-        defaultModel.provider_id !== providerId ||
-        isTouchAiManagedModel(defaultModel.model_id)
-    ) {
-        return;
-    }
-
-    const managedModels =
-        missingModels.length > 0 ? await findModelsWithProvider({ providerId }) : existingModels;
-    const nextDefaultModelId = getPreferredManagedModelId(managedModels);
-    if (nextDefaultModelId) {
-        await setDefaultModel({ modelId: nextDefaultModelId });
-    }
-}
-
 function extractManagedAuthFailureDetails(error: unknown): {
     gatewayCode: string;
     statusCode?: number;
@@ -356,10 +298,6 @@ export async function initializeManagedProviderState(): Promise<void> {
     }
 
     await Promise.all(migrations);
-
-    if (managedProviderId !== null) {
-        await ensureManagedProviderModels(managedProviderId);
-    }
 }
 
 export async function getManagedAuthState(): Promise<ManagedAuthState> {
@@ -486,7 +424,6 @@ export async function completeManagedLogin(callbackUrl: string): Promise<boolean
             config_json: buildManagedProviderConfigJson(provider, managedAuth),
         },
     });
-    await ensureManagedProviderModels(state.providerId);
     markManagedCodeProcessed(code);
 
     return true;

--- a/apps/desktop/src/views/SettingsView/components/AiServices/components/ProviderConfig.vue
+++ b/apps/desktop/src/views/SettingsView/components/AiServices/components/ProviderConfig.vue
@@ -11,6 +11,7 @@
     import {
         getProviderDriverDefinition,
         isTouchAiManagedMode,
+        MIMO_CUSTOM_API_BASE_URL,
         parseProviderConfigJson,
     } from '@/services/AgentService/infrastructure/providers';
     import type { ProviderConfigJson } from '@/services/AgentService/infrastructure/providers/types';
@@ -109,8 +110,14 @@
 
     let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 
-    function buildTouchAiCustomConfigPayload(): ProviderConfigJson['touchAiCustom'] | undefined {
-        const apiEndpoint = touchAiCustomForm.value.api_endpoint.trim();
+    function buildTouchAiCustomConfigPayload(
+        mode: 'managed' | 'custom' = managedConfigMode.value
+    ): ProviderConfigJson['touchAiCustom'] | undefined {
+        const apiEndpoint =
+            touchAiCustomForm.value.api_endpoint.trim() ||
+            (isManagedTouchAiActivityProvider.value && mode === 'custom'
+                ? MIMO_CUSTOM_API_BASE_URL
+                : '');
         const apiKey = touchAiCustomForm.value.api_key.trim();
 
         if (!apiEndpoint && !apiKey) {
@@ -140,7 +147,7 @@
             config_json: stringifyProviderConfigJson({
                 ...touchAiProviderConfig.value,
                 touchAiMode: mode,
-                touchAiCustom: buildTouchAiCustomConfigPayload(),
+                touchAiCustom: buildTouchAiCustomConfigPayload(mode),
             }),
         });
     }
@@ -152,7 +159,11 @@
             api_key: provider.api_key || '',
         };
         touchAiCustomForm.value = {
-            api_endpoint: parsedConfig.touchAiCustom?.apiEndpoint || '',
+            api_endpoint:
+                parsedConfig.touchAiCustom?.apiEndpoint ||
+                (provider.driver === 'mimo' && provider.is_builtin === 1
+                    ? MIMO_CUSTOM_API_BASE_URL
+                    : ''),
             api_key: parsedConfig.touchAiCustom?.apiKey || '',
         };
         managedConfigMode.value = isTouchAiManagedMode(parsedConfig, provider.api_endpoint)

--- a/apps/desktop/src/views/SettingsView/components/AiServices/index.vue
+++ b/apps/desktop/src/views/SettingsView/components/AiServices/index.vue
@@ -100,6 +100,28 @@
     let unlistenSettingsAiServicesFocusProvider: (() => void) | null = null;
     let lastHandledSettingsFocusRequestAt = 0;
 
+    interface RefreshModelsNotificationOptions {
+        success?: boolean;
+        failure?: boolean;
+        empty?: boolean;
+        missingCredentials?: boolean;
+        sessionExpired?: boolean;
+    }
+
+    const DEFAULT_REFRESH_MODELS_NOTIFICATIONS: Required<RefreshModelsNotificationOptions> = {
+        success: true,
+        failure: true,
+        empty: true,
+        missingCredentials: true,
+        sessionExpired: true,
+    };
+
+    const AUTO_REFRESH_MODELS_NOTIFICATIONS: RefreshModelsNotificationOptions = {
+        success: false,
+        empty: false,
+        missingCredentials: false,
+    };
+
     async function broadcastModelsUpdated() {
         await eventService.emit(AppEvent.AI_MODELS_UPDATED, {
             updatedAt: Date.now(),
@@ -300,6 +322,7 @@
 
         await selectProvider(targetProvider.id);
         await ensureTouchAiProviderMode(targetProvider, payload.mode);
+        await refreshSelectedProviderModelsAfterConfigChange();
         consumeManagedSettingsFocusRequest();
     }
 
@@ -469,7 +492,7 @@
                 providerPatch: normalizedProviderPatch,
             });
             patchProvider(selectedProviderId.value, normalizedProviderPatch);
-            alert.success(t('common.saved'));
+            await refreshSelectedProviderModelsAfterConfigChange();
         } catch (err) {
             alert.error(err instanceof Error ? err.message : t('settings.ai.saveFailed'));
         }
@@ -495,9 +518,8 @@
             });
             providers.value = [...providers.value, createdProvider];
             selectedProviderId.value = createdProvider.id;
-            await loadModelsForProvider(createdProvider.id, true);
             showAddDialog.value = false;
-            alert.success(t('settings.ai.createSucceeded'));
+            await refreshSelectedProviderModelsAfterConfigChange();
         } catch (err) {
             alert.error(err instanceof Error ? err.message : t('settings.ai.createFailed'));
         }
@@ -514,7 +536,7 @@
             });
             patchProvider(selectedProviderId.value, normalizedProviderPatch);
             showEditDialog.value = false;
-            alert.success(t('common.saved'));
+            await refreshSelectedProviderModelsAfterConfigChange();
         } catch (err) {
             alert.error(err instanceof Error ? err.message : t('settings.ai.saveFailed'));
         }
@@ -615,10 +637,36 @@
         }
     };
 
+    function resolveRefreshModelsNotifications(
+        options: boolean | RefreshModelsNotificationOptions
+    ): Required<RefreshModelsNotificationOptions> {
+        if (typeof options === 'boolean') {
+            return {
+                success: !options,
+                failure: !options,
+                empty: !options,
+                missingCredentials: !options,
+                sessionExpired: !options,
+            };
+        }
+
+        return {
+            ...DEFAULT_REFRESH_MODELS_NOTIFICATIONS,
+            ...options,
+        };
+    }
+
+    async function refreshSelectedProviderModelsAfterConfigChange(): Promise<void> {
+        await handleRefreshModels(AUTO_REFRESH_MODELS_NOTIFICATIONS);
+    }
+
     // 刷新模型列表
-    const handleRefreshModels = async (silent = false) => {
+    const handleRefreshModels = async (
+        options: boolean | RefreshModelsNotificationOptions = {}
+    ) => {
         if (!selectedProviderId.value) return;
 
+        const notifications = resolveRefreshModelsNotifications(options);
         const currentProviderId = selectedProviderId.value;
         refreshingProviderId.value = currentProviderId;
 
@@ -626,7 +674,7 @@
             refreshing.value = true;
             const provider = await findProviderById({ id: currentProviderId });
             if (!provider) {
-                if (!silent) alert.error(t('settings.ai.providerNotFound'));
+                if (notifications.failure) alert.error(t('settings.ai.providerNotFound'));
                 return;
             }
 
@@ -635,7 +683,7 @@
             }
 
             if (isManagedTouchAiProvider(provider) && !provider.api_key) {
-                if (!silent) {
+                if (notifications.missingCredentials) {
                     alert.warning(t('settings.ai.providerNeedsApiKeyForModels'));
                 }
                 return;
@@ -666,7 +714,7 @@
                 if (didInvalidateManagedAuth) {
                     removeCachedModels(provider.id);
                     await loadProviders();
-                    if (!silent) {
+                    if (notifications.sessionExpired) {
                         alert.warning(t('settings.ai.managedActivity.sessionExpired'));
                     }
                     return;
@@ -681,7 +729,7 @@
             }
 
             if (fetchedModels.length === 0) {
-                if (!silent) alert.info(t('settings.ai.noModelsFetched'));
+                if (notifications.empty) alert.info(t('settings.ai.noModelsFetched'));
                 return;
             }
 
@@ -719,7 +767,7 @@
 
             await loadModelsForProvider(currentProviderId, true); // 强制刷新缓存
             await broadcastModelsUpdated();
-            if (!silent) {
+            if (notifications.success) {
                 alert.success(t('settings.ai.refreshModelsSucceeded', { count: newModels.length }));
             }
         } catch (err) {
@@ -728,7 +776,7 @@
             }
 
             console.error('Failed to refresh models:', err);
-            if (!silent) {
+            if (notifications.failure) {
                 alert.error(t('settings.ai.refreshModelsFailed', { error: String(err) }));
             }
         } finally {

--- a/apps/desktop/tests/SettingsView/ai-services-i18n.test.ts
+++ b/apps/desktop/tests/SettingsView/ai-services-i18n.test.ts
@@ -106,6 +106,10 @@ vi.mock('@/utils/modelSchemas', () => ({
     parseModelModalities: vi.fn(() => null),
 }));
 
+vi.mock('@/services/AgentService/infrastructure/modelMetadata', () => ({
+    updateModelMetadata: vi.fn(),
+}));
+
 vi.mock('@/services/AgentService', () => ({
     aiService: {
         createProviderInstance: () => ({

--- a/apps/desktop/tests/i18n/main-bootstrap.test.ts
+++ b/apps/desktop/tests/i18n/main-bootstrap.test.ts
@@ -11,9 +11,12 @@ const {
     openSettingsWindowMock,
     settingsInitializeMock,
     appUpdateCheckNowMock,
+    isLlmMetadataEmptyMock,
     getCurrentMock,
     initializeFontLoaderMock,
     initializeLoggerMock,
+    syncAllModelsMetadataMock,
+    updateModelMetadataMock,
     onOpenUrlMock,
     originalWindowOpenMock,
     openUrlMock,
@@ -29,9 +32,12 @@ const {
     openSettingsWindowMock: vi.fn(),
     settingsInitializeMock: vi.fn(),
     appUpdateCheckNowMock: vi.fn(),
+    isLlmMetadataEmptyMock: vi.fn(),
     getCurrentMock: vi.fn(),
     initializeFontLoaderMock: vi.fn(),
     initializeLoggerMock: vi.fn(),
+    syncAllModelsMetadataMock: vi.fn(),
+    updateModelMetadataMock: vi.fn(),
     onOpenUrlMock: vi.fn(),
     originalWindowOpenMock: vi.fn(),
     openUrlMock: vi.fn(),
@@ -61,6 +67,15 @@ vi.mock('@services/AppUpdateService', () => ({
 vi.mock('@services/AuthService', () => ({
     completeManagedLogin: completeManagedLoginMock,
     initializeManagedProviderState: initializeManagedProviderStateMock,
+}));
+
+vi.mock('@database/queries', () => ({
+    isLlmMetadataEmpty: isLlmMetadataEmptyMock,
+    syncAllModelsMetadata: syncAllModelsMetadataMock,
+}));
+
+vi.mock('@/services/AgentService/infrastructure/modelMetadata', () => ({
+    updateModelMetadata: updateModelMetadataMock,
 }));
 
 vi.mock('@services/EventService', () => ({
@@ -141,6 +156,9 @@ describe('app bootstrap i18n', () => {
         appUpdateCheckNowMock.mockResolvedValue(false);
         completeManagedLoginMock.mockResolvedValue(false);
         initializeManagedProviderStateMock.mockResolvedValue(undefined);
+        isLlmMetadataEmptyMock.mockResolvedValue(false);
+        syncAllModelsMetadataMock.mockResolvedValue(undefined);
+        updateModelMetadataMock.mockResolvedValue(undefined);
         openSettingsWindowMock.mockResolvedValue(undefined);
         eventServiceEmitMock.mockResolvedValue(undefined);
         getCurrentMock.mockResolvedValue([]);
@@ -168,6 +186,43 @@ describe('app bootstrap i18n', () => {
         expect(appMountMock).toHaveBeenCalledWith('#app');
         const settingsInitializeOrder = settingsInitializeMock.mock.invocationCallOrder[0]!;
         expect(settingsInitializeOrder).toBeLessThan(appMountMock.mock.invocationCallOrder[0]!);
+    });
+
+    it('refreshes remote model metadata during bootstrap when local metadata is empty', async () => {
+        isLlmMetadataEmptyMock.mockResolvedValue(true);
+
+        const { initializeApp } = await import('@/bootstrap');
+        await initializeApp();
+
+        expect(updateModelMetadataMock).toHaveBeenCalledTimes(1);
+        expect(syncAllModelsMetadataMock).not.toHaveBeenCalled();
+    });
+
+    it('syncs cached model metadata during bootstrap without refreshing remote metadata', async () => {
+        isLlmMetadataEmptyMock.mockResolvedValue(false);
+
+        const { initializeApp } = await import('@/bootstrap');
+        await initializeApp();
+
+        expect(updateModelMetadataMock).not.toHaveBeenCalled();
+        expect(syncAllModelsMetadataMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('continues bootstrap when remote model metadata refresh fails', async () => {
+        const metadataError = new Error('metadata unavailable');
+        const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        isLlmMetadataEmptyMock.mockResolvedValue(true);
+        updateModelMetadataMock.mockRejectedValue(metadataError);
+
+        const { initializeApp } = await import('@/bootstrap');
+        await expect(initializeApp()).resolves.toBeUndefined();
+
+        expect(appMountMock).toHaveBeenCalledWith('#app');
+        expect(consoleSpy).toHaveBeenCalledWith(
+            '[Bootstrap] Failed to initialize model metadata:',
+            metadataError
+        );
+        consoleSpy.mockRestore();
     });
 
     it('mounts without the legacy DOM localizer when persisted settings fail to initialize', async () => {

--- a/apps/desktop/tests/services/AgentService/infrastructure/model-metadata.test.ts
+++ b/apps/desktop/tests/services/AgentService/infrastructure/model-metadata.test.ts
@@ -80,4 +80,62 @@ describe('model metadata refresh', () => {
 
         expect(insertRequest?.params).toEqual(expect.arrayContaining(['gpt-4', 'gpt-4o']));
     });
+
+    it('applies refreshed metadata to runtime model rows in the same update', async () => {
+        globalThis.fetch = vi.fn(async () => ({
+            ok: true,
+            json: async () => ({
+                mimo: {
+                    models: {
+                        'mimo-v2.5-pro': {
+                            id: 'mimo-v2.5-pro',
+                            name: 'mimo-v2.5-pro',
+                            attachment: true,
+                            open_weights: false,
+                            reasoning: true,
+                            temperature: true,
+                            tool_call: true,
+                            modalities: {
+                                input: ['text', 'image'],
+                                output: ['text'],
+                            },
+                        },
+                    },
+                },
+            }),
+        })) as unknown as typeof fetch;
+
+        interceptTauriInvoke((call) => {
+            if (call.cmd === 'database_tx_begin') {
+                return 'tx_model_metadata';
+            }
+
+            if (call.cmd === 'database_tx_commit' || call.cmd === 'database_tx_rollback') {
+                return undefined;
+            }
+
+            if (call.cmd === 'database_tx_query') {
+                const request = getRequest(call.payload);
+                if (request?.sql.includes('insert into "statistics"')) {
+                    return {
+                        rows: [{ key: 'model_metadata_last_updated_at' }],
+                        rowsAffected: 1,
+                        lastInsertId: 1,
+                    };
+                }
+
+                return { rows: [], rowsAffected: 1, lastInsertId: null };
+            }
+
+            return undefined;
+        });
+
+        await expect(updateModelMetadata()).resolves.toBeUndefined();
+
+        const updateRequest = getTauriInvokeCalls('database_tx_query')
+            .map((call) => getRequest(call.payload))
+            .find((request) => request?.sql.includes('UPDATE models'));
+
+        expect(updateRequest?.sql).toContain('ranked_metadata');
+    });
 });

--- a/apps/desktop/tests/services/AgentService/infrastructure/providers/mimo.test.ts
+++ b/apps/desktop/tests/services/AgentService/infrastructure/providers/mimo.test.ts
@@ -32,7 +32,21 @@ describe('MiMoProviderAdapter', () => {
         vi.clearAllMocks();
     });
 
-    it('keeps managed mode pinned to the TouchAI Hub gateway and returns the supported models locally', async () => {
+    it('keeps managed mode pinned to the TouchAI Hub gateway and discovers models from the hub', async () => {
+        fetchMock.mockResolvedValue(
+            new Response(
+                JSON.stringify({
+                    data: [{ id: 'mimo-latest' }, { id: 'mimo-pro-latest' }],
+                }),
+                {
+                    status: 200,
+                    headers: {
+                        'content-type': 'application/json',
+                    },
+                }
+            )
+        );
+
         const provider = new MiMoProviderAdapter({
             apiEndpoint: 'https://hub.touch-ai.org/api/v1',
             apiKey: 'ta_live_managed_key',
@@ -48,10 +62,20 @@ describe('MiMoProviderAdapter', () => {
             discoveryTarget: 'https://hub.touch-ai.org/api/v1/models',
         });
         await expect(provider.listModels()).resolves.toEqual([
-            { id: 'mimo-v2.5', name: 'mimo-v2.5' },
-            { id: 'mimo-v2.5-pro', name: 'mimo-v2.5-pro' },
+            { id: 'mimo-latest', name: 'mimo-latest' },
+            { id: 'mimo-pro-latest', name: 'mimo-pro-latest' },
         ]);
-        expect(fetchMock).not.toHaveBeenCalled();
+        const [target, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+        const headers = new Headers(init.headers);
+
+        expect(target).toBe('https://hub.touch-ai.org/api/v1/models');
+        expect(init.method).toBe('GET');
+        expect(init.body).toBeUndefined();
+        expect(headers.get('Authorization')).toBe('Bearer ta_live_managed_key');
+        expect(headers.get('X-TouchAI-Client')).toBe('desktop');
+        expect(headers.get('X-TouchAI-Timestamp')).toMatch(/^\d+$/);
+        expect(headers.get('X-TouchAI-Nonce')).toMatch(/^touchai-/);
+        expect(headers.get('X-TouchAI-Signature')).toMatch(/^[A-Za-z0-9_-]+$/);
     });
 
     it('uses the provider endpoint directly when builtin MiMo is not switched to explicit custom mode', async () => {
@@ -208,7 +232,7 @@ describe('MiMoProviderAdapter', () => {
         });
     });
 
-    it('rejects models outside the TouchAI Hub managed allowlist', () => {
+    it('lets the hub validate managed model ids at request time', () => {
         const provider = new MiMoProviderAdapter({
             apiEndpoint: 'https://hub.touch-ai.org/api/v1',
             apiKey: 'ta_live_managed_key',
@@ -217,12 +241,9 @@ describe('MiMoProviderAdapter', () => {
             },
         });
 
-        expect(() => asTestableProvider(provider).createLanguageModel('gpt-4.1')).toThrowError(
-            AiError
-        );
-        expect(() => asTestableProvider(provider).createLanguageModel('gpt-4.1')).toThrow(
-            'TouchAI Hub only supports mimo-v2.5 and mimo-v2.5-pro.'
-        );
-        expect(chatModelMock).not.toHaveBeenCalled();
+        expect(asTestableProvider(provider).createLanguageModel('mimo-latest')).toEqual({
+            modelId: 'mimo-latest',
+        });
+        expect(chatModelMock).toHaveBeenCalledWith('mimo-latest');
     });
 });

--- a/apps/desktop/tests/services/AuthService/index.test.ts
+++ b/apps/desktop/tests/services/AuthService/index.test.ts
@@ -85,7 +85,7 @@ describe('AuthService managed TouchAI Hub flow', () => {
         expect(openUrlMock).toHaveBeenCalledWith('https://hub.touch-ai.org/desktop/login');
     });
 
-    it('normalizes the builtin mimo provider and removes legacy mimo activity providers during bootstrap', async () => {
+    it('normalizes the builtin mimo provider without creating managed models during bootstrap', async () => {
         queriesMock.findAllProvidersSorted.mockResolvedValue([
             {
                 id: 320,
@@ -139,21 +139,8 @@ describe('AuthService managed TouchAI Hub flow', () => {
                 enabled: 1,
             },
         });
-        expect(queriesMock.createModels).toHaveBeenCalledWith([
-            {
-                provider_id: 320,
-                name: 'mimo-v2.5',
-                model_id: 'mimo-v2.5',
-                is_default: 0,
-            },
-            {
-                provider_id: 320,
-                name: 'mimo-v2.5-pro',
-                model_id: 'mimo-v2.5-pro',
-                is_default: 0,
-            },
-        ]);
-        expect(queriesMock.syncAllModelsMetadata).toHaveBeenCalledOnce();
+        expect(queriesMock.createModels).not.toHaveBeenCalled();
+        expect(queriesMock.syncAllModelsMetadata).not.toHaveBeenCalled();
     });
 
     it('clears the managed provider token on logout', async () => {
@@ -251,7 +238,8 @@ describe('AuthService managed TouchAI Hub flow', () => {
                 }),
             },
         });
-        expect(queriesMock.syncAllModelsMetadata).toHaveBeenCalledOnce();
+        expect(queriesMock.createModels).not.toHaveBeenCalled();
+        expect(queriesMock.syncAllModelsMetadata).not.toHaveBeenCalled();
     });
 
     it('does not exchange the same desktop callback code twice in one app session', async () => {

--- a/apps/desktop/tests/services/AuthService/index.test.ts
+++ b/apps/desktop/tests/services/AuthService/index.test.ts
@@ -16,6 +16,7 @@ const queriesMock = vi.hoisted(() => ({
     findModelsWithProvider: vi.fn(),
     reassignModelsAndDeleteProvider: vi.fn(),
     setDefaultModel: vi.fn(),
+    syncAllModelsMetadata: vi.fn(),
     updateProvider: vi.fn(),
 }));
 
@@ -59,6 +60,7 @@ describe('AuthService managed TouchAI Hub flow', () => {
         queriesMock.createModels.mockResolvedValue(undefined);
         queriesMock.reassignModelsAndDeleteProvider.mockResolvedValue(true);
         queriesMock.setDefaultModel.mockResolvedValue(undefined);
+        queriesMock.syncAllModelsMetadata.mockResolvedValue(undefined);
         queriesMock.updateProvider.mockResolvedValue(undefined);
         openUrlMock.mockResolvedValue(undefined);
         window.sessionStorage.clear();
@@ -151,6 +153,7 @@ describe('AuthService managed TouchAI Hub flow', () => {
                 is_default: 0,
             },
         ]);
+        expect(queriesMock.syncAllModelsMetadata).toHaveBeenCalledOnce();
     });
 
     it('clears the managed provider token on logout', async () => {
@@ -248,6 +251,7 @@ describe('AuthService managed TouchAI Hub flow', () => {
                 }),
             },
         });
+        expect(queriesMock.syncAllModelsMetadata).toHaveBeenCalledOnce();
     });
 
     it('does not exchange the same desktop callback code twice in one app session', async () => {

--- a/apps/desktop/tests/views/SettingsView/providerConfig.test.ts
+++ b/apps/desktop/tests/views/SettingsView/providerConfig.test.ts
@@ -41,6 +41,7 @@ vi.mock('@/services/AgentService', () => ({
 }));
 
 vi.mock('@/services/AgentService/infrastructure/providers', () => ({
+    MIMO_CUSTOM_API_BASE_URL: 'https://token-plan-cn.xiaomimimo.com/v1',
     getProviderDriverDefinition: () => ({
         driver: 'mimo',
         label: 'Xiaomi MiMo',
@@ -117,8 +118,18 @@ describe('ProviderConfig managed TouchAI activity provider', () => {
         expect(wrapper.find('[data-testid="settings-managed-activity-provider"]').exists()).toBe(
             false
         );
+        expect((wrapper.get('input[type="text"]').element as HTMLInputElement).value).toBe(
+            'https://token-plan-cn.xiaomimimo.com/v1'
+        );
         expect(wrapper.find('[data-testid="password-input"]').exists()).toBe(true);
         expect(wrapper.find('input[placeholder="sk-..."]').exists()).toBe(true);
+        const updatePayload = wrapper.emitted('update')?.[0]?.[0] as Partial<Provider>;
+        expect(JSON.parse(updatePayload.config_json!)).toEqual({
+            touchAiMode: 'custom',
+            touchAiCustom: {
+                apiEndpoint: 'https://token-plan-cn.xiaomimimo.com/v1',
+            },
+        });
     });
 
     it('renders the managed activity as a compact single-row authorization bar', async () => {

--- a/apps/desktop/tests/views/SettingsView/settingsAiServicesLayout.test.ts
+++ b/apps/desktop/tests/views/SettingsView/settingsAiServicesLayout.test.ts
@@ -35,6 +35,10 @@ const llmMetadataMock = vi.hoisted(() => ({
     isLlmMetadataEmpty: vi.fn().mockResolvedValue(false),
 }));
 
+const modelMetadataMock = vi.hoisted(() => ({
+    updateModelMetadata: vi.fn().mockResolvedValue(undefined),
+}));
+
 const agentServiceMock = vi.hoisted(() => ({
     createProviderInstance: vi.fn(() => ({
         listModels: vi.fn().mockResolvedValue([]),
@@ -91,9 +95,7 @@ vi.mock('@/services/AgentService', () => ({
     aiService: agentServiceMock,
 }));
 
-vi.mock('@/services/AgentService/infrastructure/modelMetadata', () => ({
-    updateModelMetadata: vi.fn().mockResolvedValue(undefined),
-}));
+vi.mock('@/services/AgentService/infrastructure/modelMetadata', () => modelMetadataMock);
 
 vi.mock('@/services/AgentService/infrastructure/providers', () => ({
     getProviderDriverDefinition: vi.fn(() => ({
@@ -122,6 +124,7 @@ describe('SettingsAiServicesSection', () => {
         managedSettingsFocusMock.consumeManagedSettingsFocusRequest.mockReturnValue(null);
         queries.findDefaultModel.mockResolvedValue(null);
         queries.findModelsWithProvider.mockResolvedValue([]);
+        modelMetadataMock.updateModelMetadata.mockResolvedValue(undefined);
     });
 
     it('omits custom-only controls for builtin providers', async () => {
@@ -595,6 +598,7 @@ describe('SettingsAiServicesSection', () => {
             })
         );
         expect(listModels).toHaveBeenCalled();
+        expect(modelMetadataMock.updateModelMetadata).not.toHaveBeenCalled();
     });
 
     it('does not refresh managed MiMo models before login is completed', async () => {

--- a/apps/desktop/tests/views/SettingsView/settingsAiServicesLayout.test.ts
+++ b/apps/desktop/tests/views/SettingsView/settingsAiServicesLayout.test.ts
@@ -147,7 +147,11 @@ describe('SettingsAiServicesSection', () => {
         const wrapper = mount(AiServicesSection, {
             global: {
                 stubs: {
-                    ProviderList: true,
+                    ProviderList: {
+                        emits: ['add-custom'],
+                        template:
+                            '<button data-testid="settings-add-custom-provider-button" @click="$emit(\'add-custom\')">add</button>',
+                    },
                     ProviderConfig: true,
                     ModelList: true,
                     AddProviderDialog: true,
@@ -187,7 +191,11 @@ describe('SettingsAiServicesSection', () => {
         const wrapper = mount(AiServicesSection, {
             global: {
                 stubs: {
-                    ProviderList: true,
+                    ProviderList: {
+                        emits: ['add-custom'],
+                        template:
+                            '<button data-testid="settings-add-custom-provider-button" @click="$emit(\'add-custom\')">add</button>',
+                    },
                     ProviderConfig: true,
                     ModelList: true,
                     AddProviderDialog: true,
@@ -207,7 +215,7 @@ describe('SettingsAiServicesSection', () => {
         expect(wrapper.text()).toContain('Custom Gateway');
     });
 
-    it('patches provider config locally without provider list reload', async () => {
+    it('patches provider config locally and refreshes models without a success toast', async () => {
         const provider = {
             id: 2,
             name: 'Custom Gateway',
@@ -221,7 +229,21 @@ describe('SettingsAiServicesSection', () => {
             created_at: '',
             updated_at: '',
         };
+        const listModels = vi.fn().mockResolvedValue([
+            {
+                id: 'gpt-5-mini',
+                name: 'GPT 5 Mini',
+            },
+        ]);
         queries.findAllProvidersSorted.mockResolvedValue([provider]);
+        queries.findProviderById.mockResolvedValue({
+            ...provider,
+            name: 'Renamed Gateway',
+        });
+        agentServiceMock.createProviderInstance.mockReturnValue({
+            listModels,
+            getApiTargets: () => ({ generationTarget: '' }),
+        });
 
         const wrapper = mount(AiServicesSection, {
             global: {
@@ -262,8 +284,88 @@ describe('SettingsAiServicesSection', () => {
             providerPatch: { name: 'Renamed Gateway' },
         });
         expect(queries.findAllProvidersSorted).toHaveBeenCalledTimes(1);
-        expect(alertMock.success).toHaveBeenCalledWith('保存成功');
+        expect(listModels).toHaveBeenCalled();
+        expect(alertMock.success).not.toHaveBeenCalled();
         expect(wrapper.text()).toContain('Renamed Gateway');
+    });
+
+    it('refreshes models after creating a provider without a success toast', async () => {
+        const createdProvider = {
+            id: 9,
+            name: 'New Gateway',
+            driver: 'openai',
+            api_endpoint: 'https://new.example.com',
+            api_key: 'sk-new',
+            config_json: null,
+            logo: 'openai.png',
+            enabled: 1,
+            is_builtin: 0,
+            created_at: '',
+            updated_at: '',
+        };
+        const listModels = vi.fn().mockResolvedValue([
+            {
+                id: 'gpt-5-mini',
+                name: 'GPT 5 Mini',
+            },
+        ]);
+        queries.findAllProvidersSorted.mockResolvedValue([]);
+        queries.createProvider.mockResolvedValue(createdProvider);
+        queries.findProviderById.mockResolvedValue(createdProvider);
+        agentServiceMock.createProviderInstance.mockReturnValue({
+            listModels,
+            getApiTargets: () => ({ generationTarget: '' }),
+        });
+
+        const wrapper = mount(AiServicesSection, {
+            global: {
+                stubs: {
+                    ProviderList: {
+                        emits: ['add-custom'],
+                        template:
+                            '<button data-testid="settings-add-custom-provider-button" @click="$emit(\'add-custom\')">add</button>',
+                    },
+                    ProviderConfig: true,
+                    ModelList: true,
+                    AddProviderDialog: {
+                        emits: ['create', 'cancel'],
+                        template: `
+                            <button
+                                data-testid="create-provider"
+                                @click="$emit('create', {
+                                    name: 'New Gateway',
+                                    driver: 'openai',
+                                    api_endpoint: 'https://new.example.com',
+                                    api_key: 'sk-new',
+                                    config_json: null,
+                                    logo: 'openai.png',
+                                    enabled: 1,
+                                    is_builtin: 0
+                                })"
+                            >
+                                create
+                            </button>
+                        `,
+                    },
+                    EditProviderDialog: true,
+                    BadgedLogo: {
+                        props: ['logo', 'name'],
+                        template: '<div data-testid="badged-logo-stub" />',
+                    },
+                },
+            },
+        });
+
+        await flushPromises();
+
+        await wrapper.get('[data-testid="settings-add-custom-provider-button"]').trigger('click');
+        await flushPromises();
+        await wrapper.get('[data-testid="create-provider"]').trigger('click');
+        await flushPromises();
+
+        expect(queries.createProvider).toHaveBeenCalled();
+        expect(listModels).toHaveBeenCalled();
+        expect(alertMock.success).not.toHaveBeenCalled();
     });
 
     it('patches the default model locally without provider list reload', async () => {
@@ -678,6 +780,15 @@ describe('SettingsAiServicesSection', () => {
             created_at: '',
             updated_at: '',
         };
+        const managedModeProvider = {
+            ...mimoProvider,
+            config_json: JSON.stringify({
+                touchAiMode: 'managed',
+                touchAiCustom: {
+                    apiEndpoint: 'https://token-plan-cn.xiaomimimo.com/v1',
+                },
+            }),
+        };
         const openAiProvider = {
             id: 2,
             name: 'OpenAI',
@@ -691,7 +802,18 @@ describe('SettingsAiServicesSection', () => {
             created_at: '',
             updated_at: '',
         };
+        const listModels = vi.fn().mockResolvedValue([
+            {
+                id: 'mimo-v2.5',
+                name: 'mimo-v2.5',
+            },
+        ]);
         queries.findAllProvidersSorted.mockResolvedValue([openAiProvider, mimoProvider]);
+        queries.findProviderById.mockResolvedValue(managedModeProvider);
+        agentServiceMock.createProviderInstance.mockReturnValue({
+            listModels,
+            getApiTargets: () => ({ generationTarget: '' }),
+        });
         managedSettingsFocusMock.peekManagedSettingsFocusRequest.mockReturnValue({
             section: 'ai-services',
             providerDriver: 'mimo',
@@ -736,5 +858,7 @@ describe('SettingsAiServicesSection', () => {
             },
         });
         expect(managedSettingsFocusMock.consumeManagedSettingsFocusRequest).toHaveBeenCalled();
+        expect(listModels).toHaveBeenCalled();
+        expect(alertMock.success).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
## Summary

- Initialize model capability metadata during app bootstrap: fetch remote metadata only when `llm_metadata` is empty, otherwise sync cached metadata into `models`.
- Apply refreshed remote metadata to runtime model rows in the same metadata update transaction.
- Keep provider/model-list refresh flows local-only for metadata projection, so refreshing models does not add a second remote metadata request.

## Related issue or RFC

- Closes #379

## AI assistance disclosure

- Tool(s) used: OpenAI Codex
- Scope of assistance: code change, tests, local verification, PR preparation
- Human review or rewrite performed: Draft PR opened for maintainer/user review
- Architecture or boundary impact: Touches AgentService metadata projection and desktop bootstrap initialization; no schema or migration change

## Testing evidence

```text
vitest run --configLoader runner tests/i18n/main-bootstrap.test.ts tests/services/AuthService/index.test.ts tests/services/AgentService/infrastructure/model-metadata.test.ts tests/views/SettingsView/settingsAiServicesLayout.test.ts
# 4 passed, 38 tests passed

vue-tsc -p tsconfig.vitest.json --noEmit
# passed

pnpm check
# passed; existing ESLint warnings only, 0 errors

pnpm test:unit
# 121 passed, 676 tests passed
```

`pnpm test:pr` was started locally but not completed: the first run failed because Rust build artifacts were written to a full D: drive, then Rust RTK download from GitHub timed out. After moving Rust artifacts to E: and prewarming the verified RTK cache, `pnpm check` and `pnpm test:unit` passed. Per follow-up request, `test:rust`, coverage, full `test:pr`, and site build are left to cloud/another-machine verification.

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: AgentService metadata update now also projects refreshed metadata into `models`; bootstrap performs generic metadata initialization. No runtime/MCP contract change.
- database baseline or migration impact: none.
- release or packaging impact: none.

## Screenshots or recordings

Not applicable; no UI layout change.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [ ] I can explain the why, what, and how of this change without relying on an AI tool.
- [ ] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [ ] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [ ] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.