### PR TITLE
fix(desktop): improve cold startup first paint

### DIFF
--- a/apps/desktop/src/utils/font.ts
+++ b/apps/desktop/src/utils/font.ts
@@ -3,10 +3,8 @@
 import { AppEvent, eventService } from '@services/EventService';
 import { paths } from '@services/NativeService';
 import { convertFileSrc } from '@tauri-apps/api/core';
+import { exists } from '@tauri-apps/plugin-fs';
 
-/**
- * 字体文件名
- */
 const FONT_FILENAME = 'SourceHanSerifSC-VF.ttf.woff2';
 const FONT_FACE_FAMILY = 'TouchAI Source Han Serif SC';
 const FONT_FACE_STYLE_ATTRIBUTE = 'data-touchai-font-face';
@@ -18,6 +16,7 @@ let fontReloadToken = 0;
 
 interface LoadFontFaceOptions {
     refresh?: boolean;
+    requireExistingFile?: boolean;
 }
 
 function getInjectedFontFaceStyle(): HTMLStyleElement | null {
@@ -35,30 +34,29 @@ function appendFontReloadToken(fontUrl: string, reloadToken: number): string {
     return `${fontUrl}${separator}touchaiFontReload=${reloadToken}`;
 }
 
-/**
- * 加载字体文件并注入 @font-face 规则
- */
-async function injectFontFace(options: LoadFontFaceOptions = {}): Promise<void> {
-    const { refresh = false } = options;
+async function resolveFontPath(): Promise<string> {
+    const fontDir = await paths.getAppDirectoryPath('ASSETS_FONT');
+    return `${fontDir}\\${FONT_FILENAME}`;
+}
+
+async function injectFontFace(options: LoadFontFaceOptions = {}): Promise<boolean> {
+    const { refresh = false, requireExistingFile = false } = options;
 
     if (!refresh && hasInjectedFontFace()) {
-        return;
+        return true;
     }
 
-    // 获取字体目录路径
-    const fontDir = await paths.getAppDirectoryPath('ASSETS_FONT');
+    const fontPath = await resolveFontPath();
+    if (requireExistingFile && !(await exists(fontPath))) {
+        return false;
+    }
 
-    // 构建字体文件的完整路径
-    const fontPath = `${fontDir}\\${FONT_FILENAME}`;
-
-    // 转换为前端可用的 URL
     const fontUrl = refresh
         ? appendFontReloadToken(convertFileSrc(fontPath), ++fontReloadToken)
         : convertFileSrc(fontPath);
 
-    // 动态注入 @font-face 规则
     if (!refresh && hasInjectedFontFace()) {
-        return;
+        return true;
     }
 
     const style = document.createElement('style');
@@ -76,6 +74,7 @@ async function injectFontFace(options: LoadFontFaceOptions = {}): Promise<void> 
     document.head.appendChild(style);
 
     console.log('Source Han Serif font loaded successfully from:', fontUrl);
+    return true;
 }
 
 function loadFontFace(options: LoadFontFaceOptions = {}): Promise<void> {
@@ -89,9 +88,11 @@ function loadFontFace(options: LoadFontFaceOptions = {}): Promise<void> {
         return fontLoadPromise;
     }
 
-    const loadPromise = injectFontFace(options).finally(() => {
-        fontLoadPromise = null;
-    });
+    const loadPromise = injectFontFace(options)
+        .then(() => undefined)
+        .finally(() => {
+            fontLoadPromise = null;
+        });
 
     if (refresh) {
         return loadPromise;
@@ -103,7 +104,6 @@ function loadFontFace(options: LoadFontFaceOptions = {}): Promise<void> {
 
 function logFontLoadError(error: unknown): void {
     console.error('Failed to load Source Han Serif font:', error);
-    // 字体加载失败不应阻止应用运行，只记录错误
 }
 
 function ensureFontReadyListener(): Promise<void> {
@@ -124,13 +124,8 @@ function ensureFontReadyListener(): Promise<void> {
     return fontReadyListenerPromise;
 }
 
-/**
- * 初始化字体加载监听器
- *
- * 主动尝试加载字体，并监听 Rust 后端发送的 `font:ready` 事件作为下载完成后的补充通知。
- */
 export function initializeFontLoader(): void {
     ensureFontReadyListener().finally(() => {
-        void loadFontFace().catch(logFontLoadError);
+        void loadFontFace({ requireExistingFile: true }).catch(logFontLoadError);
     });
 }

--- a/apps/desktop/src/utils/font.ts
+++ b/apps/desktop/src/utils/font.ts
@@ -3,6 +3,7 @@
 import { AppEvent, eventService } from '@services/EventService';
 import { paths } from '@services/NativeService';
 import { convertFileSrc } from '@tauri-apps/api/core';
+import { join } from '@tauri-apps/api/path';
 import { exists } from '@tauri-apps/plugin-fs';
 
 const FONT_FILENAME = 'SourceHanSerifSC-VF.ttf.woff2';
@@ -36,7 +37,7 @@ function appendFontReloadToken(fontUrl: string, reloadToken: number): string {
 
 async function resolveFontPath(): Promise<string> {
     const fontDir = await paths.getAppDirectoryPath('ASSETS_FONT');
-    return `${fontDir}\\${FONT_FILENAME}`;
+    return join(fontDir, FONT_FILENAME);
 }
 
 async function injectFontFace(options: LoadFontFaceOptions = {}): Promise<boolean> {

--- a/apps/desktop/src/views/SearchView/index.vue
+++ b/apps/desktop/src/views/SearchView/index.vue
@@ -62,6 +62,7 @@
     import { useSearchRequestFlow } from './composables/useSearchRequest';
     import { useSearchWindowResize } from './composables/useSearchWindowResize';
     import { useSessionHistoryPopup } from './composables/useSessionHistoryPopup';
+    import { initializeSearchViewForFirstPaint } from './startup';
     import type {
         ConversationPanelHandle,
         QuickSearchHandle,
@@ -1020,38 +1021,23 @@
     }
 
     async function initialize() {
-        try {
-            viewReady.value = false;
-
-            await Promise.all([
-                mcpStore.initialize(),
-                settingsStore.initialize(),
-                popupService.initialize(),
-            ]);
-            await syncWindowPinState().catch((error) => {
-                console.error('[SearchView] Failed to sync window pin state on initialize:', error);
-            });
-            await syncSearchWindowState().catch((error) => {
-                console.error(
-                    '[SearchView] Failed to sync search window state on initialize:',
-                    error
-                );
-            });
-
-            viewReady.value = true;
-
-            if (!(await isE2eTestMode())) {
-                mcpManager.autoConnect().catch((initializeError) => {
-                    console.error(
-                        '[SearchView] Failed to auto-connect MCP servers:',
-                        initializeError
-                    );
-                });
-            }
-        } catch (initializeError) {
-            console.error('[SearchView] Failed to initialize dependencies:', initializeError);
-            viewReady.value = false;
-        }
+        await initializeSearchViewForFirstPaint({
+            initializeSettings: () => settingsStore.initialize(),
+            initializeMcpStore: () => mcpStore.initialize(),
+            initializePopups: () => popupService.initialize(),
+            syncWindowPinState,
+            syncSearchWindowState,
+            isE2eTestMode,
+            autoConnectMcp: async () => {
+                await mcpManager.autoConnect();
+            },
+            onReady: (ready) => {
+                viewReady.value = ready;
+            },
+            logError: (message, error) => {
+                console.error(message, error);
+            },
+        });
     }
 
     watch(
@@ -1324,7 +1310,7 @@
             class="ask-user-divider relative z-10 w-full"
         ></div>
         <AskUserPanel v-if="searchViewContentReady && askUserStore.current" />
-        <div v-if="searchViewContentReady && !askUserStore.current" class="relative w-full">
+        <div v-if="viewReady && !askUserStore.current" class="relative w-full">
             <SearchBar
                 ref="searchBar"
                 :disabled="isWaitingForCompletion || Boolean(pendingToolApproval)"
@@ -1341,7 +1327,10 @@
                 @drag-start="isDragging = true"
                 @drag-end="isDragging = false"
             />
-            <div v-if="sessionHistory.length === 0" v-show="quickSearchOpen">
+            <div
+                v-if="searchViewContentReady && sessionHistory.length === 0"
+                v-show="quickSearchOpen"
+            >
                 <QuickSearchPanel
                     ref="quickSearchPanel"
                     :open="quickSearchOpen"

--- a/apps/desktop/src/views/SearchView/startup.ts
+++ b/apps/desktop/src/views/SearchView/startup.ts
@@ -1,0 +1,78 @@
+// Copyright (c) 2026. Qian Cheng. Licensed under GPL v3.
+
+type StartupTask = () => Promise<unknown>;
+
+export interface SearchViewStartupDependencies {
+    initializeSettings: StartupTask;
+    initializeMcpStore: StartupTask;
+    initializePopups: StartupTask;
+    syncWindowPinState: StartupTask;
+    syncSearchWindowState: StartupTask;
+    isE2eTestMode: () => Promise<boolean>;
+    autoConnectMcp: StartupTask;
+    onReady: (ready: boolean) => void;
+    logError?: (message: string, error: unknown) => void;
+}
+
+function logStartupError(
+    dependencies: SearchViewStartupDependencies,
+    message: string,
+    error: unknown
+): void {
+    dependencies.logError?.(message, error);
+}
+
+function runBackgroundTask(
+    dependencies: SearchViewStartupDependencies,
+    message: string,
+    task: StartupTask
+): void {
+    task().catch((error) => {
+        logStartupError(dependencies, message, error);
+    });
+}
+
+async function startMcpAutoConnect(dependencies: SearchViewStartupDependencies): Promise<void> {
+    if (await dependencies.isE2eTestMode()) {
+        return;
+    }
+
+    await dependencies.autoConnectMcp();
+}
+
+export async function initializeSearchViewForFirstPaint(
+    dependencies: SearchViewStartupDependencies
+): Promise<void> {
+    try {
+        dependencies.onReady(false);
+        await dependencies.initializeSettings();
+        dependencies.onReady(true);
+
+        runBackgroundTask(
+            dependencies,
+            '[SearchView] Failed to initialize MCP store:',
+            dependencies.initializeMcpStore
+        );
+        runBackgroundTask(
+            dependencies,
+            '[SearchView] Failed to initialize popup service:',
+            dependencies.initializePopups
+        );
+        runBackgroundTask(
+            dependencies,
+            '[SearchView] Failed to sync window pin state on initialize:',
+            dependencies.syncWindowPinState
+        );
+        runBackgroundTask(
+            dependencies,
+            '[SearchView] Failed to sync search window state on initialize:',
+            dependencies.syncSearchWindowState
+        );
+        runBackgroundTask(dependencies, '[SearchView] Failed to auto-connect MCP servers:', () =>
+            startMcpAutoConnect(dependencies)
+        );
+    } catch (error) {
+        logStartupError(dependencies, '[SearchView] Failed to initialize dependencies:', error);
+        dependencies.onReady(false);
+    }
+}

--- a/apps/desktop/tests/SearchView/startup.test.ts
+++ b/apps/desktop/tests/SearchView/startup.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { initializeSearchViewForFirstPaint } from '@/views/SearchView/startup';
+
+function deferred() {
+    let resolve!: () => void;
+    const promise = new Promise<void>((innerResolve) => {
+        resolve = innerResolve;
+    });
+    return { promise, resolve };
+}
+
+describe('initializeSearchViewForFirstPaint', () => {
+    it('marks the view ready after settings initialize without waiting for popup or MCP warmup', async () => {
+        const popupWarmup = deferred();
+        const mcpWarmup = deferred();
+        const readyStates: boolean[] = [];
+
+        await initializeSearchViewForFirstPaint({
+            initializeSettings: vi.fn(async () => undefined),
+            initializeMcpStore: vi.fn(() => mcpWarmup.promise),
+            initializePopups: vi.fn(() => popupWarmup.promise),
+            syncWindowPinState: vi.fn(async () => undefined),
+            syncSearchWindowState: vi.fn(async () => undefined),
+            isE2eTestMode: vi.fn(async () => true),
+            autoConnectMcp: vi.fn(async () => undefined),
+            onReady: (ready) => readyStates.push(ready),
+        });
+
+        expect(readyStates).toEqual([false, true]);
+
+        popupWarmup.resolve();
+        mcpWarmup.resolve();
+    });
+
+    it('keeps the view hidden when the critical settings load fails', async () => {
+        const error = new Error('settings failed');
+        const logError = vi.fn();
+        const readyStates: boolean[] = [];
+
+        await initializeSearchViewForFirstPaint({
+            initializeSettings: vi.fn(async () => {
+                throw error;
+            }),
+            initializeMcpStore: vi.fn(async () => undefined),
+            initializePopups: vi.fn(async () => undefined),
+            syncWindowPinState: vi.fn(async () => undefined),
+            syncSearchWindowState: vi.fn(async () => undefined),
+            isE2eTestMode: vi.fn(async () => true),
+            autoConnectMcp: vi.fn(async () => undefined),
+            onReady: (ready) => readyStates.push(ready),
+            logError,
+        });
+
+        expect(readyStates).toEqual([false, false]);
+        expect(logError).toHaveBeenCalledWith(
+            '[SearchView] Failed to initialize dependencies:',
+            error
+        );
+    });
+});

--- a/apps/desktop/tests/utils/font.test.ts
+++ b/apps/desktop/tests/utils/font.test.ts
@@ -4,9 +4,14 @@ import { getTauriInvokeCalls, mockTauriCommand } from '@tests/utils/tauri';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const existsMock = vi.hoisted(() => vi.fn(async () => true));
+const joinMock = vi.hoisted(() => vi.fn(async (...segments: string[]) => segments.join('/')));
 
 vi.mock('@tauri-apps/plugin-fs', () => ({
     exists: existsMock,
+}));
+
+vi.mock('@tauri-apps/api/path', () => ({
+    join: joinMock,
 }));
 
 const FONT_STYLE_SELECTOR = 'style[data-touchai-font-face="source-han-serif-sc"]';
@@ -51,6 +56,7 @@ describe('font loader', () => {
         document.head.innerHTML = '';
         existsMock.mockReset();
         existsMock.mockResolvedValue(true);
+        joinMock.mockClear();
         mockTauriCommand('get_app_directory_path', 'D:\\TouchAI\\assets\\font');
     });
 
@@ -72,6 +78,27 @@ describe('font loader', () => {
             expect(commandOrder.indexOf('plugin:event|listen')).toBeLessThan(
                 commandOrder.indexOf('get_app_directory_path')
             );
+        },
+        FONT_TEST_TIMEOUT_MS
+    );
+
+    it(
+        'resolves the cached font path with Tauri path join before checking existence',
+        async () => {
+            mockTauriCommand('get_app_directory_path', '/var/lib/touchai/assets/font');
+            const { initializeFontLoader } = await import('@/utils/font');
+
+            initializeFontLoader();
+
+            await vi.waitFor(() => {
+                expect(joinMock).toHaveBeenCalledWith(
+                    '/var/lib/touchai/assets/font',
+                    'SourceHanSerifSC-VF.ttf.woff2'
+                );
+                expect(existsMock).toHaveBeenCalledWith(
+                    '/var/lib/touchai/assets/font/SourceHanSerifSC-VF.ttf.woff2'
+                );
+            });
         },
         FONT_TEST_TIMEOUT_MS
     );

--- a/apps/desktop/tests/utils/font.test.ts
+++ b/apps/desktop/tests/utils/font.test.ts
@@ -3,6 +3,12 @@ import { emit } from '@tauri-apps/api/event';
 import { getTauriInvokeCalls, mockTauriCommand } from '@tests/utils/tauri';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+const existsMock = vi.hoisted(() => vi.fn(async () => true));
+
+vi.mock('@tauri-apps/plugin-fs', () => ({
+    exists: existsMock,
+}));
+
 const FONT_STYLE_SELECTOR = 'style[data-touchai-font-face="source-han-serif-sc"]';
 const FONT_TEST_TIMEOUT_MS = 15_000;
 
@@ -43,11 +49,13 @@ describe('font loader', () => {
         vi.resetModules();
         vi.doUnmock('@tauri-apps/api/core');
         document.head.innerHTML = '';
+        existsMock.mockReset();
+        existsMock.mockResolvedValue(true);
         mockTauriCommand('get_app_directory_path', 'D:\\TouchAI\\assets\\font');
     });
 
     it(
-        'loads the bundled serif font during initialization without waiting for font-ready',
+        'loads the cached serif font during initialization without waiting for font-ready',
         async () => {
             const { initializeFontLoader } = await import('@/utils/font');
 
@@ -64,6 +72,28 @@ describe('font loader', () => {
             expect(commandOrder.indexOf('plugin:event|listen')).toBeLessThan(
                 commandOrder.indexOf('get_app_directory_path')
             );
+        },
+        FONT_TEST_TIMEOUT_MS
+    );
+
+    it(
+        'does not inject a missing startup font asset before font-ready arrives',
+        async () => {
+            existsMock.mockResolvedValue(false);
+            const { initializeFontLoader } = await import('@/utils/font');
+
+            initializeFontLoader();
+            await waitForFontReadyListener();
+
+            await vi.waitFor(() => expect(existsMock).toHaveBeenCalled());
+            expect(fontStyles()).toHaveLength(0);
+
+            await emit(AppEvent.FONT_READY, {});
+
+            await vi.waitFor(() => {
+                expect(fontStyles()).toHaveLength(1);
+                expect(fontStyleText()).toContain('touchaiFontReload=1');
+            });
         },
         FONT_TEST_TIMEOUT_MS
     );


### PR DESCRIPTION
﻿> First external contributors may need to complete the `CLA Assistant` check before merge.
> For code changes, this PR must link the related issue or RFC in the section below.

## Summary

Improves the cold-start first paint path after #392:

- Avoids injecting a missing Source Han Serif asset URL before the Rust font download has completed.
- Lets the SearchView render its first input surface after settings initialize, while MCP store initialization, popup preloading, window state sync, and MCP auto-connect continue in the background.
- Keeps conversation, AskUser, and quick search panels gated on resize/window constraints while allowing the SearchBar to appear earlier.

## Related issue or RFC

Link the issue or RFC:

- Related to #392
- Related to #385

For code changes, link the tracking issue. Only documentation wording, link fixes, or comment-only cleanups may skip the issue-first flow.

## AI assistance disclosure

If AI tools materially assisted this contribution, disclose that here or point to the relevant commit trailer.

- Tool(s) used: Codex
- Scope of assistance: Investigated cold-start logs, implemented startup-path changes, added focused unit tests, and prepared this PR.
- Human review or rewrite performed: Local diff reviewed before commit; unrelated rounded-corner workspace changes were excluded from this PR.
- Architecture or boundary impact: No new cross-boundary architecture. Adds a SearchView startup helper to separate first-paint-critical initialization from background warmup.

## Testing evidence

List the commands you ran and the results you observed.

- `pnpm.cmd --filter @touchai/desktop test:unit tests/utils/font.test.ts tests/SearchView/startup.test.ts` - 11 tests passed.
- `pnpm.cmd --filter @touchai/desktop test:typecheck` - passed.
- `pnpm.cmd --filter @touchai/desktop exec eslint src/utils/font.ts src/views/SearchView/startup.ts src/views/SearchView/index.vue tests/utils/font.test.ts tests/SearchView/startup.test.ts` - passed.
- Commit hook ran `pnpm --filter @touchai/desktop check:rust` - passed with pre-existing unused `try_lock_mutex` warnings.
- Commit hook ran `pnpm --filter @touchai/desktop type:check` - passed.
- `pnpm.cmd --filter @touchai/desktop tauri build` - completed; generated `apps/desktop/src-tauri/target/release/bundle/msi/TouchAI_1.0.0_x64_en-US.msi`.
- Cold dev startup after deleting `apps/desktop/data` and `apps/desktop/assets`: main WebView logs appeared around 3 seconds after Rust setup, and no missing font asset protocol error appeared before `font:ready`.

Did you follow TDD (test-first) for feature and fix work? Strongly recommended. See [docs/testing/testing.md](../docs/testing/testing.md).

```text
pnpm test:pr
pnpm test:coverage:rust
pnpm test:e2e
```

`pnpm test:pr`, `pnpm test:coverage:rust`, and `pnpm test:e2e` were not run locally due time. This PR includes focused unit/type/lint/build coverage and should rely on CI for the full PR and E2E matrix.

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: No AgentService or schema changes. MCP initialization is moved out of the first-paint critical path but still starts in the background.
- database baseline or migration impact: None.
- release or packaging impact: No packaging config changes. A local MSI was built successfully for manual testing.

## Screenshots or recordings

No screenshot attached. Manual cold-start log check showed the missing font asset protocol error no longer appears before the background font download completes.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [ ] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [ ] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.
