### PR TITLE
fix(desktop): add win10 rounded corner fallback

### DIFF
--- a/apps/desktop/src-tauri/src/core/window/rounded_corners.rs
+++ b/apps/desktop/src-tauri/src/core/window/rounded_corners.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026. 千诚. Licensed under GPL v3.
+// Copyright (c) 2026. 鍗冭瘹. Licensed under GPL v3.
 
 //! Native rounded corner styling for desktop windows.
 
@@ -19,17 +19,32 @@ mod win {
     use raw_window_handle::HasWindowHandle;
     use tauri::{Runtime, WebviewWindow};
     use windows::Win32::{
-        Foundation::HWND,
+        Foundation::{HWND, RECT},
         Graphics::Dwm::{
             DwmSetWindowAttribute, DWMWA_BORDER_COLOR, DWMWA_WINDOW_CORNER_PREFERENCE,
         },
+        Graphics::Gdi::{CreateRoundRectRgn, DeleteObject, SetWindowRgn},
+        UI::WindowsAndMessaging::GetClientRect,
     };
 
     const DWMWCP_ROUND: u32 = 2;
     const DWM_BORDER_COLOR_GRAY_300: u32 = 0x00DBD5D1;
+    const FALLBACK_CORNER_RADIUS_PX: i32 = 12;
 
     fn should_manage_window(window: &WebviewWindow<impl Runtime>) -> bool {
         matches!(window.label(), "main" | "settings")
+    }
+
+    pub(super) fn fallback_region_dimensions(
+        width: i32,
+        height: i32,
+    ) -> Option<(i32, i32, i32, i32)> {
+        if width <= 0 || height <= 0 {
+            return None;
+        }
+
+        let corner_diameter = FALLBACK_CORNER_RADIUS_PX * 2;
+        Some((width + 1, height + 1, corner_diameter, corner_diameter))
     }
 
     /// Get the Win32 HWND for a Tauri webview window.
@@ -66,13 +81,47 @@ mod win {
         Ok(())
     }
 
+    fn set_window_region_rounded_corners(hwnd: HWND) -> Result<(), String> {
+        unsafe {
+            let mut rect = RECT::default();
+            GetClientRect(hwnd, &mut rect)
+                .map_err(|error| format!("Failed to read window client rect: {}", error))?;
+
+            let width = rect.right - rect.left;
+            let height = rect.bottom - rect.top;
+            let Some((right, bottom, ellipse_width, ellipse_height)) =
+                fallback_region_dimensions(width, height)
+            else {
+                return Ok(());
+            };
+
+            let region = CreateRoundRectRgn(0, 0, right, bottom, ellipse_width, ellipse_height);
+            if region.is_invalid() {
+                return Err(format!(
+                    "Failed to create rounded window region: {}",
+                    windows::core::Error::from_win32()
+                ));
+            }
+
+            if SetWindowRgn(hwnd, region, true) == 0 {
+                let _ = DeleteObject(region);
+                return Err(format!(
+                    "Failed to apply rounded window region: {}",
+                    windows::core::Error::from_win32()
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
     pub fn apply_window_corner_style<R: Runtime>(window: &WebviewWindow<R>) -> Result<(), String> {
         if !should_manage_window(window) {
             return Ok(());
         }
 
         let hwnd = window_hwnd(window)?;
-        set_dwm_corner_preference(hwnd)
+        set_dwm_corner_preference(hwnd).or_else(|_| set_window_region_rounded_corners(hwnd))
     }
 
     pub fn sync_window_corner_style<R: Runtime>(window: &WebviewWindow<R>) -> Result<(), String> {
@@ -98,4 +147,20 @@ fn sync_window_corner_style_impl<R: Runtime>(window: &WebviewWindow<R>) -> Resul
 #[cfg(not(target_os = "windows"))]
 fn sync_window_corner_style_impl<R: Runtime>(_window: &WebviewWindow<R>) -> Result<(), String> {
     Ok(())
+}
+
+#[cfg(all(test, target_os = "windows"))]
+mod tests {
+    use super::win::fallback_region_dimensions;
+
+    #[test]
+    fn fallback_region_covers_window_with_rounded_corner_diameter() {
+        assert_eq!(fallback_region_dimensions(750, 60), Some((751, 61, 24, 24)));
+    }
+
+    #[test]
+    fn fallback_region_ignores_empty_window_sizes() {
+        assert_eq!(fallback_region_dimensions(0, 60), None);
+        assert_eq!(fallback_region_dimensions(750, 0), None);
+    }
 }

--- a/apps/desktop/src-tauri/src/core/window/rounded_corners.rs
+++ b/apps/desktop/src-tauri/src/core/window/rounded_corners.rs
@@ -23,7 +23,7 @@ mod win {
         Graphics::Dwm::{
             DwmSetWindowAttribute, DWMWA_BORDER_COLOR, DWMWA_WINDOW_CORNER_PREFERENCE,
         },
-        Graphics::Gdi::{CreateRoundRectRgn, DeleteObject, SetWindowRgn},
+        Graphics::Gdi::{CreateRoundRectRgn, DeleteObject, SetWindowRgn, HRGN},
         UI::WindowsAndMessaging::GetClientRect,
     };
 
@@ -115,13 +115,31 @@ mod win {
         Ok(())
     }
 
+    fn clear_window_region(hwnd: HWND) -> Result<(), String> {
+        let no_region = HRGN(std::ptr::null_mut());
+
+        unsafe {
+            if SetWindowRgn(hwnd, no_region, true) == 0 {
+                return Err(format!(
+                    "Failed to clear rounded window region: {}",
+                    windows::core::Error::from_win32()
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
     pub fn apply_window_corner_style<R: Runtime>(window: &WebviewWindow<R>) -> Result<(), String> {
         if !should_manage_window(window) {
             return Ok(());
         }
 
         let hwnd = window_hwnd(window)?;
-        set_dwm_corner_preference(hwnd).or_else(|_| set_window_region_rounded_corners(hwnd))
+        match set_dwm_corner_preference(hwnd) {
+            Ok(()) => clear_window_region(hwnd),
+            Err(_) => set_window_region_rounded_corners(hwnd),
+        }
     }
 
     pub fn sync_window_corner_style<R: Runtime>(window: &WebviewWindow<R>) -> Result<(), String> {


### PR DESCRIPTION
> First external contributors may need to complete the `CLA Assistant` check before merge.
> For code changes, this PR must link the related issue or RFC in the section below.

## Summary

Adds a Windows 10 fallback for frameless TouchAI window corners. Windows 11 keeps using the existing DWM rounded-corner preference path, while systems where that DWM call fails now fall back to a Win32 rounded window region for the main and settings windows.

## Related issue or RFC

Link the issue or RFC:

- Closes #402

## AI assistance disclosure

If AI tools materially assisted this contribution, disclose that here or point to the relevant commit trailer.

- Tool(s) used: Codex
- Scope of assistance: Root-cause investigation, TDD-oriented implementation, local verification, PR preparation.
- Human review or rewrite performed: Maintainer review required before merge; every affected change is limited to native rounded-corner handling.
- Architecture or boundary impact: No cross-boundary architecture change. This stays inside the existing desktop native window styling module.

## Testing evidence

List the commands you ran and the results you observed.

- `pnpm.cmd --filter @touchai/desktop test:rust -- rounded_corners` - passed locally. Output included `78 passed` in `src/lib.rs`, plus integration groups `6 passed`, `1 passed`, and `9 passed`.
- `cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml --all -- --check` - passed locally.
- `pnpm.cmd --filter @touchai/desktop check:rust` - passed locally. Existing warnings remain for `try_lock_mutex` unused import/dead code.
- `pnpm test:pr` - not run locally; rely on CI for full type/lint/test/frontend coverage.
- `pnpm test:coverage:rust` - not run locally; rely on CI coverage evidence.
- `pnpm test:e2e` - not run locally; this native window visual behavior still needs packaged Windows 10 manual verification.

Did you follow TDD (test-first) for feature and fix work? Strongly recommended. See [docs/testing/testing.md](../docs/testing/testing.md).

```text
pnpm test:pr
pnpm test:coverage:rust
pnpm test:e2e
```

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: none.
- database baseline or migration impact: none.
- release or packaging impact: affects native desktop window shape on Windows 10 fallback path only; Windows 11 should keep the existing DWM path.

## Screenshots or recordings

Not captured locally. The intended visual proof is a packaged Windows 10 run showing the main/search and settings windows with rounded corners.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [ ] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [ ] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.
