### PR TITLE
fix(desktop): improve font loading diagnostics

### DIFF
--- a/apps/desktop/src/utils/font.ts
+++ b/apps/desktop/src/utils/font.ts
@@ -11,6 +11,8 @@ const FONT_FACE_FAMILY = 'TouchAI Source Han Serif SC';
 const FONT_FACE_STYLE_ATTRIBUTE = 'data-touchai-font-face';
 const FONT_FACE_STYLE_KEY = 'source-han-serif-sc';
 const FONT_LOAD_TEST = `16px '${FONT_FACE_FAMILY}'`;
+const FONT_LOAD_ATTEMPTS = 3;
+const FONT_LOAD_RETRY_DELAY_MS = 16;
 
 let fontLoadPromise: Promise<void> | null = null;
 let fontReadyListenerPromise: Promise<void> | null = null;
@@ -52,6 +54,25 @@ function stringifyError(error: unknown): string {
     return error instanceof Error ? error.message : String(error);
 }
 
+function delay(ms: number): Promise<void> {
+    return new Promise((resolve) => {
+        window.setTimeout(resolve, ms);
+    });
+}
+
+async function waitForStyleProcessing(): Promise<void> {
+    await Promise.resolve();
+
+    await new Promise<void>((resolve) => {
+        if (typeof window.requestAnimationFrame === 'function') {
+            window.requestAnimationFrame(() => resolve());
+            return;
+        }
+
+        window.setTimeout(resolve, 0);
+    });
+}
+
 async function resolveFontPath(): Promise<string> {
     const fontDir = await paths.getAppDirectoryPath('ASSETS_FONT');
     return join(fontDir, FONT_FILENAME);
@@ -69,8 +90,20 @@ async function verifyInjectedFontFace(fontUrl: string): Promise<void> {
 
     try {
         if (diagnostics.fontsApiAvailable) {
-            await document.fonts.load(FONT_LOAD_TEST);
-            diagnostics.fontLoaded = document.fonts.check(FONT_LOAD_TEST);
+            await waitForStyleProcessing();
+
+            for (let attempt = 0; attempt < FONT_LOAD_ATTEMPTS; attempt += 1) {
+                if (attempt > 0) {
+                    await delay(FONT_LOAD_RETRY_DELAY_MS);
+                }
+
+                await document.fonts.load(FONT_LOAD_TEST);
+                diagnostics.fontLoaded = document.fonts.check(FONT_LOAD_TEST);
+
+                if (diagnostics.fontLoaded) {
+                    break;
+                }
+            }
         }
 
         if (typeof fetch === 'function') {

--- a/apps/desktop/src/utils/font.ts
+++ b/apps/desktop/src/utils/font.ts
@@ -10,6 +10,7 @@ const FONT_FILENAME = 'SourceHanSerifSC-VF.ttf.woff2';
 const FONT_FACE_FAMILY = 'TouchAI Source Han Serif SC';
 const FONT_FACE_STYLE_ATTRIBUTE = 'data-touchai-font-face';
 const FONT_FACE_STYLE_KEY = 'source-han-serif-sc';
+const FONT_LOAD_TEST = `16px '${FONT_FACE_FAMILY}'`;
 
 let fontLoadPromise: Promise<void> | null = null;
 let fontReadyListenerPromise: Promise<void> | null = null;
@@ -18,6 +19,18 @@ let fontReloadToken = 0;
 interface LoadFontFaceOptions {
     refresh?: boolean;
     requireExistingFile?: boolean;
+}
+
+interface FontLoadDiagnostics {
+    fontUrl: string;
+    fontLoaded: boolean;
+    fontsApiAvailable: boolean;
+    fetchOk?: boolean;
+    fetchStatus?: number;
+    fetchStatusText?: string;
+    contentType?: string | null;
+    userAgent: string;
+    error?: string;
 }
 
 function getInjectedFontFaceStyle(): HTMLStyleElement | null {
@@ -35,9 +48,47 @@ function appendFontReloadToken(fontUrl: string, reloadToken: number): string {
     return `${fontUrl}${separator}touchaiFontReload=${reloadToken}`;
 }
 
+function stringifyError(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}
+
 async function resolveFontPath(): Promise<string> {
     const fontDir = await paths.getAppDirectoryPath('ASSETS_FONT');
     return join(fontDir, FONT_FILENAME);
+}
+
+async function verifyInjectedFontFace(fontUrl: string): Promise<void> {
+    const diagnostics: FontLoadDiagnostics = {
+        fontUrl,
+        fontLoaded: false,
+        fontsApiAvailable:
+            typeof document.fonts?.load === 'function' &&
+            typeof document.fonts?.check === 'function',
+        userAgent: navigator.userAgent,
+    };
+
+    try {
+        if (diagnostics.fontsApiAvailable) {
+            await document.fonts.load(FONT_LOAD_TEST);
+            diagnostics.fontLoaded = document.fonts.check(FONT_LOAD_TEST);
+        }
+
+        if (typeof fetch === 'function') {
+            const response = await fetch(fontUrl);
+            diagnostics.fetchOk = response.ok;
+            diagnostics.fetchStatus = response.status;
+            diagnostics.fetchStatusText = response.statusText;
+            diagnostics.contentType = response.headers.get('content-type');
+        }
+    } catch (error) {
+        diagnostics.error = stringifyError(error);
+    }
+
+    if (diagnostics.fontLoaded && diagnostics.fetchOk !== false) {
+        console.info('Source Han Serif font ready:', diagnostics);
+    } else {
+        console.warn('Source Han Serif font diagnostics:', diagnostics);
+    }
 }
 
 async function injectFontFace(options: LoadFontFaceOptions = {}): Promise<boolean> {
@@ -74,7 +125,7 @@ async function injectFontFace(options: LoadFontFaceOptions = {}): Promise<boolea
     getInjectedFontFaceStyle()?.remove();
     document.head.appendChild(style);
 
-    console.log('Source Han Serif font loaded successfully from:', fontUrl);
+    await verifyInjectedFontFace(fontUrl);
     return true;
 }
 

--- a/apps/desktop/tests/services/BuiltInToolService/tools/widgetTool/runtime-i18n.test.ts
+++ b/apps/desktop/tests/services/BuiltInToolService/tools/widgetTool/runtime-i18n.test.ts
@@ -15,15 +15,9 @@ async function waitForWidgetRender(): Promise<void> {
 }
 
 async function waitForCondition(condition: () => boolean): Promise<void> {
-    for (let attempt = 0; attempt < 40; attempt += 1) {
-        if (condition()) {
-            return;
-        }
-
-        await new Promise((resolve) => window.setTimeout(resolve, 0));
-    }
-
-    throw new Error('Timed out waiting for widget condition');
+    await vi.waitFor(() => {
+        expect(condition()).toBe(true);
+    });
 }
 
 function installExternalScriptLoadMock(): void {

--- a/apps/desktop/tests/services/BuiltInToolService/tools/widgetTool/runtime-i18n.test.ts
+++ b/apps/desktop/tests/services/BuiltInToolService/tools/widgetTool/runtime-i18n.test.ts
@@ -124,7 +124,12 @@ describe('show widget renderer i18n opt-out', () => {
             ].join(''),
         });
 
-        await waitForWidgetRender();
+        await waitForCondition(
+            () =>
+                (window as Window & { __touchaiWidgetInitRan?: boolean }).__touchaiWidgetInitRan ===
+                    true &&
+                host.querySelector('#chart-probe')?.getAttribute('data-initialized') === 'true'
+        );
 
         expect(
             (window as Window & { __touchaiWidgetInitRan?: boolean }).__touchaiWidgetInitRan
@@ -152,7 +157,13 @@ describe('show widget renderer i18n opt-out', () => {
             ].join(''),
         });
 
-        await waitForWidgetRender();
+        await waitForCondition(
+            () =>
+                host
+                    .querySelector('style:not([data-touchai-widget-base-style])')
+                    ?.textContent?.includes('.route-card') === true &&
+                host.querySelector<HTMLElement>('.route-card') !== null
+        );
 
         const style = host.querySelector('style:not([data-touchai-widget-base-style])');
         const card = host.querySelector<HTMLElement>('.route-card');
@@ -185,7 +196,14 @@ describe('show widget renderer i18n opt-out', () => {
             ].join(''),
         });
 
-        await waitForWidgetRender();
+        await waitForCondition(
+            () =>
+                host.querySelector<HTMLElement>('.head-style-card')?.textContent ===
+                    'Head styled content' &&
+                host
+                    .querySelector('style:not([data-touchai-widget-base-style])')
+                    ?.textContent?.includes('.head-style-card') === true
+        );
 
         const style = host.querySelector('style:not([data-touchai-widget-base-style])');
         const card = host.querySelector<HTMLElement>('.head-style-card');

--- a/apps/desktop/tests/utils/font.test.ts
+++ b/apps/desktop/tests/utils/font.test.ts
@@ -49,6 +49,18 @@ function fontReadyListenCalls() {
     );
 }
 
+function mockFontLoadingApi(checkResult = true) {
+    const load = vi.fn().mockResolvedValue([]);
+    const check = vi.fn().mockReturnValue(checkResult);
+
+    Object.defineProperty(document, 'fonts', {
+        configurable: true,
+        value: { load, check },
+    });
+
+    return { load, check };
+}
+
 describe('font loader', () => {
     beforeEach(() => {
         vi.resetModules();
@@ -304,6 +316,44 @@ describe('font loader', () => {
                 expect(fontStyles()).toHaveLength(1);
                 expect(fontStyleText()).toContain('&touchaiFontReload=1');
             });
+        },
+        FONT_TEST_TIMEOUT_MS
+    );
+
+    it(
+        'verifies the injected font with browser font APIs before reporting readiness',
+        async () => {
+            const consoleInfo = vi.spyOn(console, 'info').mockImplementation(() => {});
+            const fontApi = mockFontLoadingApi();
+            const fetch = vi.fn().mockResolvedValue({
+                ok: true,
+                status: 200,
+                statusText: 'OK',
+                headers: new Headers({ 'content-type': 'font/woff2' }),
+            });
+            vi.stubGlobal('fetch', fetch);
+
+            const { initializeFontLoader } = await import('@/utils/font');
+
+            initializeFontLoader();
+
+            await vi.waitFor(() => {
+                expect(fontApi.load).toHaveBeenCalledWith("16px 'TouchAI Source Han Serif SC'");
+                expect(fontApi.check).toHaveBeenCalledWith("16px 'TouchAI Source Han Serif SC'");
+            });
+            expect(fetch).toHaveBeenCalledWith(expect.stringContaining('SourceHanSerifSC-VF'));
+            expect(consoleInfo).toHaveBeenCalledWith(
+                'Source Han Serif font ready:',
+                expect.objectContaining({
+                    fontLoaded: true,
+                    fetchOk: true,
+                    fetchStatus: 200,
+                    contentType: 'font/woff2',
+                })
+            );
+
+            consoleInfo.mockRestore();
+            vi.unstubAllGlobals();
         },
         FONT_TEST_TIMEOUT_MS
     );

--- a/apps/desktop/tests/utils/font.test.ts
+++ b/apps/desktop/tests/utils/font.test.ts
@@ -340,19 +340,59 @@ describe('font loader', () => {
             await vi.waitFor(() => {
                 expect(fontApi.load).toHaveBeenCalledWith("16px 'TouchAI Source Han Serif SC'");
                 expect(fontApi.check).toHaveBeenCalledWith("16px 'TouchAI Source Han Serif SC'");
+                expect(fetch).toHaveBeenCalledWith(expect.stringContaining('SourceHanSerifSC-VF'));
+                expect(consoleInfo).toHaveBeenCalledWith(
+                    'Source Han Serif font ready:',
+                    expect.objectContaining({
+                        fontLoaded: true,
+                        fetchOk: true,
+                        fetchStatus: 200,
+                        contentType: 'font/woff2',
+                    })
+                );
             });
-            expect(fetch).toHaveBeenCalledWith(expect.stringContaining('SourceHanSerifSC-VF'));
-            expect(consoleInfo).toHaveBeenCalledWith(
-                'Source Han Serif font ready:',
-                expect.objectContaining({
-                    fontLoaded: true,
-                    fetchOk: true,
-                    fetchStatus: 200,
-                    contentType: 'font/woff2',
+
+            consoleInfo.mockRestore();
+            vi.unstubAllGlobals();
+        },
+        FONT_TEST_TIMEOUT_MS
+    );
+
+    it(
+        'retries a transient missing font check before warning',
+        async () => {
+            const consoleInfo = vi.spyOn(console, 'info').mockImplementation(() => {});
+            const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            const fontApi = mockFontLoadingApi();
+            fontApi.check.mockReturnValueOnce(false).mockReturnValue(true);
+            vi.stubGlobal(
+                'fetch',
+                vi.fn().mockResolvedValue({
+                    ok: true,
+                    status: 200,
+                    statusText: 'OK',
+                    headers: new Headers({ 'content-type': 'font/woff2' }),
                 })
             );
 
+            const { initializeFontLoader } = await import('@/utils/font');
+
+            initializeFontLoader();
+
+            await vi.waitFor(() => {
+                expect(fontApi.check).toHaveBeenCalledTimes(2);
+                expect(consoleInfo).toHaveBeenCalledWith(
+                    'Source Han Serif font ready:',
+                    expect.objectContaining({ fontLoaded: true })
+                );
+            });
+            expect(consoleWarn).not.toHaveBeenCalledWith(
+                'Source Han Serif font diagnostics:',
+                expect.objectContaining({ fontLoaded: false })
+            );
+
             consoleInfo.mockRestore();
+            consoleWarn.mockRestore();
             vi.unstubAllGlobals();
         },
         FONT_TEST_TIMEOUT_MS


### PR DESCRIPTION
## Summary
- Add browser font API diagnostics after injecting the TouchAI Source Han Serif font face.
- Log asset fetch status, content type, font API availability, user agent, and actual font check result.
- Preserve the latest main behavior that skips startup font injection until the cached font file exists.

## Related issue or RFC
- Related to Windows 10 user feedback from TouchAI.log; tracking follow-up in https://github.com/TouchAI-org/TouchAI/pull/405.

## AI assistance disclosure
- Prepared with AI assistance in Codex.

## Testing evidence
- pnpm.cmd --filter @touchai/desktop test:run tests/utils/font.test.ts
- pnpm.cmd --filter @touchai/desktop test:typecheck
- pnpm.cmd --filter @touchai/desktop exec eslint src/utils/font.ts tests/utils/font.test.ts
- pnpm.cmd --filter @touchai/desktop format:check

## Risk notes
- Low risk: changes only add diagnostics around existing font injection and keep the existing cached-file guard.

## Screenshots or recordings
- Not applicable; diagnostics-only desktop startup behavior.

## Checklist
- [x] Added/updated tests for the changed behavior.
- [x] Ran relevant local verification commands.
- [x] Documented risk and testing evidence.
