### PR TITLE
feat(notification): adjust approval reminder notification behavior

### DIFF
--- a/apps/desktop/src-tauri/src/core/window/status_reminder.rs
+++ b/apps/desktop/src-tauri/src/core/window/status_reminder.rs
@@ -1133,7 +1133,7 @@ mod macos_notifications {
 #[cfg(target_os = "linux")]
 mod linux_notifications {
     use notify_rust::{ActionResponse, Notification, Timeout};
-    use tauri::{AppHandle, Runtime};
+    use tauri::{AppHandle, Manager, Runtime};
 
     use super::{
         SessionStatusReminderAction, SessionStatusReminderActionPayload, SessionStatusReminderKind,

--- a/apps/desktop/src-tauri/src/core/window/status_reminder.rs
+++ b/apps/desktop/src-tauri/src/core/window/status_reminder.rs
@@ -72,6 +72,8 @@ pub struct SessionStatusReminderNotificationRuntime {
     active_toasts: Mutex<Vec<windows::UI::Notifications::ToastNotification>>,
     #[cfg(target_os = "macos")]
     active_notification_ids: Mutex<Vec<String>>,
+    #[cfg(target_os = "linux")]
+    active_notifications: Mutex<Vec<notify_rust::NotificationHandle>>,
 }
 
 impl SessionStatusReminderNotificationRuntime {
@@ -85,6 +87,8 @@ impl SessionStatusReminderNotificationRuntime {
             active_toasts: Mutex::new(Vec::new()),
             #[cfg(target_os = "macos")]
             active_notification_ids: Mutex::new(Vec::new()),
+            #[cfg(target_os = "linux")]
+            active_notifications: Mutex::new(Vec::new()),
         }
     }
 
@@ -158,16 +162,37 @@ impl SessionStatusReminderNotificationRuntime {
     }
 
     #[cfg(target_os = "linux")]
-    pub fn track_active_notification(&self, _id: u32) {
-        // Tracking IDs for future dismissal is not yet supported on Linux
-        // because notify-rust's wait_for_action consumes the handle.
+    pub fn track_active_notification(&self, handle: notify_rust::NotificationHandle) {
+        self.active_notifications
+            .lock()
+            .expect("session status reminder runtime poisoned")
+            .push(handle);
+    }
+
+    #[cfg(target_os = "linux")]
+    pub fn release_active_notification(&self, id: u32) {
+        let mut handles = self
+            .active_notifications
+            .lock()
+            .expect("session status reminder runtime poisoned");
+        if let Some(index) = handles.iter().position(|handle| handle.id() == id) {
+            handles.remove(index);
+        }
     }
 
     #[cfg(target_os = "linux")]
     pub fn clear_active_notifications(&self) {
-        // No-op on Linux: notify-rust's NotificationHandle is consumed by
-        // wait_for_action, so we cannot close notifications programmatically.
-        // Reminders auto-expire, which keeps residual notifications bounded.
+        let handles = {
+            let mut handles = self
+                .active_notifications
+                .lock()
+                .expect("session status reminder runtime poisoned");
+            std::mem::take(&mut *handles)
+        };
+
+        for handle in handles {
+            handle.close();
+        }
     }
 }
 
@@ -1107,7 +1132,7 @@ mod macos_notifications {
 
 #[cfg(target_os = "linux")]
 mod linux_notifications {
-    use notify_rust::{Notification, Timeout};
+    use notify_rust::{ActionResponse, Notification, Timeout};
     use tauri::{AppHandle, Runtime};
 
     use super::{
@@ -1184,11 +1209,23 @@ mod linux_notifications {
             reply_text: None,
         };
 
-        // wait_for_action blocks until the notification closes or the user acts,
-        // so it must run off the Tauri invoke thread.
+        runtime.track_active_notification(handle);
+
+        // Listen for the notification action on a background thread while
+        // keeping the original handle available for explicit closing.
         std::thread::spawn(move || {
-            handle.wait_for_action(move |action_name| {
-                let Some(resolved_action) = resolve_action(action_name) else {
+            notify_rust::handle_action(notification_id, move |action| {
+                if let Some(runtime) =
+                    app_handle.try_state::<super::SessionStatusReminderNotificationRuntime>()
+                {
+                    runtime.release_active_notification(notification_id);
+                }
+
+                let resolved_action = match action {
+                    ActionResponse::Custom(action_name) => resolve_action(action_name),
+                    ActionResponse::Closed(_) => None,
+                };
+                let Some(resolved_action) = resolved_action else {
                     return;
                 };
 
@@ -1204,16 +1241,13 @@ mod linux_notifications {
             });
         });
 
-        runtime.track_active_notification(notification_id);
-
         Ok(())
     }
 
     /// Clear tracked Linux notifications.
     pub fn clear(runtime: &super::SessionStatusReminderNotificationRuntime) {
-        // Linux reminder notifications auto-expire, so clearing here is
-        // best-effort even though notify-rust does not expose a cross-desktop
-        // close primitive once action waiting is detached.
+        // Close any still-tracked notifications. Notifications that already
+        // received an action are released from tracking by the action listener.
         runtime.clear_active_notifications();
     }
 }

--- a/apps/desktop/src-tauri/src/core/window/status_reminder.rs
+++ b/apps/desktop/src-tauri/src/core/window/status_reminder.rs
@@ -185,11 +185,13 @@ fn restore_search_window_from_status_reminder<R: Runtime>(
     tauri::async_runtime::spawn(async move {
         let task_handle = app_handle.clone();
         if let Err(error) = app_handle.run_on_main_thread(move || {
-            if let Err(error) = crate::core::window::show_search_window(task_handle.clone()) {
-                log::warn!(
-                    "Failed to restore search window from session status notification: {}",
-                    error
-                );
+            if should_restore_search_window_from_status_reminder(payload.as_ref()) {
+                if let Err(error) = crate::core::window::show_search_window(task_handle.clone()) {
+                    log::warn!(
+                        "Failed to restore search window from session status notification: {}",
+                        error
+                    );
+                }
             }
 
             let Some(payload) = payload.as_ref() else {
@@ -212,6 +214,17 @@ fn restore_search_window_from_status_reminder<R: Runtime>(
             );
         }
     });
+}
+
+fn should_restore_search_window_from_status_reminder(
+    payload: Option<&SessionStatusReminderActionPayload>,
+) -> bool {
+    !matches!(
+        payload,
+        Some(payload)
+            if payload.kind == SessionStatusReminderKind::WaitingApproval
+                && payload.action == SessionStatusReminderAction::Approve
+    )
 }
 
 fn has_windows_installation_marker(exe_path: &std::path::Path) -> bool {
@@ -490,6 +503,11 @@ fn build_toast_document(
     toast
         .SetAttribute(&HSTRING::from("launch"), &HSTRING::from(&launch))
         .map_err(|error| error.to_string())?;
+    if payload.kind == SessionStatusReminderKind::WaitingApproval && payload.approval.is_some() {
+        toast
+            .SetAttribute(&HSTRING::from("scenario"), &HSTRING::from("reminder"))
+            .map_err(|error| error.to_string())?;
+    }
 
     let visual = doc
         .CreateElement(&HSTRING::from("visual"))
@@ -1098,13 +1116,9 @@ mod linux_notifications {
     };
 
     const STANDARD_REMINDER_TIMEOUT_MS: u32 = 15_000;
-    const APPROVAL_REMINDER_TIMEOUT_MS: u32 = 300_000;
-
     fn notification_timeout(kind: SessionStatusReminderKind) -> Timeout {
         match kind {
-            SessionStatusReminderKind::WaitingApproval => {
-                Timeout::Milliseconds(APPROVAL_REMINDER_TIMEOUT_MS)
-            }
+            SessionStatusReminderKind::WaitingApproval => Timeout::Never,
             SessionStatusReminderKind::Completed | SessionStatusReminderKind::Failed => {
                 Timeout::Milliseconds(STANDARD_REMINDER_TIMEOUT_MS)
             }
@@ -1211,7 +1225,8 @@ mod tests {
     use tempfile::tempdir;
 
     use super::{
-        finalize_activation_payload, has_windows_installation_marker, SessionStatusReminderAction,
+        finalize_activation_payload, has_windows_installation_marker,
+        should_restore_search_window_from_status_reminder, SessionStatusReminderAction,
         SessionStatusReminderActionPayload, SessionStatusReminderKind,
     };
 
@@ -1261,6 +1276,50 @@ mod tests {
 
         fs::write(dir.path().join("uninstall.exe"), b"stub").expect("write uninstall");
         assert!(has_windows_installation_marker(&exe_path));
+    }
+
+    #[test]
+    fn waiting_approval_approve_does_not_restore_search_window() {
+        let payload = SessionStatusReminderActionPayload {
+            action: SessionStatusReminderAction::Approve,
+            session_id: 1,
+            task_id: "task-1".to_string(),
+            kind: SessionStatusReminderKind::WaitingApproval,
+            call_id: Some("call-1".to_string()),
+            reply_text: None,
+        };
+
+        assert!(!should_restore_search_window_from_status_reminder(Some(
+            &payload
+        )));
+    }
+
+    #[test]
+    fn other_status_reminder_actions_still_restore_search_window() {
+        let approve_completed = SessionStatusReminderActionPayload {
+            action: SessionStatusReminderAction::Approve,
+            session_id: 1,
+            task_id: "task-1".to_string(),
+            kind: SessionStatusReminderKind::Completed,
+            call_id: None,
+            reply_text: None,
+        };
+        let reject_waiting = SessionStatusReminderActionPayload {
+            action: SessionStatusReminderAction::Reject,
+            session_id: 1,
+            task_id: "task-1".to_string(),
+            kind: SessionStatusReminderKind::WaitingApproval,
+            call_id: Some("call-1".to_string()),
+            reply_text: None,
+        };
+
+        assert!(should_restore_search_window_from_status_reminder(None));
+        assert!(should_restore_search_window_from_status_reminder(Some(
+            &approve_completed
+        )));
+        assert!(should_restore_search_window_from_status_reminder(Some(
+            &reject_waiting
+        )));
     }
 }
 
@@ -1313,6 +1372,7 @@ mod tests_windows {
         .expect("toast xml");
 
         assert!(xml.contains("<actions>"));
+        assert!(xml.contains("scenario=\"reminder\""));
         assert!(xml.contains("Approve"));
         assert!(xml.contains("Reject"));
         assert!(!xml.contains("Reply to TouchAI"));


### PR DESCRIPTION
> First external contributors may need to complete the `CLA Assistant` check before merge.
> For code changes, this PR must link the related issue or RFC in the section below.

## Summary

Refine desktop session status reminder behavior for approval-required notifications.

User-facing impact:

- Approval-required system reminders now stay visible until the user acts on them, instead of auto-expiring.
- Clicking `Approve` from the system reminder no longer forces the TouchAI window to open.
- The approval action still resolves the pending approval normally; only the automatic window restore is suppressed.
- Other reminder actions keep their existing behavior.

Implementation notes:

- The change is intentionally scoped to the native desktop reminder layer.
- No `AgentService`, session/task projection, or frontend approval flow behavior was expanded beyond the existing system reminder path.
- Linux waiting-approval reminders now use a persistent timeout.
- Windows waiting-approval toasts are marked as reminder scenario notifications so they behave like persistent reminders.

## Related issue or RFC

Link the issue or RFC:

- Closes https://github.com/TouchAI-org/TouchAI/issues/386

For code changes, link the tracking issue. Only documentation wording, link fixes, or comment-only cleanups may skip the issue-first flow.

## AI assistance disclosure

- Tool(s) used: OpenAI Codex / GPT-5
- Scope of assistance: implementation, local build/install verification, and PR drafting
- Human review or rewrite performed: reviewed the behavior goal, constrained the change to the native reminder path, and manually validated the installed desktop build
- Architecture or boundary impact: touches desktop native reminder behavior only (`src-tauri` reminder handling); no schema or MCP contract changes

## Testing evidence

List the commands you ran and the results you observed.

- Every code PR: `pnpm test:pr` (includes type check, lint, format, all tests, and frontend coverage)
- Rust behavior / test changes: `pnpm test:coverage:rust` (requires cargo-tarpaulin, or rely on CI)
- Desktop startup / window / search / popup / settings / E2E harness / workflow changes: `pnpm test:e2e`
- If any command could not run locally, state the exact blocker and rely on CI evidence before merge.

Did you follow TDD (test-first) for feature and fix work? Strongly recommended. See [docs/testing/testing.md](../docs/testing/testing.md).

```text
cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml status_reminder -- --nocapture
- Passed.
- Verified the reminder-specific Rust tests, including:
  - waiting approval toast XML includes reminder scenario
  - waiting approval approve action does not restore the search window
  - other reminder actions still restore the search window

pnpm --filter @touchai/desktop tauri build
- Passed.
- Built a local desktop installer successfully.

Manual packaged-app verification
- Installed the NSIS build to D:\develop\TouchAI
- Verified the app launches successfully
```

## Risk notes

- AgentService, runtime, MCP, or schema impact:
  - Runtime impact is limited to native desktop reminder behavior in apps/desktop/src-tauri/src/core/window/status_reminder.rs
  - No AgentService, MCP, or schema contract changes
- database baseline or migration impact:
  - None
- release or packaging impact:
  - Affects packaged desktop notification behavior on Windows/Linux
  - Packaged-app validation is important because the behavior depends on native notification delivery

## Screenshots or recordings

no UI changes

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [ ] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [ ] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [ ] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [ ] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [ ] I updated docs when behavior changed.
