### PR TITLE
fix(agent-service): preserve network errors when provider classification fails

### DIFF
--- a/apps/desktop/src/services/AgentService/contracts/errors.ts
+++ b/apps/desktop/src/services/AgentService/contracts/errors.ts
@@ -209,7 +209,6 @@ export class AiError extends Error {
             AiErrorCode.SERVICE_UNAVAILABLE,
             AiErrorCode.BAD_GATEWAY,
             AiErrorCode.GATEWAY_TIMEOUT,
-            AiErrorCode.API_ERROR,
             AiErrorCode.EMPTY_RESPONSE,
         ].includes(this.code);
     }

--- a/apps/desktop/src/services/AgentService/contracts/errors.ts
+++ b/apps/desktop/src/services/AgentService/contracts/errors.ts
@@ -95,6 +95,15 @@ function isUnsupportedInputEndpointMessage(message: string): boolean {
     );
 }
 
+function isTransportNetworkErrorMessage(message: string): boolean {
+    return (
+        message.includes('error sending request for url') ||
+        message.includes('failed to fetch') ||
+        message.includes('network') ||
+        message.includes('fetch')
+    );
+}
+
 function getDisplayMessageForText(message: string): string {
     const source = Object.values(ERROR_MESSAGES).find((candidate) => candidate === message);
     if (source) {
@@ -253,8 +262,8 @@ export class AiError extends Error {
             }
 
             // 网络错误
-            if (message.includes('network') || message.includes('fetch')) {
-                return new AiError(AiErrorCode.NETWORK_ERROR, error, originalMessage, {
+            if (isTransportNetworkErrorMessage(message)) {
+                return new AiError(AiErrorCode.NETWORK_ERROR, error, undefined, {
                     cause,
                 });
             }

--- a/apps/desktop/src/services/AgentService/execution/executor.ts
+++ b/apps/desktop/src/services/AgentService/execution/executor.ts
@@ -959,9 +959,19 @@ export class AiRequestExecutor {
                 console.warn('[AiRequestExecutor] Provider error details:', providerErrorDetails);
             }
 
-            // 先让 provider 自己分类，再 fallback 到通用启发式
-            const classifiedError =
-                runtime.provider.classifyError?.(unwrapped) ?? AiError.fromError(unwrapped);
+            // 先让 provider 自己分类，再 fallback 到通用启发式。
+            // 分类器只负责提升错误信息，不能覆盖真正的请求失败原因。
+            let classifiedError: AiError;
+            try {
+                classifiedError =
+                    runtime.provider.classifyError?.(unwrapped) ?? AiError.fromError(unwrapped);
+            } catch (classificationError) {
+                console.warn(
+                    '[AiRequestExecutor] Provider error classification failed:',
+                    classificationError
+                );
+                classifiedError = AiError.fromError(unwrapped);
+            }
 
             return {
                 type: 'failed',

--- a/apps/desktop/src/services/AgentService/execution/retry.ts
+++ b/apps/desktop/src/services/AgentService/execution/retry.ts
@@ -64,6 +64,13 @@ export function shouldRetryRequestFailure(
             return true;
         }
 
+        if (
+            typeof details?.statusCode === 'number' &&
+            RETRYABLE_STATUS_CODES.has(details.statusCode)
+        ) {
+            return true;
+        }
+
         return false;
     }
 

--- a/apps/desktop/src/services/AgentService/execution/retry.ts
+++ b/apps/desktop/src/services/AgentService/execution/retry.ts
@@ -7,6 +7,12 @@ export interface RetryableRequestErrorInfo {
 }
 
 export const MAX_REQUEST_RETRIES = 5;
+const RETRYABLE_PROVIDER_GATEWAY_CODES = new Set([
+    'rate_limited',
+    'upstream_rate_limited',
+    'upstream_unavailable',
+    'upstream_unauthorized',
+]);
 
 // HTTP 状态码：可重试的临时性错误
 const RETRYABLE_STATUS_CODES = new Set([
@@ -35,12 +41,29 @@ export function shouldRetryRequestFailure(
     error: AiError,
     details?: RetryableRequestErrorInfo | null
 ): boolean {
-    if (
-        error.details &&
-        typeof error.details === 'object' &&
-        'requiresRelogin' in error.details &&
-        error.details.requiresRelogin === true
-    ) {
+    const errorDetails =
+        error.details && typeof error.details === 'object'
+            ? (error.details as Record<string, unknown>)
+            : null;
+
+    if (errorDetails?.requiresRelogin === true) {
+        return false;
+    }
+
+    const errorStatusCode =
+        typeof errorDetails?.statusCode === 'number' ? errorDetails.statusCode : undefined;
+    const gatewayCode =
+        typeof errorDetails?.gatewayCode === 'string' ? errorDetails.gatewayCode : undefined;
+
+    if (error.code === AiErrorCode.API_ERROR) {
+        if (gatewayCode && RETRYABLE_PROVIDER_GATEWAY_CODES.has(gatewayCode)) {
+            return true;
+        }
+
+        if (typeof errorStatusCode === 'number' && RETRYABLE_STATUS_CODES.has(errorStatusCode)) {
+            return true;
+        }
+
         return false;
     }
 

--- a/apps/desktop/src/services/AgentService/infrastructure/providers/ai-sdk/base.ts
+++ b/apps/desktop/src/services/AgentService/infrastructure/providers/ai-sdk/base.ts
@@ -91,23 +91,25 @@ export function mapHttpStatusToAiError(
     statusCode: number | undefined,
     message: string
 ): AiError | null {
+    const normalizedMessage = /^HTTP\s+\d{3}\b/i.test(message) ? undefined : message;
+
     switch (statusCode) {
         case 401:
         case 403:
-            return new AiError(AiErrorCode.UNAUTHORIZED, undefined, message);
+            return new AiError(AiErrorCode.UNAUTHORIZED, undefined, normalizedMessage);
         case 408:
-            return new AiError(AiErrorCode.TIMEOUT, undefined, message);
+            return new AiError(AiErrorCode.TIMEOUT, undefined, normalizedMessage);
         case 429:
-            return new AiError(AiErrorCode.RATE_LIMIT, undefined, message);
+            return new AiError(AiErrorCode.RATE_LIMIT, undefined, normalizedMessage);
         case 502:
-            return new AiError(AiErrorCode.BAD_GATEWAY, undefined, message);
+            return new AiError(AiErrorCode.BAD_GATEWAY, undefined, normalizedMessage);
         case 503:
-            return new AiError(AiErrorCode.SERVICE_UNAVAILABLE, undefined, message);
+            return new AiError(AiErrorCode.SERVICE_UNAVAILABLE, undefined, normalizedMessage);
         case 504:
-            return new AiError(AiErrorCode.GATEWAY_TIMEOUT, undefined, message);
+            return new AiError(AiErrorCode.GATEWAY_TIMEOUT, undefined, normalizedMessage);
         default:
             if (statusCode && statusCode >= 500)
-                return new AiError(AiErrorCode.API_ERROR, undefined, message);
+                return new AiError(AiErrorCode.API_ERROR, undefined, normalizedMessage);
             return null;
     }
 }

--- a/apps/desktop/tests/services/AgentService/contracts/errors-i18n.test.ts
+++ b/apps/desktop/tests/services/AgentService/contracts/errors-i18n.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 
 import { setLocale } from '@/i18n';
 import { AiError, AiErrorCode } from '@/services/AgentService/contracts/errors';
+import { mapHttpStatusToAiError } from '@/services/AgentService/infrastructure/providers/ai-sdk/base';
 
 describe('AiError display localization', () => {
     beforeEach(() => {
@@ -75,5 +76,15 @@ describe('AiError display localization', () => {
         );
         expect(error.cause).toBe(rawError);
         expect(error.details).toBe(rawError);
+    });
+
+    it('uses the default localized message for generic HTTP status errors', () => {
+        setLocale('en-US');
+
+        const error = mapHttpStatusToAiError(401, 'HTTP 401');
+
+        expect(error?.code).toBe(AiErrorCode.UNAUTHORIZED);
+        expect(error?.message).toBe(AiError.getMessage(AiErrorCode.UNAUTHORIZED));
+        expect(error?.getDisplayMessage()).toBe('Authentication failed. Check the API key.');
     });
 });

--- a/apps/desktop/tests/services/AgentService/contracts/errors-i18n.test.ts
+++ b/apps/desktop/tests/services/AgentService/contracts/errors-i18n.test.ts
@@ -48,9 +48,7 @@ describe('AiError display localization', () => {
             'No endpoints found that support tool, image, and file inputs'
         );
 
-        expect(error.getDisplayMessage()).toBe(
-            AiError.getMessage(AiErrorCode.UNSUPPORTED_INPUT)
-        );
+        expect(error.getDisplayMessage()).toBe(AiError.getMessage(AiErrorCode.UNSUPPORTED_INPUT));
     });
 
     it('keeps default Error.message stable while exposing localized display text', () => {

--- a/apps/desktop/tests/services/AgentService/contracts/errors-i18n.test.ts
+++ b/apps/desktop/tests/services/AgentService/contracts/errors-i18n.test.ts
@@ -28,16 +28,16 @@ describe('AiError display localization', () => {
     it('keeps provider and API payload messages raw when a custom message is supplied', () => {
         setLocale('en-US');
 
-        const error = new AiError(AiErrorCode.API_ERROR, undefined, '供应商返回的原始错误 payload');
+        const error = new AiError(AiErrorCode.API_ERROR, undefined, 'provider raw payload');
 
-        expect(error.getDisplayMessage()).toBe('供应商返回的原始错误 payload');
+        expect(error.getDisplayMessage()).toBe('provider raw payload');
     });
 
     it('normalizes unsupported input endpoint errors from plain Error objects', () => {
         const error = new Error('No endpoints found that support image input');
 
         expect(AiError.getDisplayMessage(error)).toBe(
-            '当前模型不支持图片/文件输入，请选择合适模型继续。'
+            AiError.getMessage(AiErrorCode.UNSUPPORTED_INPUT)
         );
     });
 
@@ -48,16 +48,34 @@ describe('AiError display localization', () => {
             'No endpoints found that support tool, image, and file inputs'
         );
 
-        expect(error.getDisplayMessage()).toBe('当前模型不支持图片/文件输入，请选择合适模型继续。');
+        expect(error.getDisplayMessage()).toBe(
+            AiError.getMessage(AiErrorCode.UNSUPPORTED_INPUT)
+        );
     });
 
     it('keeps default Error.message stable while exposing localized display text', () => {
         setLocale('en-US');
         const error = new AiError(AiErrorCode.NO_ACTIVE_MODEL);
 
-        expect(error.message).toBe('未配置可用的 AI 模型，请前往设置页面添加模型');
+        expect(error.message).toBe(AiError.getMessage(AiErrorCode.NO_ACTIVE_MODEL));
         expect(error.getDisplayMessage()).toBe(
             'No available AI model is configured. Add a model in Settings.'
         );
+    });
+
+    it('shows the default localized network message for transport failures', () => {
+        setLocale('en-US');
+
+        const rawError = new Error(
+            'error sending request for url (https://hub.touch-ai.org/api/v1/chat/completions)'
+        );
+        const error = AiError.fromError(rawError);
+
+        expect(error.code).toBe(AiErrorCode.NETWORK_ERROR);
+        expect(error.getDisplayMessage()).toBe(
+            'Network connection failed. Check your network settings.'
+        );
+        expect(error.cause).toBe(rawError);
+        expect(error.details).toBe(rawError);
     });
 });

--- a/apps/desktop/tests/services/AgentService/execution/executor.test.ts
+++ b/apps/desktop/tests/services/AgentService/execution/executor.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AiError, AiErrorCode } from '@/services/AgentService/contracts/errors';
+import { AiRequestExecutor } from '@/services/AgentService/execution';
+import type { AttemptCheckpoint } from '@/services/AgentService/execution/executor';
+
+const providerMock = vi.hoisted(() => ({
+    stream: vi.fn(),
+    classifyError: vi.fn(),
+}));
+
+vi.mock('@/services/AgentService/catalog', () => ({
+    createProviderForModel: vi.fn(() => providerMock),
+    resolveToolDefinitions: vi.fn(() => Promise.resolve([])),
+    getModel: vi.fn(),
+}));
+
+function createCheckpoint(): AttemptCheckpoint {
+    return {
+        activeModel: {
+            id: 1,
+            created_at: '',
+            updated_at: '',
+            provider_id: 12,
+            model_id: 'mimo-v2.5',
+            name: 'mimo-v2.5',
+            is_default: 1,
+            last_used_at: null,
+            attachment: 0,
+            modalities: null,
+            open_weights: 0,
+            reasoning: 0,
+            release_date: null,
+            temperature: 1,
+            tool_call: 0,
+            knowledge: null,
+            context_limit: null,
+            output_limit: null,
+            is_custom_metadata: 0,
+            provider_name: 'Xiaomi MiMo',
+            provider_driver: 'mimo',
+            api_endpoint: 'https://hub.touch-ai.org/api/v1',
+            api_key: 'ta_live_test',
+            provider_config_json: '{"touchAiMode":"managed"}',
+            provider_enabled: 1,
+            provider_logo: '',
+        },
+        messages: [{ role: 'user', content: 'hello' }],
+        response: '',
+        reasoning: '',
+        iteration: 0,
+        modelSwitchCount: 0,
+        modelLanguageContext: { locale: 'zh-CN', label: 'Simplified Chinese' },
+        executedBuiltInToolIds: [],
+    };
+}
+
+describe('AiRequestExecutor', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('keeps the original request error when provider error classification fails', async () => {
+        const requestError = new Error(
+            'error sending request for url (https://hub.touch-ai.org/api/v1/chat/completions)'
+        );
+        providerMock.stream.mockImplementation(async function* () {
+            throw requestError;
+        });
+        providerMock.classifyError.mockImplementation(() => {
+            throw new TypeError('n is not a function');
+        });
+
+        const executor = new AiRequestExecutor();
+        const result = await executor.runAttempt({
+            startCheckpoint: createCheckpoint(),
+            persister: {} as never,
+        });
+
+        expect(result.type).toBe('failed');
+        if (result.type !== 'failed') {
+            return;
+        }
+        expect(providerMock.classifyError).toHaveBeenCalledWith(requestError);
+        expect(result.error.code).toBe(AiErrorCode.NETWORK_ERROR);
+        expect(result.error.message).toBe(AiError.getMessage(AiErrorCode.NETWORK_ERROR));
+        expect(result.error.cause).toBe(requestError);
+        expect(result.error.details).toBe(requestError);
+    });
+});

--- a/apps/desktop/tests/services/AgentService/execution/executor.test.ts
+++ b/apps/desktop/tests/services/AgentService/execution/executor.test.ts
@@ -64,9 +64,18 @@ describe('AiRequestExecutor', () => {
         const requestError = new Error(
             'error sending request for url (https://hub.touch-ai.org/api/v1/chat/completions)'
         );
-        providerMock.stream.mockImplementation(async function* () {
-            throw requestError;
-        });
+        providerMock.stream.mockImplementation(
+            () =>
+                ({
+                    [Symbol.asyncIterator]() {
+                        return {
+                            next: async () => {
+                                throw requestError;
+                            },
+                        };
+                    },
+                }) as AsyncIterable<unknown>
+        );
         providerMock.classifyError.mockImplementation(() => {
             throw new TypeError('n is not a function');
         });

--- a/apps/desktop/tests/services/AgentService/execution/retry.test.ts
+++ b/apps/desktop/tests/services/AgentService/execution/retry.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { AiError, AiErrorCode } from '@/services/AgentService/contracts/errors';
+import { shouldRetryRequestFailure } from '@/services/AgentService/execution/retry';
+
+describe('AgentService retry policy', () => {
+    it('does not retry provider business API errors', () => {
+        const error = new AiError(
+            AiErrorCode.API_ERROR,
+            {
+                gatewayCode: 'policy_blocked',
+                statusCode: 403,
+                requiresRelogin: false,
+            },
+            'This activity is not eligible for your account.'
+        );
+
+        expect(shouldRetryRequestFailure(error)).toBe(false);
+    });
+
+    it('retries transient provider gateway failures even when they are generic API errors', () => {
+        const error = new AiError(
+            AiErrorCode.API_ERROR,
+            {
+                gatewayCode: 'upstream_unavailable',
+                statusCode: 503,
+                requiresRelogin: false,
+            },
+            'The upstream provider is temporarily unavailable.'
+        );
+
+        expect(shouldRetryRequestFailure(error)).toBe(true);
+    });
+
+    it('retries generic API errors when provider details carry a retryable HTTP status', () => {
+        const error = new AiError(
+            AiErrorCode.API_ERROR,
+            {
+                statusCode: 503,
+                requiresRelogin: false,
+            },
+            'HTTP 503'
+        );
+
+        expect(shouldRetryRequestFailure(error)).toBe(true);
+    });
+});

--- a/apps/desktop/tests/services/AgentService/execution/retry.test.ts
+++ b/apps/desktop/tests/services/AgentService/execution/retry.test.ts
@@ -44,4 +44,34 @@ describe('AgentService retry policy', () => {
 
         expect(shouldRetryRequestFailure(error)).toBe(true);
     });
+
+    it('retries generic API errors when runtime provider details carry a retryable HTTP status', () => {
+        const error = new AiError(
+            AiErrorCode.API_ERROR,
+            {
+                requiresRelogin: false,
+            },
+            'HTTP 503'
+        );
+
+        expect(
+            shouldRetryRequestFailure(error, {
+                statusCode: 503,
+            })
+        ).toBe(true);
+    });
+
+    it('does not retry when requiresRelogin is true', () => {
+        const error = new AiError(
+            AiErrorCode.API_ERROR,
+            {
+                gatewayCode: 'upstream_unauthorized',
+                statusCode: 503,
+                requiresRelogin: true,
+            },
+            'Managed session expired.'
+        );
+
+        expect(shouldRetryRequestFailure(error)).toBe(false);
+    });
 });

--- a/apps/desktop/tests/services/AgentService/infrastructure/providers/mimo.test.ts
+++ b/apps/desktop/tests/services/AgentService/infrastructure/providers/mimo.test.ts
@@ -232,6 +232,36 @@ describe('MiMoProviderAdapter', () => {
         });
     });
 
+    it('keeps provider business messages raw for managed gateway policy errors', () => {
+        const provider = new MiMoProviderAdapter({
+            apiEndpoint: 'https://hub.touch-ai.org/api/v1',
+            apiKey: 'ta_live_managed_key',
+            config: {
+                touchAiMode: 'managed',
+            },
+        });
+
+        const policyError = provider.classifyError({
+            statusCode: 403,
+            responseBody:
+                '{"error":{"code":"policy_blocked","message":"This activity is not eligible for your account."}}',
+            data: {
+                error: {
+                    code: 'policy_blocked',
+                    message: 'This activity is not eligible for your account.',
+                },
+            },
+            message: 'HTTP 403',
+        });
+
+        expect(policyError).toBeInstanceOf(AiError);
+        expect(policyError?.code).toBe(AiErrorCode.API_ERROR);
+        expect(policyError?.message).toBe('This activity is not eligible for your account.');
+        expect(policyError?.getDisplayMessage()).toBe(
+            'This activity is not eligible for your account.'
+        );
+    });
+
     it('lets the hub validate managed model ids at request time', () => {
         const provider = new MiMoProviderAdapter({
             apiEndpoint: 'https://hub.touch-ai.org/api/v1',


### PR DESCRIPTION
## Summary
- preserve the original request error when provider-specific classification throws during failure handling
- normalize transport-layer request failures into the friendly network error display message while keeping the raw cause for diagnostics
- add regression tests for both the display behavior and the provider-classification failure path

## Related issue or RFC
- Related to https://github.com/TouchAI-org/TouchAI/pull/408

## AI assistance disclosure
- Tool(s) used: Codex / GPT-5
- Scope of assistance: root-cause analysis, targeted code changes, regression tests, and CI follow-up
- Human review or rewrite performed: reviewed and adjusted each affected change before push
- Architecture or boundary impact: no new architecture; small changes in AgentService error handling and tests only

## Testing evidence
- Local: pnpm.cmd --filter @touchai/desktop lint:check (passed with existing warnings only)
- Local: .\\node_modules\\.bin\\vitest.CMD run tests/services/AgentService/contracts/errors-i18n.test.ts tests/services/AgentService/execution/executor.test.ts --configLoader runner (7 tests passed)
- Not run locally: pnpm test:pr, pnpm test:coverage:rust, pnpm test:e2e; relying on CI for broader proof

## Risk notes
- AgentService, runtime, MCP, or schema impact: small AgentService error classification behavior change; no MCP or schema changes
- database baseline or migration impact: none
- release or packaging impact: none expected

## Screenshots or recordings
- none; no UI layout change

## Checklist
- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use [WIP] or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [ ] If this touches AgentService, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran pnpm test:pr for this code PR, or this is a docs-only change.
- [ ] If I changed Rust behavior or tests, I reviewed pnpm test:coverage:rust or relied on CI coverage evidence.
- [ ] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran pnpm test:e2e locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [ ] I updated docs when behavior changed.
