### PR TITLE
fix(search): center single-line search bar content

### DIFF
--- a/apps/desktop/src/views/SearchView/components/SearchBar/index.vue
+++ b/apps/desktop/src/views/SearchView/components/SearchBar/index.vue
@@ -6,7 +6,8 @@
     <div
         ref="searchBarContainerRef"
         data-testid="search-bar"
-        class="search-bar-container relative flex h-full min-h-14 w-full items-start gap-2 p-3"
+        class="search-bar-container relative flex h-full min-h-14 w-full gap-2 p-3"
+        :class="isMultiLine ? 'items-start' : 'items-center'"
         @mousedown="handleContainerMouseDown"
     >
         <div

--- a/apps/desktop/tests/SearchView/SearchBarLayout.test.ts
+++ b/apps/desktop/tests/SearchView/SearchBarLayout.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { nextTick } from 'vue';
 
 const { isMultiLine, useSearchInputMock } = vi.hoisted(() => {
-    const fakeRef = <T,>(value: T) => ({
+    const fakeRef = <T>(value: T) => ({
         __v_isRef: true,
         value,
     });

--- a/apps/desktop/tests/SearchView/SearchBarLayout.test.ts
+++ b/apps/desktop/tests/SearchView/SearchBarLayout.test.ts
@@ -1,0 +1,108 @@
+import { mount } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { nextTick } from 'vue';
+
+const { isMultiLine, useSearchInputMock } = vi.hoisted(() => {
+    const fakeRef = <T,>(value: T) => ({
+        __v_isRef: true,
+        value,
+    });
+    const isMultiLine = fakeRef(false);
+    return {
+        isMultiLine,
+        useSearchInputMock: vi.fn(() => ({
+            editor: fakeRef({}),
+            selectedModel: fakeRef(null),
+            activeModel: fakeRef({
+                model_id: 'mimo-v2.5',
+                name: 'mimo-v2.5',
+            }),
+            prefetchModelDropdownData: vi.fn(),
+            invalidateModelDropdownData: vi.fn(),
+            prepareModelDropdownOpen: vi.fn(),
+            selectModelFromDropdown: vi.fn(),
+            getModelDropdownAnchor: vi.fn(),
+            getModelDropdownContext: vi.fn(),
+            isMultiLine,
+            cursorAtStart: fakeRef(false),
+            cursorAtTextStart: fakeRef(true),
+            cursorAtEnd: fakeRef(true),
+            focus: vi.fn(),
+            loadActiveModel: vi.fn(),
+            captureInputHistorySnapshot: vi.fn(),
+            restoreInputHistorySnapshot: vi.fn(),
+            handleContainerMouseDown: vi.fn(),
+            handleEditorMouseDown: vi.fn(),
+            initEditor: vi.fn(),
+            destroyEditor: vi.fn(),
+            onEditorClick: vi.fn(),
+            logoContainerRef: fakeRef(null),
+        })),
+    };
+});
+
+vi.mock('@assets/logo.svg', () => ({ default: 'logo.svg' }));
+
+vi.mock('@components/ModelLogo.vue', () => ({
+    default: {
+        name: 'ModelLogo',
+        props: ['modelId', 'name'],
+        template: '<div class="mock-model-logo" />',
+    },
+}));
+
+vi.mock('@tiptap/vue-3', () => ({
+    EditorContent: {
+        name: 'EditorContent',
+        props: ['editor'],
+        template: '<div class="mock-editor-content" />',
+    },
+}));
+
+vi.mock('@/views/SearchView/components/SearchBar/composables/useSearchLogic', () => ({
+    useSearchInput: useSearchInputMock,
+}));
+
+import SearchBar from '@/views/SearchView/components/SearchBar/index.vue';
+
+describe('SearchBar layout', () => {
+    beforeEach(() => {
+        isMultiLine.value = false;
+        useSearchInputMock.mockClear();
+    });
+
+    function mountSearchBar() {
+        return mount(SearchBar, {
+            props: {
+                queryText: '',
+                attachments: [],
+                modelOverride: {
+                    modelId: null,
+                    providerId: null,
+                },
+            },
+        });
+    }
+
+    it('centers the search bar row vertically while the editor is single-line', () => {
+        const wrapper = mountSearchBar();
+
+        const searchBar = wrapper.get('[data-testid="search-bar"]');
+
+        expect(searchBar.classes()).toContain('items-center');
+        expect(searchBar.classes()).not.toContain('items-start');
+    });
+
+    it('top-aligns the search bar row when the editor becomes multiline', async () => {
+        const wrapper = mountSearchBar();
+
+        isMultiLine.value = true;
+        wrapper.vm.$forceUpdate();
+        await nextTick();
+
+        const searchBar = wrapper.get('[data-testid="search-bar"]');
+
+        expect(searchBar.classes()).toContain('items-start');
+        expect(searchBar.classes()).not.toContain('items-center');
+    });
+});


### PR DESCRIPTION
## Summary
- Center the SearchBar root row while the editor is single-line, so the model logo and model chip no longer sit at the top of the bar.
- Keep the multiline state top-aligned so expanded input content still grows from the top.
- Add a focused component regression test for single-line vs multiline SearchBar alignment.

## Related issue or RFC

- Closes #398

## Root cause

Introduced by commit `0400a4657dabd66e64cb80e897fa64fe148ca2dc` (`fix(desktop): stabilize search window border resize (#345)`). That change replaced the SearchBar root row from `items-center` to fixed `items-start` and removed `self-center` from the logo container. As a result, even when the editor was single-line, the whole SearchBar row was top-aligned.

## AI assistance disclosure

- Tool(s) used: Codex
- Scope of assistance: issue creation, root-cause tracing, code/test changes, draft PR preparation, CI follow-up
- Human review or rewrite performed: Pending maintainer/user verification on another machine
- Architecture or boundary impact: None; scoped to frontend SearchBar layout

## Testing evidence

Local verification was not run per user request. The user plans to verify on another machine. GitHub Actions is the verification source for this draft PR.

```text
Not run locally: pnpm test:pr
Not run locally: focused Vitest SearchBar layout test
```

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: None
- database baseline or migration impact: None
- release or packaging impact: None

## Screenshots or recordings

Not captured locally per user request.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope.
- [ ] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC. Not applicable.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC. Not applicable.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [x] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence. Not applicable.
- [ ] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed. Not applicable.