### PR TITLE
fix(desktop): make font loading deterministic

### DIFF
--- a/apps/desktop/src-tauri/src/core/system/assets.rs
+++ b/apps/desktop/src-tauri/src/core/system/assets.rs
@@ -3,6 +3,8 @@
 //! 应用资源下载与管理。
 
 use log::{error, info, warn};
+use sha2::{Digest, Sha256};
+use std::io::ErrorKind;
 use std::path::PathBuf;
 use tauri::Emitter;
 use tokio::fs;
@@ -12,6 +14,9 @@ use crate::core::system::paths::{app_directory_path, AppDirectory};
 
 /// 字体文件名
 const FONT_FILENAME: &str = "SourceHanSerifSC-VF.ttf.woff2";
+const FONT_EXPECTED_SIZE_BYTES: u64 = 21_600_852;
+const FONT_EXPECTED_SHA256: &str =
+    "95bee5840bd5bcc68ada7d9c32fbf40af38a7dadeb77bfae4dd26d85b131ce20";
 
 /// CDN 地址列表（按优先级排序）
 const FONT_CDN_URLS: &[&str] = &[
@@ -34,7 +39,65 @@ fn get_font_path() -> Result<PathBuf, String> {
 /// 检查字体文件是否已存在
 async fn font_exists() -> Result<bool, String> {
     let font_path = get_font_path()?;
-    Ok(font_path.exists())
+    is_valid_font_file(&font_path).await
+}
+
+async fn is_valid_font_file(font_path: &std::path::Path) -> Result<bool, String> {
+    let metadata = match fs::metadata(&font_path).await {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(false),
+        Err(error) => {
+            return Err(format!(
+                "Failed to read font metadata '{}': {error}",
+                font_path.display()
+            ));
+        }
+    };
+
+    if metadata.len() != FONT_EXPECTED_SIZE_BYTES {
+        warn!(
+            "Ignoring invalid cached font '{}': expected {} bytes, found {} bytes",
+            font_path.display(),
+            FONT_EXPECTED_SIZE_BYTES,
+            metadata.len()
+        );
+        return Ok(false);
+    }
+
+    let data = fs::read(&font_path)
+        .await
+        .map_err(|e| format!("Failed to read cached font '{}': {e}", font_path.display()))?;
+    match validate_font_data(&data) {
+        Ok(()) => Ok(true),
+        Err(error) => {
+            warn!(
+                "Ignoring invalid cached font '{}': {}",
+                font_path.display(),
+                error
+            );
+            Ok(false)
+        }
+    }
+}
+
+fn validate_font_data(data: &[u8]) -> Result<(), String> {
+    if data.len() as u64 != FONT_EXPECTED_SIZE_BYTES {
+        return Err(format!(
+            "expected {} bytes, found {} bytes",
+            FONT_EXPECTED_SIZE_BYTES,
+            data.len()
+        ));
+    }
+
+    let actual_hash = format!("{:x}", Sha256::digest(data));
+    if actual_hash != FONT_EXPECTED_SHA256 {
+        return Err(format!(
+            "expected sha256 {}, found {}",
+            FONT_EXPECTED_SHA256, actual_hash
+        ));
+    }
+
+    Ok(())
 }
 
 /// 从指定 URL 下载文件
@@ -81,19 +144,47 @@ async fn try_download_from_cdns() -> Result<Vec<u8>, String> {
 
 /// 保存字体文件到本地
 async fn save_font(data: &[u8]) -> Result<(), String> {
+    validate_font_data(data)?;
     let font_path = get_font_path()?;
+    let temp_font_path = font_path.with_file_name(format!("{FONT_FILENAME}.tmp"));
 
-    let mut file = fs::File::create(&font_path)
-        .await
-        .map_err(|e| format!("Failed to create font file: {}", e))?;
+    if let Some(parent) = font_path.parent() {
+        fs::create_dir_all(parent).await.map_err(|e| {
+            format!(
+                "Failed to create font directory '{}': {e}",
+                parent.display()
+            )
+        })?;
+    }
 
-    file.write_all(data)
-        .await
-        .map_err(|e| format!("Failed to write font file: {}", e))?;
+    {
+        let mut file = fs::File::create(&temp_font_path)
+            .await
+            .map_err(|e| format!("Failed to create temporary font file: {}", e))?;
 
-    file.flush()
+        file.write_all(data)
+            .await
+            .map_err(|e| format!("Failed to write temporary font file: {}", e))?;
+
+        file.flush()
+            .await
+            .map_err(|e| format!("Failed to flush temporary font file: {}", e))?;
+    }
+
+    match fs::remove_file(&font_path).await {
+        Ok(()) => {}
+        Err(error) if error.kind() == ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(format!(
+                "Failed to remove existing font file '{}': {error}",
+                font_path.display()
+            ));
+        }
+    }
+
+    fs::rename(&temp_font_path, &font_path)
         .await
-        .map_err(|e| format!("Failed to flush font file: {}", e))?;
+        .map_err(|e| format!("Failed to replace font file: {}", e))?;
 
     info!("Font saved to: {}", font_path.display());
     Ok(())
@@ -153,5 +244,77 @@ pub async fn initialize_font(app_handle: tauri::AppHandle) -> Result<(), String>
             Ok(())
         }
         Err(e) => Err(e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_valid_font_file, validate_font_data, FONT_EXPECTED_SHA256, FONT_FILENAME};
+    use sha2::{Digest, Sha256};
+    use tempfile::tempdir;
+    use tokio::fs;
+
+    #[tokio::test]
+    async fn missing_font_cache_is_not_valid() {
+        let root = tempdir().expect("tempdir");
+        let font_path = root.path().join(FONT_FILENAME);
+
+        assert!(!is_valid_font_file(&font_path)
+            .await
+            .expect("missing font cache check"));
+    }
+
+    #[tokio::test]
+    async fn existing_short_font_cache_is_not_valid() {
+        let root = tempdir().expect("tempdir");
+        let font_dir = root.path().join("assets").join("font");
+        fs::create_dir_all(&font_dir)
+            .await
+            .expect("create font dir");
+        let font_path = font_dir.join(FONT_FILENAME);
+        fs::write(&font_path, b"not a font")
+            .await
+            .expect("write invalid font");
+
+        assert!(!is_valid_font_file(&font_path)
+            .await
+            .expect("font cache check"));
+    }
+
+    #[tokio::test]
+    async fn bundled_font_cache_is_valid() {
+        let font_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../assets/font")
+            .join(FONT_FILENAME);
+
+        assert!(is_valid_font_file(&font_path)
+            .await
+            .expect("bundled font cache check"));
+    }
+
+    #[test]
+    fn valid_font_hash_matches_expected_constant() {
+        let font_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../assets/font")
+            .join(FONT_FILENAME);
+        let data = std::fs::read(font_path).expect("read bundled font");
+        let actual_hash = format!("{:x}", Sha256::digest(&data));
+
+        assert_eq!(actual_hash, FONT_EXPECTED_SHA256);
+        validate_font_data(&data).expect("validate bundled font data");
+    }
+
+    #[test]
+    fn same_size_font_with_wrong_hash_is_rejected() {
+        let font_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../assets/font")
+            .join(FONT_FILENAME);
+        let mut data = std::fs::read(font_path).expect("read bundled font");
+        let last_byte = data.last_mut().expect("font has data");
+        *last_byte = last_byte.wrapping_add(1);
+
+        let error = validate_font_data(&data).expect_err("mutated font should fail hash check");
+
+        assert!(error.contains("expected sha256"));
     }
 }

--- a/apps/desktop/src-tauri/src/core/system/assets.rs
+++ b/apps/desktop/src-tauri/src/core/system/assets.rs
@@ -28,7 +28,7 @@ const FONT_CDN_URLS: &[&str] = &[
 const DOWNLOAD_TIMEOUT_SECS: u64 = 30;
 
 /// 最大重试轮次（每轮会尝试所有 CDN）
-const MAX_RETRY_ROUNDS: usize = 2;
+const MAX_RETRY_ROUNDS: usize = 5;
 
 /// 获取字体文件路径
 fn get_font_path() -> Result<PathBuf, String> {
@@ -272,8 +272,8 @@ pub async fn initialize_font(app_handle: tauri::AppHandle) -> Result<(), String>
 #[cfg(test)]
 mod tests {
     use super::{
-        is_valid_font_file, replace_font_file, validate_font_data, FONT_EXPECTED_SHA256,
-        FONT_FILENAME,
+        is_valid_font_file, replace_font_file, validate_font_data, FONT_CDN_URLS,
+        FONT_EXPECTED_SHA256, FONT_FILENAME, MAX_RETRY_ROUNDS,
     };
     use sha2::{Digest, Sha256};
     use tempfile::tempdir;
@@ -341,6 +341,18 @@ mod tests {
         let error = validate_font_data(&data).expect_err("mutated font should fail hash check");
 
         assert!(error.contains("expected sha256"));
+    }
+
+    #[test]
+    fn font_download_retry_budget_covers_multiple_cdn_rounds() {
+        assert!(
+            MAX_RETRY_ROUNDS >= 5,
+            "font download should retry each CDN at least 5 rounds"
+        );
+        assert!(
+            MAX_RETRY_ROUNDS * FONT_CDN_URLS.len() >= 10,
+            "font download should have at least 10 total CDN attempts"
+        );
     }
 
     #[tokio::test]

--- a/apps/desktop/src-tauri/src/core/system/assets.rs
+++ b/apps/desktop/src-tauri/src/core/system/assets.rs
@@ -5,7 +5,7 @@
 use log::{error, info, warn};
 use sha2::{Digest, Sha256};
 use std::io::ErrorKind;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tauri::Emitter;
 use tokio::fs;
 use tokio::io::AsyncWriteExt;
@@ -42,7 +42,7 @@ async fn font_exists() -> Result<bool, String> {
     is_valid_font_file(&font_path).await
 }
 
-async fn is_valid_font_file(font_path: &std::path::Path) -> Result<bool, String> {
+async fn is_valid_font_file(font_path: &Path) -> Result<bool, String> {
     let metadata = match fs::metadata(&font_path).await {
         Ok(metadata) => metadata,
         Err(error) if error.kind() == ErrorKind::NotFound => return Ok(false),
@@ -98,6 +98,41 @@ fn validate_font_data(data: &[u8]) -> Result<(), String> {
     }
 
     Ok(())
+}
+
+#[cfg(windows)]
+async fn replace_font_file(source_path: &Path, font_path: &Path) -> Result<(), String> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows::core::PCWSTR;
+    use windows::Win32::Storage::FileSystem::{
+        MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+    };
+
+    fn wide_path(path: &Path) -> Vec<u16> {
+        path.as_os_str()
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect()
+    }
+
+    let source_wide = wide_path(source_path);
+    let font_wide = wide_path(font_path);
+
+    unsafe {
+        MoveFileExW(
+            PCWSTR(source_wide.as_ptr()),
+            PCWSTR(font_wide.as_ptr()),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    }
+    .map_err(|e| format!("Failed to replace font file: {e}"))
+}
+
+#[cfg(not(windows))]
+async fn replace_font_file(source_path: &Path, font_path: &Path) -> Result<(), String> {
+    fs::rename(source_path, font_path)
+        .await
+        .map_err(|e| format!("Failed to replace font file: {}", e))
 }
 
 /// 从指定 URL 下载文件
@@ -171,20 +206,7 @@ async fn save_font(data: &[u8]) -> Result<(), String> {
             .map_err(|e| format!("Failed to flush temporary font file: {}", e))?;
     }
 
-    match fs::remove_file(&font_path).await {
-        Ok(()) => {}
-        Err(error) if error.kind() == ErrorKind::NotFound => {}
-        Err(error) => {
-            return Err(format!(
-                "Failed to remove existing font file '{}': {error}",
-                font_path.display()
-            ));
-        }
-    }
-
-    fs::rename(&temp_font_path, &font_path)
-        .await
-        .map_err(|e| format!("Failed to replace font file: {}", e))?;
+    replace_font_file(&temp_font_path, &font_path).await?;
 
     info!("Font saved to: {}", font_path.display());
     Ok(())
@@ -249,7 +271,10 @@ pub async fn initialize_font(app_handle: tauri::AppHandle) -> Result<(), String>
 
 #[cfg(test)]
 mod tests {
-    use super::{is_valid_font_file, validate_font_data, FONT_EXPECTED_SHA256, FONT_FILENAME};
+    use super::{
+        is_valid_font_file, replace_font_file, validate_font_data, FONT_EXPECTED_SHA256,
+        FONT_FILENAME,
+    };
     use sha2::{Digest, Sha256};
     use tempfile::tempdir;
     use tokio::fs;
@@ -316,5 +341,50 @@ mod tests {
         let error = validate_font_data(&data).expect_err("mutated font should fail hash check");
 
         assert!(error.contains("expected sha256"));
+    }
+
+    #[tokio::test]
+    async fn replace_font_file_keeps_existing_font_when_source_is_missing() {
+        let root = tempdir().expect("tempdir");
+        let source_path = root.path().join("missing-font.tmp");
+        let font_path = root.path().join(FONT_FILENAME);
+        fs::write(&font_path, b"existing font")
+            .await
+            .expect("write existing font");
+
+        let error = replace_font_file(&source_path, &font_path)
+            .await
+            .expect_err("missing source should fail");
+
+        assert!(error.contains("Failed to replace font file"));
+        assert_eq!(
+            fs::read(&font_path).await.expect("read existing font"),
+            b"existing font"
+        );
+    }
+
+    #[tokio::test]
+    async fn replace_font_file_commits_new_font_over_existing_font() {
+        let root = tempdir().expect("tempdir");
+        let source_path = root.path().join("font.tmp");
+        let font_path = root.path().join(FONT_FILENAME);
+        fs::write(&source_path, b"new font")
+            .await
+            .expect("write replacement font");
+        fs::write(&font_path, b"existing font")
+            .await
+            .expect("write existing font");
+
+        replace_font_file(&source_path, &font_path)
+            .await
+            .expect("replace font");
+
+        assert_eq!(
+            fs::read(&font_path).await.expect("read replaced font"),
+            b"new font"
+        );
+        assert!(!fs::try_exists(&source_path)
+            .await
+            .expect("check source path"));
     }
 }

--- a/apps/desktop/src/services/BuiltInToolService/tools/widgetTool/showWidget/runtimeConstants.ts
+++ b/apps/desktop/src/services/BuiltInToolService/tools/widgetTool/showWidget/runtimeConstants.ts
@@ -77,8 +77,7 @@ export const SHOW_WIDGET_THEME_FALLBACKS: Record<ShowWidgetThemeVarName, string>
     '--color-scrollbar-thumb-hover': 'rgba(156, 163, 175, 0.6)',
     '--font-sans':
         "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'PingFang SC', 'Microsoft YaHei', sans-serif",
-    '--font-serif':
-        "'Source Han Serif SC', 'Source Han Serif CN', 'Noto Serif SC', 'Source Han Serif', serif",
+    '--font-serif': "'TouchAI Source Han Serif SC', 'Noto Serif SC', serif",
     '--font-mono': "'JetBrains Mono', 'Fira Code', 'Consolas', 'Monaco', monospace",
     '--border-radius-md': '8px',
     '--border-radius-lg': '12px',

--- a/apps/desktop/src/styles/markdown.css
+++ b/apps/desktop/src/styles/markdown.css
@@ -45,7 +45,7 @@
         --touchai-markdown-surface-shadow: 0 1px 2px rgba(15, 23, 42, 0.06);
 
         font-family:
-            'TouchAI Source Han Serif SC', 'Noto Serif SC', 'Source Serif Pro', 'Georgia', serif;
+            'TouchAI Source Han Serif SC', 'Noto Serif SC', 'Source Serif Pro', Georgia, serif;
         font-size: 15px;
         line-height: 2.05;
         letter-spacing: 0.02em;

--- a/apps/desktop/src/styles/markdown.css
+++ b/apps/desktop/src/styles/markdown.css
@@ -44,7 +44,8 @@
         --touchai-markdown-surface-border: var(--color-markdown-surface-border);
         --touchai-markdown-surface-shadow: 0 1px 2px rgba(15, 23, 42, 0.06);
 
-        font-family: 'Source Han Serif SC', 'Noto Serif SC', 'Source Serif Pro', 'Georgia', serif;
+        font-family:
+            'TouchAI Source Han Serif SC', 'Noto Serif SC', 'Source Serif Pro', 'Georgia', serif;
         font-size: 15px;
         line-height: 2.05;
         letter-spacing: 0.02em;

--- a/apps/desktop/src/styles/tailwind.css
+++ b/apps/desktop/src/styles/tailwind.css
@@ -11,8 +11,7 @@
 @theme {
     --font-sans:
         -apple-system, BlinkMacSystemFont, 'Segoe UI', 'PingFang SC', 'Microsoft YaHei', sans-serif;
-    --font-serif:
-        'Source Han Serif SC', 'Source Han Serif CN', 'Noto Serif SC', 'Source Han Serif', serif;
+    --font-serif: 'TouchAI Source Han Serif SC', 'Noto Serif SC', serif;
 
     /* 背景色 */
     --color-background-primary: rgba(251, 251, 246, 0.98);

--- a/apps/desktop/src/utils/font.ts
+++ b/apps/desktop/src/utils/font.ts
@@ -8,11 +8,43 @@ import { convertFileSrc } from '@tauri-apps/api/core';
  * 字体文件名
  */
 const FONT_FILENAME = 'SourceHanSerifSC-VF.ttf.woff2';
+const FONT_FACE_FAMILY = 'TouchAI Source Han Serif SC';
+const FONT_FACE_STYLE_ATTRIBUTE = 'data-touchai-font-face';
+const FONT_FACE_STYLE_KEY = 'source-han-serif-sc';
+
+let fontLoadPromise: Promise<void> | null = null;
+let fontReadyListenerPromise: Promise<void> | null = null;
+let fontReloadToken = 0;
+
+interface LoadFontFaceOptions {
+    refresh?: boolean;
+}
+
+function getInjectedFontFaceStyle(): HTMLStyleElement | null {
+    return document.head.querySelector<HTMLStyleElement>(
+        `style[${FONT_FACE_STYLE_ATTRIBUTE}="${FONT_FACE_STYLE_KEY}"]`
+    );
+}
+
+function hasInjectedFontFace(): boolean {
+    return getInjectedFontFaceStyle() !== null;
+}
+
+function appendFontReloadToken(fontUrl: string, reloadToken: number): string {
+    const separator = fontUrl.includes('?') ? '&' : '?';
+    return `${fontUrl}${separator}touchaiFontReload=${reloadToken}`;
+}
 
 /**
  * 加载字体文件并注入 @font-face 规则
  */
-async function injectFontFace(): Promise<void> {
+async function injectFontFace(options: LoadFontFaceOptions = {}): Promise<void> {
+    const { refresh = false } = options;
+
+    if (!refresh && hasInjectedFontFace()) {
+        return;
+    }
+
     // 获取字体目录路径
     const fontDir = await paths.getAppDirectoryPath('ASSETS_FONT');
 
@@ -20,41 +52,85 @@ async function injectFontFace(): Promise<void> {
     const fontPath = `${fontDir}\\${FONT_FILENAME}`;
 
     // 转换为前端可用的 URL
-    const fontUrl = convertFileSrc(fontPath);
+    const fontUrl = refresh
+        ? appendFontReloadToken(convertFileSrc(fontPath), ++fontReloadToken)
+        : convertFileSrc(fontPath);
 
     // 动态注入 @font-face 规则
+    if (!refresh && hasInjectedFontFace()) {
+        return;
+    }
+
     const style = document.createElement('style');
+    style.setAttribute(FONT_FACE_STYLE_ATTRIBUTE, FONT_FACE_STYLE_KEY);
     style.textContent = `
         @font-face {
-            font-family: 'Source Han Serif SC';
-            src: url('${fontUrl}') format('woff2-variations');
-            font-weight: 200 900;
+            font-family: '${FONT_FACE_FAMILY}';
+            src: url('${fontUrl}') format('woff2');
+            font-weight: 250 900;
             font-style: normal;
             font-display: swap;
         }
     `;
+    getInjectedFontFaceStyle()?.remove();
     document.head.appendChild(style);
 
     console.log('Source Han Serif font loaded successfully from:', fontUrl);
 }
 
+function loadFontFace(options: LoadFontFaceOptions = {}): Promise<void> {
+    const { refresh = false } = options;
+
+    if (!refresh && hasInjectedFontFace()) {
+        return Promise.resolve();
+    }
+
+    if (!refresh && fontLoadPromise) {
+        return fontLoadPromise;
+    }
+
+    const loadPromise = injectFontFace(options).finally(() => {
+        fontLoadPromise = null;
+    });
+
+    if (refresh) {
+        return loadPromise;
+    }
+
+    fontLoadPromise = loadPromise;
+    return fontLoadPromise;
+}
+
+function logFontLoadError(error: unknown): void {
+    console.error('Failed to load Source Han Serif font:', error);
+    // 字体加载失败不应阻止应用运行，只记录错误
+}
+
+function ensureFontReadyListener(): Promise<void> {
+    if (fontReadyListenerPromise) {
+        return fontReadyListenerPromise;
+    }
+
+    fontReadyListenerPromise = eventService
+        .on(AppEvent.FONT_READY, () => {
+            void loadFontFace({ refresh: true }).catch(logFontLoadError);
+        })
+        .then(() => undefined)
+        .catch((error) => {
+            fontReadyListenerPromise = null;
+            console.error('Failed to listen for font-ready event:', error);
+        });
+
+    return fontReadyListenerPromise;
+}
+
 /**
  * 初始化字体加载监听器
  *
- * 监听 Rust 后端发送的 `font:ready` 事件，
- * 收到事件后才加载字体文件。
+ * 主动尝试加载字体，并监听 Rust 后端发送的 `font:ready` 事件作为下载完成后的补充通知。
  */
 export function initializeFontLoader(): void {
-    eventService
-        .on(AppEvent.FONT_READY, async () => {
-            try {
-                await injectFontFace();
-            } catch (error) {
-                console.error('Failed to load Source Han Serif font:', error);
-                // 字体加载失败不应阻止应用运行，只记录错误
-            }
-        })
-        .catch((error) => {
-            console.error('Failed to listen for font-ready event:', error);
-        });
+    ensureFontReadyListener().finally(() => {
+        void loadFontFace().catch(logFontLoadError);
+    });
 }

--- a/apps/desktop/src/views/SearchView/components/ConversationPanel/components/UserMessage.vue
+++ b/apps/desktop/src/views/SearchView/components/ConversationPanel/components/UserMessage.vue
@@ -85,8 +85,7 @@
 
 <style scoped>
     .user-text {
-        font-family:
-            'Source Han Serif CN', 'Noto Serif SC', 'Source Han Serif', 'Noto Serif CJK SC', serif;
+        font-family: 'TouchAI Source Han Serif SC', 'Noto Serif SC', serif;
     }
 
     .user-text::selection {

--- a/apps/desktop/tests/utils/font.test.ts
+++ b/apps/desktop/tests/utils/font.test.ts
@@ -1,0 +1,253 @@
+import { AppEvent } from '@services/EventService';
+import { emit } from '@tauri-apps/api/event';
+import { getTauriInvokeCalls, mockTauriCommand } from '@tests/utils/tauri';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const FONT_STYLE_SELECTOR = 'style[data-touchai-font-face="source-han-serif-sc"]';
+const FONT_TEST_TIMEOUT_MS = 15_000;
+
+function fontStyles(): HTMLStyleElement[] {
+    return [...document.head.querySelectorAll<HTMLStyleElement>(FONT_STYLE_SELECTOR)];
+}
+
+function fontStyleText(): string {
+    return fontStyles()[0]?.textContent ?? '';
+}
+
+function getPayloadEvent(payload: unknown): unknown {
+    if (!payload || typeof payload !== 'object' || payload instanceof ArrayBuffer) {
+        return undefined;
+    }
+
+    return (payload as { event?: unknown }).event;
+}
+
+async function waitForFontReadyListener(): Promise<void> {
+    await vi.waitFor(() => {
+        expect(
+            getTauriInvokeCalls('plugin:event|listen').some(
+                (call) => getPayloadEvent(call.payload) === AppEvent.FONT_READY
+            )
+        ).toBe(true);
+    });
+}
+
+function fontReadyListenCalls() {
+    return getTauriInvokeCalls('plugin:event|listen').filter(
+        (call) => getPayloadEvent(call.payload) === AppEvent.FONT_READY
+    );
+}
+
+describe('font loader', () => {
+    beforeEach(() => {
+        vi.resetModules();
+        vi.doUnmock('@tauri-apps/api/core');
+        document.head.innerHTML = '';
+        mockTauriCommand('get_app_directory_path', 'D:\\TouchAI\\assets\\font');
+    });
+
+    it(
+        'loads the bundled serif font during initialization without waiting for font-ready',
+        async () => {
+            const { initializeFontLoader } = await import('@/utils/font');
+
+            initializeFontLoader();
+
+            await vi.waitFor(() => expect(fontStyles()).toHaveLength(1));
+            const styleText = fontStyleText();
+            expect(styleText).toContain("font-family: 'TouchAI Source Han Serif SC'");
+            expect(styleText).toContain("format('woff2')");
+            expect(styleText).toContain('font-weight: 250 900');
+            expect(styleText).toContain('font-display: swap');
+
+            const commandOrder = getTauriInvokeCalls().map((call) => call.cmd);
+            expect(commandOrder.indexOf('plugin:event|listen')).toBeLessThan(
+                commandOrder.indexOf('get_app_directory_path')
+            );
+        },
+        FONT_TEST_TIMEOUT_MS
+    );
+
+    it(
+        'keeps one font-face style when font-ready is delivered more than once',
+        async () => {
+            const { initializeFontLoader } = await import('@/utils/font');
+
+            initializeFontLoader();
+            await waitForFontReadyListener();
+
+            await emit(AppEvent.FONT_READY, {});
+            await emit(AppEvent.FONT_READY, {});
+
+            await vi.waitFor(() => {
+                expect(fontStyles()).toHaveLength(1);
+                expect(fontStyleText()).toContain('touchaiFontReload=2');
+            });
+        },
+        FONT_TEST_TIMEOUT_MS
+    );
+
+    it(
+        'does not register duplicate font-ready listeners when initialized more than once',
+        async () => {
+            const { initializeFontLoader } = await import('@/utils/font');
+
+            initializeFontLoader();
+            initializeFontLoader();
+            initializeFontLoader();
+            await waitForFontReadyListener();
+
+            await vi.waitFor(() => expect(fontReadyListenCalls()).toHaveLength(1));
+            await emit(AppEvent.FONT_READY, {});
+
+            await vi.waitFor(() => {
+                expect(fontStyles()).toHaveLength(1);
+                expect(fontStyleText()).toContain('touchaiFontReload=1');
+            });
+        },
+        FONT_TEST_TIMEOUT_MS
+    );
+
+    it(
+        'can reload the startup font-face rule after the injected style is removed',
+        async () => {
+            const { initializeFontLoader } = await import('@/utils/font');
+
+            initializeFontLoader();
+            await vi.waitFor(() => expect(fontStyles()).toHaveLength(1));
+
+            fontStyles()[0]?.remove();
+            initializeFontLoader();
+
+            await vi.waitFor(() => {
+                expect(fontStyles()).toHaveLength(1);
+                expect(fontStyleText()).not.toContain('touchaiFontReload=');
+            });
+        },
+        FONT_TEST_TIMEOUT_MS
+    );
+
+    it(
+        'refreshes an early font-face rule after the font file is downloaded',
+        async () => {
+            const { initializeFontLoader } = await import('@/utils/font');
+
+            initializeFontLoader();
+            await waitForFontReadyListener();
+            await vi.waitFor(() => expect(fontStyles()).toHaveLength(1));
+
+            const earlyStyle = fontStyles()[0];
+
+            await emit(AppEvent.FONT_READY, {});
+
+            await vi.waitFor(() => {
+                const styles = fontStyles();
+                expect(styles).toHaveLength(1);
+                expect(styles[0]).not.toBe(earlyStyle);
+                expect(fontStyleText()).toContain('touchaiFontReload=1');
+            });
+        },
+        FONT_TEST_TIMEOUT_MS
+    );
+
+    it(
+        'does not let a slower startup load replace a refreshed font-face rule',
+        async () => {
+            let directoryCallCount = 0;
+            let resolveStartupLoad: ((fontDir: string) => void) | undefined;
+
+            mockTauriCommand('get_app_directory_path', () => {
+                directoryCallCount += 1;
+
+                if (directoryCallCount === 1) {
+                    return new Promise<string>((resolve) => {
+                        resolveStartupLoad = resolve;
+                    });
+                }
+
+                return 'D:\\TouchAI\\assets\\font';
+            });
+
+            const { initializeFontLoader } = await import('@/utils/font');
+
+            initializeFontLoader();
+            await waitForFontReadyListener();
+            await vi.waitFor(() => expect(resolveStartupLoad).toBeTypeOf('function'));
+
+            await emit(AppEvent.FONT_READY, {});
+            await vi.waitFor(() => {
+                const styles = fontStyles();
+                expect(styles).toHaveLength(1);
+                expect(fontStyleText()).toContain('touchaiFontReload=1');
+            });
+
+            resolveStartupLoad?.('D:\\TouchAI\\assets\\font');
+            await vi.waitFor(() => {
+                const styles = fontStyles();
+                expect(styles).toHaveLength(1);
+                expect(fontStyleText()).toContain('touchaiFontReload=1');
+            });
+        },
+        FONT_TEST_TIMEOUT_MS
+    );
+
+    it(
+        'recovers from a startup path lookup failure when font-ready arrives later',
+        async () => {
+            const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+            let directoryCallCount = 0;
+
+            mockTauriCommand('get_app_directory_path', () => {
+                directoryCallCount += 1;
+                if (directoryCallCount === 1) {
+                    throw new Error('font directory is not ready');
+                }
+
+                return 'D:\\TouchAI\\assets\\font';
+            });
+
+            const { initializeFontLoader } = await import('@/utils/font');
+
+            initializeFontLoader();
+            await waitForFontReadyListener();
+            await vi.waitFor(() => expect(consoleError).toHaveBeenCalled());
+            expect(fontStyles()).toHaveLength(0);
+
+            await emit(AppEvent.FONT_READY, {});
+
+            await vi.waitFor(() => {
+                expect(fontStyles()).toHaveLength(1);
+                expect(fontStyleText()).toContain('touchaiFontReload=1');
+            });
+
+            consoleError.mockRestore();
+        },
+        FONT_TEST_TIMEOUT_MS
+    );
+
+    it(
+        'appends a reload token with ampersand when the asset URL already has a query string',
+        async () => {
+            vi.doMock('@tauri-apps/api/core', async (importOriginal) => {
+                const actual = await importOriginal<typeof import('@tauri-apps/api/core')>();
+                return {
+                    ...actual,
+                    convertFileSrc: () => 'http://asset.localhost/font.woff2?cache=base',
+                };
+            });
+
+            const { initializeFontLoader } = await import('@/utils/font');
+
+            initializeFontLoader();
+            await waitForFontReadyListener();
+
+            await emit(AppEvent.FONT_READY, {});
+
+            await vi.waitFor(() => {
+                expect(fontStyles()).toHaveLength(1);
+                expect(fontStyleText()).toContain('&touchaiFontReload=1');
+            });
+        },
+        FONT_TEST_TIMEOUT_MS
+    );
+});


### PR DESCRIPTION
## Summary

- make desktop serif font loading deterministic by registering the `font:ready` listener once, proactively injecting the bundled font, and refreshing the font-face rule after backend download completion
- give the bundled font a TouchAI-specific family name and remove local `Source Han Serif...` fallbacks that can resolve to machine-specific Heavy instances
- validate cached/downloaded font bytes by expected size and SHA-256 before using or saving the desktop font asset
- add frontend regression coverage for missed events, duplicate initialization, refresh races, recovery after startup lookup failure, and cache-busting URLs
- add Rust cache validation coverage for missing, short, valid bundled, and same-size wrong-hash font files

## Related issue or RFC

- Closes #385

## AI assistance disclosure

- Tool(s) used: Codex
- Scope of assistance: investigation, implementation, tests, local verification, PR preparation
- Human review or rewrite performed: pending maintainer review
- Architecture or boundary impact: no RFC-first boundary impact; scoped to desktop font resource loading and frontend font-face injection

## Testing evidence

```text
pnpm exec vitest run tests/utils/font.test.ts --configLoader runner --reporter verbose --no-coverage
# 1 file, 8 tests passed

pnpm --filter @touchai/desktop test:typecheck
# passed

pnpm exec eslint src/utils/font.ts tests/utils/font.test.ts src/services/BuiltInToolService/tools/widgetTool/showWidget/runtimeConstants.ts src/views/SearchView/components/ConversationPanel/components/UserMessage.vue
# passed

pnpm exec prettier --check apps/desktop/src/utils/font.ts apps/desktop/tests/utils/font.test.ts apps/desktop/src/styles/tailwind.css apps/desktop/src/styles/markdown.css apps/desktop/src/services/BuiltInToolService/tools/widgetTool/showWidget/runtimeConstants.ts apps/desktop/src/views/SearchView/components/ConversationPanel/components/UserMessage.vue
# passed

cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml --all
# passed

git diff --check
# passed

git -C apps/desktop exec tsc --noEmit
# not used; equivalent local command run from apps/desktop: pnpm exec tsc --noEmit, passed
```

Rust note: local `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml --lib core::system::assets::tests -- --nocapture` was attempted with `CARGO_TARGET_DIR=E:\TouchAI\target\issue-385-font-loading`, but cold compilation timed out locally after 15 minutes without producing a test result. This draft PR is opened to let GitHub Actions run the full Rust check in CI.

Did you follow TDD? Yes. Frontend tests were expanded first; duplicate initialization failed red before adding listener idempotency. Existing red/green coverage also locked in startup injection and font-ready refresh behavior.

## Risk notes

- AgentService, runtime, MCP, or schema impact: none
- database baseline or migration impact: none
- release or packaging impact: desktop startup now validates the cached font by hash and may redownload when cache bytes are incomplete/corrupt

## Screenshots or recordings

Original symptom screenshot showed Settings UI resolving to an overly heavy serif face on affected Windows machines.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [ ] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [ ] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [ ] I updated docs when behavior changed.