### PR TITLE
fix(desktop): invalidate MiMo managed auth on bare 401

### DIFF
--- a/apps/desktop/src/services/AgentService/infrastructure/providers/adapters/mimo.ts
+++ b/apps/desktop/src/services/AgentService/infrastructure/providers/adapters/mimo.ts
@@ -50,7 +50,7 @@ function buildGatewayErrorDetails(
     return {
         gatewayCode: code ?? null,
         statusCode,
-        requiresRelogin: code ? reloginRequiredGatewayCodes.has(code) : false,
+        requiresRelogin: code ? reloginRequiredGatewayCodes.has(code) : statusCode === 401,
         payload: data,
     };
 }

--- a/apps/desktop/src/services/AuthService/index.ts
+++ b/apps/desktop/src/services/AuthService/index.ts
@@ -197,7 +197,7 @@ function buildNormalizedManagedProviderPatch(provider: ManagedProviderRow) {
 }
 
 function extractManagedAuthFailureDetails(error: unknown): {
-    gatewayCode: string;
+    gatewayCode: string | null;
     statusCode?: number;
 } | null {
     if (error == null || typeof error !== 'object' || !('details' in error)) {
@@ -213,14 +213,18 @@ function extractManagedAuthFailureDetails(error: unknown): {
     const requiresRelogin = detailRecord.requiresRelogin === true;
     const gatewayCode =
         typeof detailRecord.gatewayCode === 'string' ? detailRecord.gatewayCode : null;
-    if (!requiresRelogin || !gatewayCode) {
+    const statusCode =
+        typeof detailRecord.statusCode === 'number' ? detailRecord.statusCode : undefined;
+    if (
+        !requiresRelogin ||
+        (gatewayCode ? !MANAGED_AUTH_FAILURE_CODES.has(gatewayCode) : statusCode !== 401)
+    ) {
         return null;
     }
 
     return {
         gatewayCode,
-        statusCode:
-            typeof detailRecord.statusCode === 'number' ? detailRecord.statusCode : undefined,
+        statusCode,
     };
 }
 
@@ -350,7 +354,7 @@ export async function invalidateManagedAuthForError(options: {
     error: unknown;
 }): Promise<boolean> {
     const details = extractManagedAuthFailureDetails(options.error);
-    if (!details || !MANAGED_AUTH_FAILURE_CODES.has(details.gatewayCode)) {
+    if (!details) {
         return false;
     }
 

--- a/apps/desktop/tests/services/AgentService/infrastructure/providers/mimo.test.ts
+++ b/apps/desktop/tests/services/AgentService/infrastructure/providers/mimo.test.ts
@@ -232,6 +232,30 @@ describe('MiMoProviderAdapter', () => {
         });
     });
 
+    it('treats unstructured managed gateway unauthorized responses as requiring relogin', () => {
+        const provider = new MiMoProviderAdapter({
+            apiEndpoint: 'https://hub.touch-ai.org/api/v1',
+            apiKey: 'ta_live_managed_key',
+            config: {
+                touchAiMode: 'managed',
+            },
+        });
+
+        const authError = provider.classifyError({
+            statusCode: 401,
+            responseBody: '{"message":"Unauthorized"}',
+            message: 'Unauthorized',
+        });
+
+        expect(authError).toBeInstanceOf(AiError);
+        expect(authError?.code).toBe(AiErrorCode.UNAUTHORIZED);
+        expect((authError as AiError).details).toMatchObject({
+            gatewayCode: null,
+            statusCode: 401,
+            requiresRelogin: true,
+        });
+    });
+
     it('lets the hub validate managed model ids at request time', () => {
         const provider = new MiMoProviderAdapter({
             apiEndpoint: 'https://hub.touch-ai.org/api/v1',

--- a/apps/desktop/tests/services/AuthService/index.test.ts
+++ b/apps/desktop/tests/services/AuthService/index.test.ts
@@ -349,4 +349,35 @@ describe('AuthService managed TouchAI Hub flow', () => {
             updatedAt: expect.any(Number),
         });
     });
+
+    it('invalidates the managed token when a managed 401 response requires relogin without a gateway code', async () => {
+        const { invalidateManagedAuthForError } = await import('@/services/AuthService');
+
+        await expect(
+            invalidateManagedAuthForError({
+                providerId: 320,
+                error: {
+                    details: {
+                        requiresRelogin: true,
+                        gatewayCode: null,
+                        statusCode: 401,
+                    },
+                },
+            })
+        ).resolves.toBe(true);
+
+        expect(queriesMock.updateProvider).toHaveBeenCalledWith({
+            id: 320,
+            providerPatch: {
+                api_key: null,
+                api_endpoint: 'https://hub.touch-ai.org/api/v1',
+                config_json: JSON.stringify({
+                    touchAiMode: 'managed',
+                }),
+            },
+        });
+        expect(eventServiceMock.emit).toHaveBeenCalledWith('AI_MODELS_UPDATED', {
+            updatedAt: expect.any(Number),
+        });
+    });
 });


### PR DESCRIPTION
## Summary
- Treat bare managed MiMo gateway 401 responses as relogin-required even when the response lacks a structured gateway code.
- Allow the managed auth invalidation path to clear the stored activity key for that relogin-required 401 case.
- Add focused regression coverage for unstructured Unauthorized responses and key invalidation.

## Related issue or RFC
- Closes https://github.com/TouchAI-org/TouchAI/issues/397

## AI assistance disclosure
- Tool(s) used: Codex.
- Scope of assistance: Root-cause investigation, focused implementation, tests, and PR preparation.
- Human review or rewrite performed: Changes were reviewed against field logs and targeted regression tests.
- Architecture or boundary impact: None; this keeps the MiMo managed-auth handling localized.

## Testing evidence
```text
pnpm.cmd --dir apps/desktop exec vitest run --configLoader runner tests/services/AgentService/infrastructure/providers/mimo.test.ts tests/services/AuthService/index.test.ts
```
Result: passed locally, 2 test files and 18 tests.

Full `pnpm test:pr` was not run locally because this is a narrowly scoped activity fix; relying on CI for full PR validation.

## Risk notes
- `AgentService`, runtime, MCP, or schema impact: localized MiMo provider/auth invalidation handling only.
- database baseline or migration impact: none.
- release or packaging impact: none.

## Screenshots or recordings
- Not applicable; no UI changes.

## Checklist
- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC or the change is localized and documented in Risk notes.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [x] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [x] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.