### PR TITLE
feat(desktop): support adaptive tool timeouts

### DIFF
--- a/apps/desktop/src/services/AgentService/catalog/tools.ts
+++ b/apps/desktop/src/services/AgentService/catalog/tools.ts
@@ -11,6 +11,31 @@ export interface ResolveToolDefinitionsOptions {
     excludedToolNames?: string[];
 }
 
+const TOOL_TIMEOUT_META_PROPERTY = {
+    type: 'object',
+    description: 'Optional execution metadata for this tool call.',
+    properties: {
+        timeoutMs: {
+            type: 'integer',
+            description:
+                'Optional timeout in milliseconds. Use only when a task is expected to take longer or shorter than the default. Maximum: 600000 (10 minutes).',
+        },
+    },
+} as const;
+
+function withAdaptiveTimeoutSchema(tool: AiToolDefinition): AiToolDefinition {
+    return {
+        ...tool,
+        input_schema: {
+            ...tool.input_schema,
+            properties: {
+                ...tool.input_schema.properties,
+                _meta: TOOL_TIMEOUT_META_PROPERTY,
+            },
+        },
+    };
+}
+
 /**
  * 解析当前模型可用的工具定义列表。
  */
@@ -27,10 +52,11 @@ export async function resolveToolDefinitions(
         builtInToolService.getEnabledToolDefinitions(),
     ]);
     const allTools = [...mcpTools, ...builtInTools];
-    if (!options.excludedToolNames?.length) {
-        return allTools;
+    let filteredTools = allTools;
+    if (options.excludedToolNames?.length) {
+        const excludedToolNames = new Set(options.excludedToolNames);
+        filteredTools = allTools.filter((tool) => !excludedToolNames.has(tool.name));
     }
 
-    const excludedToolNames = new Set(options.excludedToolNames);
-    return allTools.filter((tool) => !excludedToolNames.has(tool.name));
+    return filteredTools.map(withAdaptiveTimeoutSchema);
 }

--- a/apps/desktop/src/services/AgentService/catalog/tools.ts
+++ b/apps/desktop/src/services/AgentService/catalog/tools.ts
@@ -18,7 +18,9 @@ const TOOL_TIMEOUT_META_PROPERTY = {
         timeoutMs: {
             type: 'integer',
             description:
-                'Optional timeout in milliseconds. Use only when a task is expected to take longer or shorter than the default. Maximum: 600000 (10 minutes).',
+                'Optional timeout in milliseconds. Use only when a task is expected to take longer or shorter than the default. Minimum: 1000 (1 second). Maximum: 600000 (10 minutes).',
+            minimum: 1000,
+            maximum: 600000,
         },
     },
 } as const;

--- a/apps/desktop/src/services/AgentService/execution/executor.ts
+++ b/apps/desktop/src/services/AgentService/execution/executor.ts
@@ -363,7 +363,11 @@ function parseRequestedTimeoutMs(toolArgs: Record<string, unknown>): {
     delete sanitizedToolArgs[TOOL_TIMEOUT_META_KEY];
 
     const timeoutMs = (meta as Record<string, unknown>).timeoutMs;
-    if (typeof timeoutMs !== 'number' || !Number.isFinite(timeoutMs)) {
+    if (
+        typeof timeoutMs !== 'number' ||
+        !Number.isFinite(timeoutMs) ||
+        !Number.isInteger(timeoutMs)
+    ) {
         return {
             requestedTimeoutMs: undefined,
             sanitizedToolArgs,

--- a/apps/desktop/src/services/AgentService/execution/executor.ts
+++ b/apps/desktop/src/services/AgentService/execution/executor.ts
@@ -352,8 +352,7 @@ function parseRequestedTimeoutMs(toolArgs: Record<string, unknown>): {
     sanitizedToolArgs: Record<string, unknown>;
 } {
     const meta = toolArgs[TOOL_TIMEOUT_META_KEY];
-    const sanitizedToolArgs =
-        TOOL_TIMEOUT_META_KEY in toolArgs ? { ...toolArgs } : toolArgs;
+    const sanitizedToolArgs = TOOL_TIMEOUT_META_KEY in toolArgs ? { ...toolArgs } : toolArgs;
     if (TOOL_TIMEOUT_META_KEY in sanitizedToolArgs) {
         delete sanitizedToolArgs[TOOL_TIMEOUT_META_KEY];
     }

--- a/apps/desktop/src/services/AgentService/execution/executor.ts
+++ b/apps/desktop/src/services/AgentService/execution/executor.ts
@@ -43,6 +43,7 @@ const BUILT_IN_UPGRADE_TOOL_NAME = 'builtin__upgrade_model';
 const MAX_REQUEST_MODEL_SWITCHES = 4;
 const MODEL_SWITCH_EXCLUDED_TOOL_NAMES = [BUILT_IN_UPGRADE_TOOL_NAME];
 const toolArgumentsSchema = z.record(z.string(), z.unknown());
+const TOOL_TIMEOUT_META_KEY = '_meta';
 /**
  * 这些文本会进入工具结果和会话历史，属于用户可见内容，因此统一使用中文。
  * console 日志仍保留英文，便于对齐 SDK、provider 和协议层排障信息。
@@ -346,6 +347,35 @@ function parseToolCallArguments(toolCall: AiToolCall):
     };
 }
 
+function parseRequestedTimeoutMs(toolArgs: Record<string, unknown>): {
+    requestedTimeoutMs?: number;
+    sanitizedToolArgs: Record<string, unknown>;
+} {
+    const meta = toolArgs[TOOL_TIMEOUT_META_KEY];
+    if (!meta || typeof meta !== 'object' || Array.isArray(meta)) {
+        return {
+            requestedTimeoutMs: undefined,
+            sanitizedToolArgs: toolArgs,
+        };
+    }
+
+    const sanitizedToolArgs = { ...toolArgs };
+    delete sanitizedToolArgs[TOOL_TIMEOUT_META_KEY];
+
+    const timeoutMs = (meta as Record<string, unknown>).timeoutMs;
+    if (typeof timeoutMs !== 'number' || !Number.isFinite(timeoutMs)) {
+        return {
+            requestedTimeoutMs: undefined,
+            sanitizedToolArgs,
+        };
+    }
+
+    return {
+        requestedTimeoutMs: timeoutMs,
+        sanitizedToolArgs,
+    };
+}
+
 /**
  * 负责单次模型执行的底层编排：
  * - 模型解析
@@ -453,6 +483,7 @@ export class AiRequestExecutor {
         toolCallMessageId: number | null;
         sessionId: number | null;
         onChunk?: RequestExecutionCallbacks['onChunk'];
+        requestedTimeoutMs?: number;
     }): Promise<{
         toolCall: AiToolCall;
         result: string;
@@ -521,6 +552,7 @@ export class AiRequestExecutor {
                 signal: options.signal,
                 iteration: options.iteration,
                 toolCallId: options.toolCall.id,
+                requestedTimeoutMs: options.requestedTimeoutMs,
                 resolved: {
                     serverId: mapping.serverId,
                     originalName: mapping.originalName,
@@ -736,10 +768,13 @@ export class AiRequestExecutor {
             };
         }
 
-        const { toolArgs } = parsedToolArguments;
+        const { requestedTimeoutMs, sanitizedToolArgs } = parseRequestedTimeoutMs(
+            parsedToolArguments.toolArgs
+        );
+
         const builtInResult = await builtInToolService.executeTool({
             toolCall: options.toolCall,
-            toolArgs,
+            toolArgs: sanitizedToolArgs,
             iteration: runtime.iteration,
             currentModel: runtime.activeModel,
             hasExecutedBuiltInTool: (toolId) => runtime.executedBuiltInTools.has(toolId),
@@ -749,6 +784,7 @@ export class AiRequestExecutor {
             requestToolApproval: options.requestToolApproval,
             requestUserQuestions: options.requestUserQuestions,
             emitToolEvent: (toolEvent) => this.emitToolEvent(options.onChunk, toolEvent),
+            requestedTimeoutMs,
         });
 
         if (builtInResult) {
@@ -757,12 +793,13 @@ export class AiRequestExecutor {
 
         return this.executeMcpToolCall({
             toolCall: options.toolCall,
-            toolArgs,
+            toolArgs: sanitizedToolArgs,
             iteration: runtime.iteration,
             signal: options.signal,
             toolCallMessageId: options.toolCallMessageId,
             sessionId: options.persister.getSessionId(),
             onChunk: options.onChunk,
+            requestedTimeoutMs,
         });
     }
 

--- a/apps/desktop/src/services/AgentService/execution/executor.ts
+++ b/apps/desktop/src/services/AgentService/execution/executor.ts
@@ -352,15 +352,18 @@ function parseRequestedTimeoutMs(toolArgs: Record<string, unknown>): {
     sanitizedToolArgs: Record<string, unknown>;
 } {
     const meta = toolArgs[TOOL_TIMEOUT_META_KEY];
+    const sanitizedToolArgs =
+        TOOL_TIMEOUT_META_KEY in toolArgs ? { ...toolArgs } : toolArgs;
+    if (TOOL_TIMEOUT_META_KEY in sanitizedToolArgs) {
+        delete sanitizedToolArgs[TOOL_TIMEOUT_META_KEY];
+    }
+
     if (!meta || typeof meta !== 'object' || Array.isArray(meta)) {
         return {
             requestedTimeoutMs: undefined,
-            sanitizedToolArgs: toolArgs,
+            sanitizedToolArgs,
         };
     }
-
-    const sanitizedToolArgs = { ...toolArgs };
-    delete sanitizedToolArgs[TOOL_TIMEOUT_META_KEY];
 
     const timeoutMs = (meta as Record<string, unknown>).timeoutMs;
     if (

--- a/apps/desktop/src/services/AgentService/infrastructure/mcp/McpManager.ts
+++ b/apps/desktop/src/services/AgentService/infrastructure/mcp/McpManager.ts
@@ -28,6 +28,7 @@ import { eq } from 'drizzle-orm';
 
 import { t } from '@/i18n';
 import { parseMcpToolSchemaJson } from '@/utils/mcpSchemas';
+import { clampTimeoutMs } from '@/utils/timeouts';
 
 import type { AiToolDefinition } from '../../contracts/tooling';
 import {
@@ -457,10 +458,12 @@ export class McpManager {
         }
 
         // Apply requested timeout bounded between 1s and 10 mins, default to tool config
-        let effectiveTimeout = resolved.toolTimeout;
-        if (options?.requestedTimeoutMs && options.requestedTimeoutMs > 0) {
-            effectiveTimeout = Math.min(Math.max(options.requestedTimeoutMs, 1000), 600000);
-        }
+        const effectiveTimeout = clampTimeoutMs(
+            options?.requestedTimeoutMs,
+            resolved.toolTimeout,
+            1000,
+            600000
+        );
 
         // 将工具调用与超时和中止信号进行竞争
         const callPromise = this.callTool(resolved.serverId, resolved.originalName, args);

--- a/apps/desktop/src/services/AgentService/infrastructure/mcp/McpManager.ts
+++ b/apps/desktop/src/services/AgentService/infrastructure/mcp/McpManager.ts
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2026. Qian Cheng. Licensed under GPL v3.
+// Copyright (c) 2026. Qian Cheng. Licensed under GPL v3.
 
 /**
  * MCP Manager - 管理 MCP 服务器连接和工具调用
@@ -438,6 +438,7 @@ export class McpManager {
             iteration?: number;
             toolCallId?: string;
             resolved?: { serverId: number; originalName: string; toolTimeout: number };
+            requestedTimeoutMs?: number;
         }
     ): Promise<{
         result: string;
@@ -455,11 +456,17 @@ export class McpManager {
             throw new Error(t('agent.mcp.toolNotFound', { toolName }));
         }
 
+        // Apply requested timeout bounded between 1s and 10 mins, default to tool config
+        let effectiveTimeout = resolved.toolTimeout;
+        if (options?.requestedTimeoutMs && options.requestedTimeoutMs > 0) {
+            effectiveTimeout = Math.min(Math.max(options.requestedTimeoutMs, 1000), 600000);
+        }
+
         // 将工具调用与超时和中止信号进行竞争
         const callPromise = this.callTool(resolved.serverId, resolved.originalName, args);
         const response = await raceWithTimeoutAndSignal(
             callPromise,
-            resolved.toolTimeout,
+            effectiveTimeout,
             options?.signal
         );
 

--- a/apps/desktop/src/services/BuiltInToolService/service.ts
+++ b/apps/desktop/src/services/BuiltInToolService/service.ts
@@ -49,6 +49,7 @@ interface BuiltInToolExecutionOptions {
         questions: AskUserQuestion[]
     ) => Promise<AskUserAnswer[] | null>;
     emitToolEvent: (event: ToolEvent) => void;
+    requestedTimeoutMs?: number;
 }
 
 interface BuiltInToolExecutionResponse {
@@ -257,6 +258,7 @@ class BuiltInToolService {
             emitToolEvent: options.emitToolEvent,
             hasExecutedBuiltInTool: options.hasExecutedBuiltInTool,
             requestUserQuestions: options.requestUserQuestions,
+            requestedTimeoutMs: options.requestedTimeoutMs,
         };
 
         const callStartTime = Date.now();

--- a/apps/desktop/src/services/BuiltInToolService/tools/bash/index.ts
+++ b/apps/desktop/src/services/BuiltInToolService/tools/bash/index.ts
@@ -153,12 +153,19 @@ export async function executeBashTool(
     context: BaseBuiltInToolExecutionContext
 ): Promise<BuiltInToolExecutionResult> {
     const commandContext = await resolveCommandContext(args, config);
+
+    // Apply requested timeout bounded between 1s and 10 mins, default to tool config
+    let effectiveTimeout = config.timeoutMs;
+    if (context.requestedTimeoutMs && context.requestedTimeoutMs > 0) {
+        effectiveTimeout = Math.min(Math.max(context.requestedTimeoutMs, 1000), 600000);
+    }
+
     const response = await executeCancelableBash(
         {
             executionId: context.callId,
             command: commandContext.command,
             workingDirectory: commandContext.workingDirectory,
-            timeoutMs: config.timeoutMs,
+            timeoutMs: effectiveTimeout,
             compactOutput: config.compactOutput,
             rawOutput: commandContext.rawOutput,
         },

--- a/apps/desktop/src/services/BuiltInToolService/tools/bash/index.ts
+++ b/apps/desktop/src/services/BuiltInToolService/tools/bash/index.ts
@@ -6,6 +6,7 @@ import { t, tt } from '@/i18n';
 import { AiError, AiErrorCode } from '@/services/AgentService/contracts/errors';
 import type { ToolApprovalRequest } from '@/services/AgentService/contracts/tooling';
 import { normalizeOptionalString, truncateText } from '@/utils/text';
+import { clampTimeoutMs } from '@/utils/timeouts';
 
 import {
     type BaseBuiltInToolExecutionContext,
@@ -155,10 +156,12 @@ export async function executeBashTool(
     const commandContext = await resolveCommandContext(args, config);
 
     // Apply requested timeout bounded between 1s and 10 mins, default to tool config
-    let effectiveTimeout = config.timeoutMs;
-    if (context.requestedTimeoutMs && context.requestedTimeoutMs > 0) {
-        effectiveTimeout = Math.min(Math.max(context.requestedTimeoutMs, 1000), 600000);
-    }
+    const effectiveTimeout = clampTimeoutMs(
+        context.requestedTimeoutMs,
+        config.timeoutMs,
+        1000,
+        600000
+    );
 
     const response = await executeCancelableBash(
         {

--- a/apps/desktop/src/services/BuiltInToolService/types.ts
+++ b/apps/desktop/src/services/BuiltInToolService/types.ts
@@ -42,6 +42,7 @@ export interface BaseBuiltInToolExecutionContext {
         callId: string,
         questions: AskUserQuestion[]
     ) => Promise<AskUserAnswer[] | null>;
+    requestedTimeoutMs?: number;
 }
 
 /**

--- a/apps/desktop/src/utils/timeouts.ts
+++ b/apps/desktop/src/utils/timeouts.ts
@@ -1,0 +1,13 @@
+export function clampTimeoutMs(
+    requested: number | undefined | null,
+    fallback: number,
+    min = 1000,
+    max = 600000
+): number {
+    if (typeof requested !== 'number' || !Number.isFinite(requested)) {
+        return fallback;
+    }
+    const integer = Math.floor(requested);
+    const bounded = Math.min(Math.max(integer, min), max);
+    return bounded;
+}


### PR DESCRIPTION
## Summary

This change allows the LLM to suggest tool call timeout values dynamically instead of relying only on static defaults.

User-facing impact:
- tool execution becomes more adaptive for long-running or short-running tasks
- tools can optionally receive `_meta.timeoutMs` as execution metadata
- requested timeout values are clamped to safe bounds to avoid runaway execution
- existing default timeout behavior is preserved when the model does not specify a timeout

Implementation summary:
- expose optional `_meta.timeoutMs` in tool schemas before tools are provided to the model
- parse timeout metadata separately from business arguments in the executor
- apply bounded timeout selection in MCP execution and built-in Bash execution
- preserve existing tool defaults when no timeout is provided
- strip invalid `_meta` values before forwarding arguments downstream
- align runtime validation with the schema’s integer timeout contract

## Related issue or RFC

- Closes #47

## AI assistance disclosure

- Tool(s) used:
  - Trae / GPT-based coding assistant
- Scope of assistance:
  - helped analyze the issue
  - implemented the timeout propagation changes
  - helped prepare PR summary and screenshot guidance
- Human review or rewrite performed:
  - I manually reviewed the affected files, verified the behavior in the desktop UI, and checked the final diff before opening this PR
- Architecture or boundary impact:
  - yes, this touches `AgentService`, MCP timeout handling, tool schema exposure, and built-in tool execution boundaries

## Testing evidence

- `pnpm type:check`
  - passed
- `pnpm test:pr`
  - not run locally
  - blocker: not completed before opening this PR, so CI should be used as the full validation source before merge
- `pnpm test:coverage:rust`
  - not run locally
  - blocker: `cargo-tarpaulin` is not installed locally, so CI coverage evidence should be used before merge
- `pnpm test:e2e`
  - not run locally
  - blocker: not completed before opening this PR; CI should be treated as the first complete proof if required by maintainers

Did you follow TDD (test-first) for feature and fix work?
- No. This change was implemented first and then validated with targeted type checking plus manual UI verification.

```text
pnpm type:check
pnpm test:pr
pnpm test:coverage:rust
pnpm test:e2e
```

## Risk notes

- `AgentService`, runtime, MCP, or schema impact:
  - touches tool schema exposure, executor argument parsing, MCP timeout propagation, and built-in Bash timeout handling
  - bounded to optional `_meta.timeoutMs`
  - defaults are preserved when timeout is omitted
  - safe timeout clamp is enforced with a minimum of `1000ms` and maximum of `600000ms`
- database baseline or migration impact:
  - none
- release or packaging impact:
  - none expected

## Screenshots or recordings

1. Desktop UI: Bash tool call executed successfully in conversation view

<img width="1107" height="814" alt="test1" src="https://github.com/user-attachments/assets/90384e78-cdda-4d27-8e91-faebe76d44a8" />

2. Desktop UI: Bash tool log details in Settings -> Built-in Tools -> Bash

<img width="1674" height="1046" alt="test2" src="https://github.com/user-attachments/assets/4785f020-4af7-43be-9c18-66aa310fb821" />

3. Code evidence: `_meta.timeoutMs` exposed in tool schema

<img width="1971" height="828" alt="test3" src="https://github.com/user-attachments/assets/8cf23a06-9458-443b-a606-7744ea9f36ed" />

4. Code evidence: requested timeout is clamped to safe bounds before execution

<img width="1149" height="498" alt="test4" src="https://github.com/user-attachments/assets/4247c4ba-0f1b-4b14-8ba2-47fe2e2b7dcb" />

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [ ] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [ ] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [ ] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [ ] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [ ] I added tests or explained why tests are not appropriate.
- [ ] I updated docs when behavior changed.