### PR TITLE
fix(agent-service): show friendly unsupported input errors

### DIFF
--- a/apps/desktop/src/i18n/textMap.ts
+++ b/apps/desktop/src/i18n/textMap.ts
@@ -578,6 +578,8 @@ export const zhToEnTextMap = {
         'The current model does not support images. Remove unsupported attachments or switch models.',
     '当前模型不支持文件，请移除不支持的附件或切换模型':
         'The current model does not support files. Remove unsupported attachments or switch models.',
+    '当前模型不支持图片/文件输入，请选择合适模型继续。':
+        'The current model does not support image or file input. Choose a compatible model to continue.',
     该模型不支持图片: 'This model does not support images.',
     该模型不支持文件: 'This model does not support files.',
     '（当前模型不支持图片）': ' (current model does not support images)',

--- a/apps/desktop/src/services/AgentService/contracts/errors.ts
+++ b/apps/desktop/src/services/AgentService/contracts/errors.ts
@@ -18,6 +18,7 @@ export enum AiErrorCode {
     STREAM_ERROR = 'STREAM_ERROR',
     SESSION_ACTIVE_TASK_EXISTS = 'SESSION_ACTIVE_TASK_EXISTS',
     TASK_NOT_FOUND = 'TASK_NOT_FOUND',
+    UNSUPPORTED_INPUT = 'UNSUPPORTED_INPUT',
 
     // 网络相关错误 (3xxx) - 可重试
     NETWORK_ERROR = 'NETWORK_ERROR',
@@ -60,6 +61,7 @@ const ERROR_MESSAGES: Record<AiErrorCode, SourceText> = {
     [AiErrorCode.STREAM_ERROR]: '流式响应处理失败',
     [AiErrorCode.SESSION_ACTIVE_TASK_EXISTS]: '当前会话已有正在运行的任务，请等待完成或先取消',
     [AiErrorCode.TASK_NOT_FOUND]: '任务不存在或已结束',
+    [AiErrorCode.UNSUPPORTED_INPUT]: '当前模型不支持图片/文件输入，请选择合适模型继续。',
 
     // 网络相关
     [AiErrorCode.NETWORK_ERROR]: '网络连接失败，请检查网络设置',
@@ -86,6 +88,25 @@ const ERROR_MESSAGES: Record<AiErrorCode, SourceText> = {
     // 未知错误
     [AiErrorCode.UNKNOWN]: '未知错误',
 };
+
+function isUnsupportedInputEndpointMessage(message: string): boolean {
+    return /no endpoints found that support\b(?=.*\b(?:image|file)s?\b).*\binputs?\b/i.test(
+        message
+    );
+}
+
+function getDisplayMessageForText(message: string): string {
+    const source = Object.values(ERROR_MESSAGES).find((candidate) => candidate === message);
+    if (source) {
+        return tt(source);
+    }
+
+    if (isUnsupportedInputEndpointMessage(message)) {
+        return tt(ERROR_MESSAGES[AiErrorCode.UNSUPPORTED_INPUT]);
+    }
+
+    return message;
+}
 
 /**
  * AI 服务统一错误类
@@ -127,8 +148,7 @@ export class AiError extends Error {
      * Localize known default AiError messages after they have crossed a string-only boundary.
      */
     static getKnownDefaultDisplayMessage(message: string): string {
-        const source = Object.values(ERROR_MESSAGES).find((candidate) => candidate === message);
-        return source ? tt(source) : message;
+        return getDisplayMessageForText(message);
     }
 
     /**
@@ -138,7 +158,11 @@ export class AiError extends Error {
      * 避免破坏远端 payload 的诊断价值。
      */
     getDisplayMessage(): string {
-        return this.usesDefaultMessage ? tt(ERROR_MESSAGES[this.code]) : this.message;
+        if (this.usesDefaultMessage) {
+            return tt(ERROR_MESSAGES[this.code]);
+        }
+
+        return getDisplayMessageForText(this.message);
     }
 
     /**
@@ -150,10 +174,10 @@ export class AiError extends Error {
         }
 
         if (error instanceof Error) {
-            return error.message;
+            return getDisplayMessageForText(error.message);
         }
 
-        return String(error);
+        return getDisplayMessageForText(String(error));
     }
 
     /**
@@ -193,6 +217,7 @@ export class AiError extends Error {
             AiErrorCode.UNAUTHORIZED,
             AiErrorCode.INVALID_CONFIG,
             AiErrorCode.MISSING_ENDPOINT,
+            AiErrorCode.UNSUPPORTED_INPUT,
         ].includes(this.code);
     }
 
@@ -209,6 +234,12 @@ export class AiError extends Error {
         if (error instanceof Error || typeof error == 'string') {
             const message = error instanceof Error ? error.message.toLowerCase() : error;
             const originalMessage = error instanceof Error ? error.message : String(error);
+
+            if (isUnsupportedInputEndpointMessage(originalMessage)) {
+                return new AiError(AiErrorCode.UNSUPPORTED_INPUT, error, undefined, {
+                    cause,
+                });
+            }
 
             // 取消相关（abort / cancel / AbortError）
             if (

--- a/apps/desktop/src/services/AgentService/execution/executor.ts
+++ b/apps/desktop/src/services/AgentService/execution/executor.ts
@@ -23,7 +23,12 @@ import type {
     ToolApprovalDecisionRequest,
     ToolEventModelSummary,
 } from '../contracts/tooling';
-import { type AttachmentIndex, buildAttachmentParts } from '../infrastructure/attachments';
+import {
+    type AttachmentIndex,
+    buildAttachmentParts,
+    getModelAttachmentCapabilities,
+    getUnsupportedAttachmentTypes,
+} from '../infrastructure/attachments';
 import { mcpManager } from '../infrastructure/mcp';
 import {
     type AiProvider,
@@ -271,6 +276,25 @@ function throwIfAborted(signal?: AbortSignal): void {
     if (signal?.aborted) {
         throw new AiError(AiErrorCode.REQUEST_CANCELLED);
     }
+}
+
+function throwIfAttachmentsUnsupportedByModel(
+    attachments: AttachmentIndex[] | undefined,
+    model: ModelWithProvider
+): void {
+    const unsupportedAttachmentTypes = getUnsupportedAttachmentTypes(
+        attachments ?? [],
+        getModelAttachmentCapabilities(model)
+    );
+    if (unsupportedAttachmentTypes.length === 0) {
+        return;
+    }
+
+    throw new AiError(AiErrorCode.UNSUPPORTED_INPUT, {
+        unsupportedAttachmentTypes,
+        modelId: model.model_id,
+        providerId: model.provider_id,
+    });
 }
 
 function formatToolArgumentsIssues(error: z.ZodError): string {
@@ -781,7 +805,14 @@ export class AiRequestExecutor {
             )
         );
 
-        let requestedModelSwitch: BuiltInToolControlSignal | null = null;
+        const requestedModelSwitch =
+            toolResults.find(({ controlSignal }) => controlSignal?.type === 'upgrade_model')
+                ?.controlSignal ?? null;
+        const nextModel =
+            requestedModelSwitch?.type === 'upgrade_model'
+                ? requestedModelSwitch.targetModel
+                : runtime.activeModel;
+
         for (const {
             toolCall,
             builtInToolId,
@@ -790,8 +821,9 @@ export class AiRequestExecutor {
             toolLogId,
             toolLogKind,
             attachments,
-            controlSignal,
         } of toolResults) {
+            throwIfAttachmentsUnsupportedByModel(attachments, nextModel);
+
             runtime.messages.push({
                 role: 'tool',
                 content: await buildToolResultMessageContent(result, attachments),
@@ -809,10 +841,6 @@ export class AiRequestExecutor {
 
             if (builtInToolId && !isError) {
                 runtime.executedBuiltInTools.add(builtInToolId);
-            }
-
-            if (!requestedModelSwitch && controlSignal?.type === 'upgrade_model') {
-                requestedModelSwitch = controlSignal;
             }
         }
 

--- a/apps/desktop/src/services/AgentService/execution/runtime.ts
+++ b/apps/desktop/src/services/AgentService/execution/runtime.ts
@@ -4,8 +4,12 @@ import { updateModelLastUsed } from '@database/queries';
 import type { SessionTurnEntity } from '@database/types';
 
 import { t } from '@/i18n';
-import type { AttachmentIndex } from '@/services/AgentService/infrastructure/attachments';
-import { ensurePersistedAttachmentIndex } from '@/services/AgentService/infrastructure/attachments';
+import {
+    type AttachmentIndex,
+    ensurePersistedAttachmentIndex,
+    getModelAttachmentCapabilities,
+    getUnsupportedAttachmentTypes,
+} from '@/services/AgentService/infrastructure/attachments';
 import type { InputHistorySnapshot } from '@/types/session';
 
 import { AiError, AiErrorCode } from '../contracts/errors';
@@ -16,6 +20,7 @@ import { composePromptSnapshot } from '../prompt/composer';
 import { buildPromptTransportMessages } from '../prompt/transport';
 import type { PromptSnapshot } from '../prompt/types';
 import { buildSessionTitle } from '../session/title';
+import { findUnsupportedSessionAttachmentTypes } from '../session/transport';
 import type { TaskExecutionMode } from '../task/types';
 import {
     AiRequestExecutor,
@@ -222,6 +227,22 @@ export class AiConversationRuntime {
             providerId: this.options.providerId,
         });
         const attachments = this.options.attachments ?? [];
+        const attachmentCapabilities = getModelAttachmentCapabilities(initialModel);
+        const unsupportedAttachmentTypes = new Set([
+            ...getUnsupportedAttachmentTypes(attachments, attachmentCapabilities),
+            ...(await findUnsupportedSessionAttachmentTypes({
+                sessionId: this.options.sessionId,
+                capabilities: attachmentCapabilities,
+            })),
+        ]);
+        if (unsupportedAttachmentTypes.size > 0) {
+            throw new AiError(AiErrorCode.UNSUPPORTED_INPUT, {
+                unsupportedAttachmentTypes: Array.from(unsupportedAttachmentTypes),
+                modelId: initialModel.model_id,
+                providerId: initialModel.provider_id,
+            });
+        }
+
         if (attachments.length > 0) {
             await this.prepareAttachmentsForTransport(attachments);
         }
@@ -241,7 +262,7 @@ export class AiConversationRuntime {
             sessionId: this.options.sessionId,
             snapshot: promptSnapshot,
             attachments,
-            supportsAttachments: initialModel.attachment === 1,
+            attachmentCapabilities,
         });
         const initialCheckpoint = this.executor.createInitialCheckpoint({
             initialModel,

--- a/apps/desktop/src/services/AgentService/infrastructure/attachments/index.ts
+++ b/apps/desktop/src/services/AgentService/infrastructure/attachments/index.ts
@@ -36,7 +36,11 @@ export {
     hydratePersistedAttachments,
 } from './storage';
 export {
+    type AttachmentCapabilities,
+    type AttachmentType,
     getAttachmentSupportMessage,
+    getModelAttachmentCapabilities,
+    getUnsupportedAttachmentTypes,
     isAttachmentSupported,
     resolveAttachmentSupportStatus,
 } from './support';

--- a/apps/desktop/src/services/AgentService/infrastructure/attachments/support.ts
+++ b/apps/desktop/src/services/AgentService/infrastructure/attachments/support.ts
@@ -3,8 +3,45 @@
  */
 
 import { tt } from '@/i18n';
+import { parseModelModalities } from '@/utils/modelSchemas';
 
 import type { AttachmentIndex, AttachmentSupportStatus } from './types';
+
+export interface AttachmentCapabilities {
+    supportsImages: boolean;
+    supportsFiles: boolean;
+}
+
+export type AttachmentType = AttachmentIndex['type'];
+
+export function getModelAttachmentCapabilities(model: {
+    modalities?: string | null;
+    attachment?: number | null;
+}): AttachmentCapabilities {
+    const modalities = parseModelModalities(model.modalities);
+    return {
+        supportsImages: Boolean(modalities.input?.includes('image')),
+        supportsFiles: model.attachment === 1,
+    };
+}
+
+export function getUnsupportedAttachmentTypes(
+    attachments: Pick<AttachmentIndex, 'type'>[],
+    capabilities: AttachmentCapabilities
+): AttachmentType[] {
+    const unsupportedTypes = new Set<AttachmentType>();
+
+    for (const attachment of attachments) {
+        if (attachment.type === 'image' && !capabilities.supportsImages) {
+            unsupportedTypes.add('image');
+        }
+        if (attachment.type === 'file' && !capabilities.supportsFiles) {
+            unsupportedTypes.add('file');
+        }
+    }
+
+    return Array.from(unsupportedTypes);
+}
 
 /**
  * 根据文件类型和模型能力计算附件支持状态。
@@ -15,7 +52,7 @@ import type { AttachmentIndex, AttachmentSupportStatus } from './types';
  */
 export function resolveAttachmentSupportStatus(
     fileType: 'image' | 'file',
-    capabilities: { supportsImages: boolean; supportsFiles: boolean }
+    capabilities: AttachmentCapabilities
 ): AttachmentSupportStatus {
     if (fileType === 'image' && !capabilities.supportsImages) return 'unsupported-image';
     if (fileType === 'file' && !capabilities.supportsFiles) return 'unsupported-file';

--- a/apps/desktop/src/services/AgentService/prompt/transport.ts
+++ b/apps/desktop/src/services/AgentService/prompt/transport.ts
@@ -1,6 +1,10 @@
 // Copyright (c) 2026. Qian Cheng. Licensed under GPL v3
 
-import type { AttachmentIndex } from '@/services/AgentService/infrastructure/attachments';
+import {
+    type AttachmentCapabilities,
+    type AttachmentIndex,
+    getUnsupportedAttachmentTypes,
+} from '@/services/AgentService/infrastructure/attachments';
 
 import type { AiContentPart, AiMessage } from '../contracts/protocol';
 import { buildAttachmentParts } from '../infrastructure/attachments';
@@ -12,6 +16,7 @@ interface BuildPromptTransportMessagesOptions {
     snapshot: PromptSnapshot;
     attachments?: AttachmentIndex[];
     supportsAttachments?: boolean;
+    attachmentCapabilities?: AttachmentCapabilities;
 }
 
 export type PromptAttachmentSlot =
@@ -104,17 +109,27 @@ async function buildUserPromptMessage(options: {
     prompt: string;
     attachments?: AttachmentIndex[];
     supportsAttachments?: boolean;
+    attachmentCapabilities?: AttachmentCapabilities;
 }): Promise<AiMessage> {
-    const supportsAttachments = options.supportsAttachments ?? true;
-    const attachments = options.attachments ?? [];
+    const attachmentCapabilities =
+        options.attachmentCapabilities ??
+        (() => {
+            const supportsAttachments = options.supportsAttachments ?? true;
+            return {
+                supportsImages: supportsAttachments,
+                supportsFiles: supportsAttachments,
+            };
+        })();
+    const attachments = (options.attachments ?? []).filter(
+        (attachment) =>
+            getUnsupportedAttachmentTypes([attachment], attachmentCapabilities).length === 0
+    );
     const hasDraftInsertionOffsets = attachments.some(
         (attachment) => typeof attachment.draftInsertionOffset === 'number'
     );
-    const attachmentParts = supportsAttachments
-        ? hasDraftInsertionOffsets
-            ? await buildInterleavedPromptContent(options.prompt, attachments)
-            : await buildAttachmentParts(attachments)
-        : [];
+    const attachmentParts = hasDraftInsertionOffsets
+        ? await buildInterleavedPromptContent(options.prompt, attachments)
+        : await buildAttachmentParts(attachments);
 
     const hasText = options.prompt.trim().length > 0;
     const hasAttachments = attachmentParts.length > 0;
@@ -154,6 +169,7 @@ export async function buildPromptTransportMessages(
     const historyMessages = await loadSessionTransportMessages({
         sessionId: options.sessionId,
         supportsAttachments: options.supportsAttachments,
+        attachmentCapabilities: options.attachmentCapabilities,
     });
     const messages: AiMessage[] = [];
 
@@ -170,6 +186,7 @@ export async function buildPromptTransportMessages(
             prompt: options.snapshot.userPrompt,
             attachments: options.attachments,
             supportsAttachments: options.supportsAttachments,
+            attachmentCapabilities: options.attachmentCapabilities,
         })
     );
 

--- a/apps/desktop/src/services/AgentService/session/transport.ts
+++ b/apps/desktop/src/services/AgentService/session/transport.ts
@@ -9,7 +9,13 @@ import {
 
 import type { AiContentPart, AiMessage } from '../contracts/protocol';
 import type { AiToolCall } from '../contracts/tooling';
-import { buildAttachmentParts, hydratePersistedAttachments } from '../infrastructure/attachments';
+import {
+    type AttachmentCapabilities,
+    type AttachmentType,
+    buildAttachmentParts,
+    getUnsupportedAttachmentTypes,
+    hydratePersistedAttachments,
+} from '../infrastructure/attachments';
 
 function toTransportToolName(toolLog: ToolLogHistoryRow): string {
     if (toolLog.source === 'builtin') {
@@ -39,12 +45,53 @@ function buildAssistantTransportContent(row: {
 
 const MISSING_TOOL_RESULT_PLACEHOLDER = 'Missing historical tool result.';
 
+export async function findUnsupportedSessionAttachmentTypes(options: {
+    sessionId?: number;
+    capabilities: AttachmentCapabilities;
+}): Promise<AttachmentType[]> {
+    if (!options.sessionId) {
+        return [];
+    }
+
+    const rows = await findMessagesBySessionId(options.sessionId);
+    const transportAttachmentRows = rows
+        .filter((row) => row.role === 'user' || row.role === 'tool_result')
+        .flatMap((row) => row.attachments);
+
+    return getUnsupportedAttachmentTypes(transportAttachmentRows, options.capabilities);
+}
+
+function resolveTransportAttachmentCapabilities(options: {
+    attachmentCapabilities?: AttachmentCapabilities;
+    supportsAttachments?: boolean;
+}): AttachmentCapabilities {
+    if (options.attachmentCapabilities) {
+        return options.attachmentCapabilities;
+    }
+
+    const supportsAttachments = options.supportsAttachments ?? true;
+    return {
+        supportsImages: supportsAttachments,
+        supportsFiles: supportsAttachments,
+    };
+}
+
+function filterSupportedAttachmentRows<T extends { type: AttachmentType }>(
+    attachments: T[],
+    capabilities: AttachmentCapabilities
+): T[] {
+    return attachments.filter(
+        (attachment) => getUnsupportedAttachmentTypes([attachment], capabilities).length === 0
+    );
+}
+
 /**
  * 将会话历史重组为下一轮请求可继续复用的模型消息。
  */
 export async function loadSessionTransportMessages(options: {
     sessionId?: number;
     supportsAttachments?: boolean;
+    attachmentCapabilities?: AttachmentCapabilities;
 }): Promise<AiMessage[]> {
     const [rows, toolLogs] = options.sessionId
         ? await Promise.all([
@@ -52,7 +99,7 @@ export async function loadSessionTransportMessages(options: {
               findToolLogRowsBySessionId(options.sessionId),
           ])
         : [[], []];
-    const supportsAttachments = options.supportsAttachments ?? true;
+    const attachmentCapabilities = resolveTransportAttachmentCapabilities(options);
     const messages: AiMessage[] = [];
     const toolLogsByMessageId = new Map<number, ToolLogHistoryRow[]>();
     const toolLogByIdentity = new Map<string, ToolLogHistoryRow>();
@@ -178,9 +225,14 @@ export async function loadSessionTransportMessages(options: {
             );
 
             if (pendingToolCall) {
-                const attachments = supportsAttachments
-                    ? await hydratePersistedAttachments(row.attachments)
-                    : [];
+                const supportedAttachmentRows = filterSupportedAttachmentRows(
+                    row.attachments,
+                    attachmentCapabilities
+                );
+                const attachments =
+                    supportedAttachmentRows.length > 0
+                        ? await hydratePersistedAttachments(supportedAttachmentRows)
+                        : [];
                 const attachmentParts =
                     attachments.length > 0
                         ? await buildAttachmentParts(attachments, {
@@ -213,9 +265,14 @@ export async function loadSessionTransportMessages(options: {
         if (row.role === 'user') {
             flushMissingToolResults();
 
-            const attachments = supportsAttachments
-                ? await hydratePersistedAttachments(row.attachments)
-                : [];
+            const supportedAttachmentRows = filterSupportedAttachmentRows(
+                row.attachments,
+                attachmentCapabilities
+            );
+            const attachments =
+                supportedAttachmentRows.length > 0
+                    ? await hydratePersistedAttachments(supportedAttachmentRows)
+                    : [];
             const attachmentParts =
                 attachments.length > 0 ? await buildAttachmentParts(attachments) : [];
 

--- a/apps/desktop/tests/services/AgentService/attachment-capability-preflight.test.ts
+++ b/apps/desktop/tests/services/AgentService/attachment-capability-preflight.test.ts
@@ -1,0 +1,202 @@
+import type { MessageRow, ToolLogHistoryRow } from '@database/queries/messages';
+import type { ModelWithProvider } from '@database/queries/models';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AiErrorCode } from '@/services/AgentService/contracts/errors';
+import { AiConversationRuntime } from '@/services/AgentService/execution/runtime';
+import type { AttachmentIndex } from '@/services/AgentService/infrastructure/attachments';
+import {
+    getModelAttachmentCapabilities,
+    getUnsupportedAttachmentTypes,
+} from '@/services/AgentService/infrastructure/attachments';
+import { findUnsupportedSessionAttachmentTypes } from '@/services/AgentService/session/transport';
+
+const BASE_TIME = '2026-06-03T10:00:00.000Z';
+
+const mocks = vi.hoisted(() => ({
+    findMessagesBySessionId: vi.fn<() => Promise<MessageRow[]>>(),
+    findToolLogRowsBySessionId: vi.fn<() => Promise<ToolLogHistoryRow[]>>(),
+}));
+
+vi.mock('@database/queries/messages', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@database/queries/messages')>();
+
+    return {
+        ...actual,
+        findMessagesBySessionId: mocks.findMessagesBySessionId,
+        findToolLogRowsBySessionId: mocks.findToolLogRowsBySessionId,
+    };
+});
+
+function createAttachment(overrides: Partial<AttachmentIndex> = {}): AttachmentIndex {
+    const type = overrides.type ?? 'image';
+    return {
+        id: `attachment-${type}`,
+        type,
+        path: `D:/attachments/${type}`,
+        originPath: `D:/attachments/${type}`,
+        name: `${type}.dat`,
+        ...overrides,
+    };
+}
+
+function createMessageAttachment(type: 'image' | 'file') {
+    return {
+        message_id: type === 'image' ? 10 : 11,
+        sort_order: 0,
+        id: type === 'image' ? 1 : 2,
+        hash: `hash-${type}`,
+        type,
+        original_name: `${type}.dat`,
+        origin_path: `D:/attachments/${type}`,
+        mime_type: type === 'image' ? 'image/png' : 'application/pdf',
+        size: 10,
+        created_at: BASE_TIME,
+    };
+}
+
+function createMessageRow(overrides: Partial<MessageRow>): MessageRow {
+    return {
+        id: 1,
+        session_id: 1,
+        role: 'user',
+        content: '',
+        reasoning: null,
+        attachments: [],
+        tool_call_id: null,
+        tool_name: null,
+        tool_input: null,
+        tool_log_ref_id: null,
+        tool_status: null,
+        tool_duration_ms: null,
+        server_id: null,
+        tool_log_id: null,
+        tool_log_kind: null,
+        created_at: BASE_TIME,
+        updated_at: BASE_TIME,
+        ...overrides,
+    };
+}
+
+function createModel(overrides: Partial<ModelWithProvider> = {}): ModelWithProvider {
+    return {
+        id: 1,
+        created_at: BASE_TIME,
+        updated_at: BASE_TIME,
+        provider_id: 1,
+        model_id: 'text-only',
+        name: 'Text Only',
+        is_default: 1,
+        last_used_at: null,
+        attachment: 0,
+        modalities: JSON.stringify({ input: ['text'], output: ['text'] }),
+        open_weights: 0,
+        reasoning: 1,
+        release_date: null,
+        temperature: 1,
+        tool_call: 1,
+        knowledge: null,
+        context_limit: null,
+        output_limit: null,
+        is_custom_metadata: 0,
+        provider_name: 'Test Provider',
+        provider_driver: 'openai',
+        api_endpoint: 'https://example.test',
+        api_key: null,
+        provider_config_json: null,
+        provider_enabled: 1,
+        provider_logo: '',
+        ...overrides,
+    };
+}
+
+describe('AgentService attachment capability preflight', () => {
+    beforeEach(() => {
+        mocks.findMessagesBySessionId.mockReset();
+        mocks.findToolLogRowsBySessionId.mockReset();
+        mocks.findToolLogRowsBySessionId.mockResolvedValue([]);
+    });
+
+    it('derives image and file support from model metadata independently', () => {
+        expect(
+            getModelAttachmentCapabilities({
+                modalities: JSON.stringify({ input: ['text', 'image'], output: ['text'] }),
+                attachment: 0,
+            })
+        ).toEqual({ supportsImages: true, supportsFiles: false });
+
+        expect(
+            getModelAttachmentCapabilities({
+                modalities: JSON.stringify({ input: ['text'], output: ['text'] }),
+                attachment: 1,
+            })
+        ).toEqual({ supportsImages: false, supportsFiles: true });
+    });
+
+    it('detects unsupported current attachments without reading attachment content', () => {
+        expect(
+            getUnsupportedAttachmentTypes(
+                [createAttachment({ type: 'image' }), createAttachment({ type: 'file' })],
+                { supportsImages: false, supportsFiles: true }
+            )
+        ).toEqual(['image']);
+    });
+
+    it('detects unsupported historical user and tool-result attachments before transport build', async () => {
+        mocks.findMessagesBySessionId.mockResolvedValue([
+            createMessageRow({
+                id: 10,
+                role: 'user',
+                content: 'image from history',
+                attachments: [createMessageAttachment('image')],
+            }),
+            createMessageRow({
+                id: 11,
+                role: 'tool_result',
+                content: 'file returned by tool',
+                attachments: [createMessageAttachment('file')],
+            }),
+            createMessageRow({
+                id: 12,
+                role: 'assistant',
+                content: 'ignored assistant attachment metadata',
+                attachments: [createMessageAttachment('image')],
+            }),
+        ]);
+
+        await expect(
+            findUnsupportedSessionAttachmentTypes({
+                sessionId: 1,
+                capabilities: { supportsImages: false, supportsFiles: false },
+            })
+        ).resolves.toEqual(['image', 'file']);
+    });
+
+    it('fails a runtime before the first model attempt when history has unsupported attachments', async () => {
+        mocks.findMessagesBySessionId.mockResolvedValue([
+            createMessageRow({
+                id: 10,
+                role: 'user',
+                content: 'image from history',
+                attachments: [createMessageAttachment('image')],
+            }),
+        ]);
+
+        const runAttempt = vi.fn();
+        const runtime = new AiConversationRuntime(
+            {
+                getModel: vi.fn().mockResolvedValue(createModel()),
+                runAttempt,
+            } as unknown as ConstructorParameters<typeof AiConversationRuntime>[0],
+            {
+                prompt: 'continue',
+                sessionId: 1,
+            }
+        );
+
+        await expect(runtime.run()).rejects.toMatchObject({
+            code: AiErrorCode.UNSUPPORTED_INPUT,
+        });
+        expect(runAttempt).not.toHaveBeenCalled();
+    });
+});

--- a/apps/desktop/tests/services/AgentService/contracts/errors-i18n.test.ts
+++ b/apps/desktop/tests/services/AgentService/contracts/errors-i18n.test.ts
@@ -33,6 +33,24 @@ describe('AiError display localization', () => {
         expect(error.getDisplayMessage()).toBe('供应商返回的原始错误 payload');
     });
 
+    it('normalizes unsupported input endpoint errors from plain Error objects', () => {
+        const error = new Error('No endpoints found that support image input');
+
+        expect(AiError.getDisplayMessage(error)).toBe(
+            '当前模型不支持图片/文件输入，请选择合适模型继续。'
+        );
+    });
+
+    it('normalizes unsupported endpoint errors when other capabilities are listed too', () => {
+        const error = new AiError(
+            AiErrorCode.API_ERROR,
+            undefined,
+            'No endpoints found that support tool, image, and file inputs'
+        );
+
+        expect(error.getDisplayMessage()).toBe('当前模型不支持图片/文件输入，请选择合适模型继续。');
+    });
+
     it('keeps default Error.message stable while exposing localized display text', () => {
         setLocale('en-US');
         const error = new AiError(AiErrorCode.NO_ACTIVE_MODEL);

--- a/apps/desktop/tests/services/AgentService/session-history-i18n.test.ts
+++ b/apps/desktop/tests/services/AgentService/session-history-i18n.test.ts
@@ -166,6 +166,36 @@ describe('AgentService session history i18n', () => {
         );
     });
 
+    it('rebuilds unsupported file endpoint errors as friendly model capability messages', async () => {
+        setLocale('zh-CN');
+
+        const history = await buildSessionHistory({
+            messages: [
+                createMessageRow({
+                    id: 10,
+                    role: 'user',
+                    content: '继续刚才的对话',
+                }),
+            ],
+            turns: [
+                createTurn({
+                    id: 1,
+                    prompt_message_id: 10,
+                    status: 'failed',
+                    error_message: 'No endpoints found that support file input',
+                }),
+            ],
+            attempts: [],
+            resolveServerName: () => '',
+        });
+
+        expect(history[1]).toMatchObject({
+            role: 'assistant',
+            content: '请求失败: 当前模型不支持图片/文件输入，请选择合适模型继续。',
+            isError: true,
+        });
+    });
+
     it('localizes restored built-in tool presentation verbs in English history', async () => {
         setLocale('en-US');
 

--- a/apps/desktop/tests/services/AgentService/task/projection/projection-i18n.test.ts
+++ b/apps/desktop/tests/services/AgentService/task/projection/projection-i18n.test.ts
@@ -83,6 +83,28 @@ describe('SessionTaskProjection i18n statuses', () => {
         );
     });
 
+    it('replaces unsupported image endpoint errors with a friendly model capability message', () => {
+        setLocale('zh-CN');
+        const snapshot = createSnapshot();
+        const projection = createProjection(snapshot);
+
+        projection.bootstrap([], 'Hello', []);
+        projection.syncTaskMetadata({
+            type: 'task_failed',
+            taskId: 'task-1',
+            turnId: 1,
+            error: 'No endpoints found that support image input',
+        });
+
+        const statusMessage = snapshot.sessionHistory[snapshot.sessionHistory.length - 1];
+        expect(statusMessage).toMatchObject({
+            role: 'assistant',
+            content: '请求失败: 当前模型不支持图片/文件输入，请选择合适模型继续。',
+            isError: true,
+        });
+        expect(snapshot.error).toBe('当前模型不支持图片/文件输入，请选择合适模型继续。');
+    });
+
     it('uses English cancelled request status when the active locale is English', () => {
         setLocale('en-US');
         const snapshot = createSnapshot();


### PR DESCRIPTION
> First external contributors may need to complete the `CLA Assistant` check before merge.
> For code changes, this PR must link the related issue or RFC in the section below.

## Summary

- Normalize AI SDK endpoint capability errors for unsupported image/file input into a friendly user-facing message.
- Apply the same normalization to live task failure projection and restored session history failure statuses.
- Add regression coverage for image and file unsupported endpoint errors plus i18n source coverage.

## Related issue or RFC

- Fixes #406

## AI assistance disclosure

- Tool(s) used: OpenAI Codex
- Scope of assistance: implemented the error-display normalization, regression tests, and GitHub issue/PR updates.
- Human review or rewrite performed: reviewed the diff, local test output, CI status, and PR/issue text before submission.
- Architecture or boundary impact: no new architecture or cross-boundary abstraction; this stays within AgentService error display/i18n handling.

## Testing evidence

Local checks run:

```text
pnpm.cmd --filter @touchai/desktop exec vitest run --configLoader runner tests/i18n/sourceCoverage.test.ts tests/services/AgentService/task/projection/projection-i18n.test.ts tests/services/AgentService/session-history-i18n.test.ts
pnpm.cmd --filter @touchai/desktop exec eslint src/services/AgentService/contracts/errors.ts tests/services/AgentService/task/projection/projection-i18n.test.ts tests/services/AgentService/session-history-i18n.test.ts
pnpm.cmd exec prettier --check apps/desktop/src/services/AgentService/contracts/errors.ts apps/desktop/src/i18n/textMap.ts apps/desktop/tests/services/AgentService/task/projection/projection-i18n.test.ts apps/desktop/tests/services/AgentService/session-history-i18n.test.ts
```

Observed result: all listed local checks passed.

`pnpm test:pr` was not run locally because the change is narrowly scoped to AgentService error display/i18n paths and targeted checks were run locally; CI coverage is used for the full suite. CI currently reports an unrelated `BuiltInToolService/tools/widgetTool/runtime-i18n.test.ts` failure in Frontend Tests, outside the files touched by this PR.

TDD: yes. Regression tests were added first and verified red before implementing the normalization.

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: AgentService display-layer behavior only; no request payload, runtime, MCP, database schema, or provider contract changes.
- database baseline or migration impact: none.
- release or packaging impact: none.

## Screenshots or recordings

No screenshot included. This changes failed request status text; regression tests cover the displayed message for live projection and restored history.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [ ] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [x] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [x] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.