### PR TITLE
fix(desktop): prevent shell vars from rendering as math

### DIFF
--- a/apps/desktop/src/components/MarkdownContent.vue
+++ b/apps/desktop/src/components/MarkdownContent.vue
@@ -154,14 +154,39 @@
     const SHELL_VARIABLE_PATTERN =
         /^\$(?:\{(?:env:)?[A-Za-z_][A-Za-z0-9_]*\}|env:[A-Za-z_][A-Za-z0-9_]*|[A-Za-z_][A-Za-z0-9_]*)/;
 
+    function startsInlineMathSpan(content: string, index: number): boolean {
+        for (let cursor = index + 1; cursor < content.length; cursor += 1) {
+            const char = content[cursor];
+            if (char === '\n') {
+                return false;
+            }
+            if (char === '\\') {
+                cursor += 1;
+                continue;
+            }
+            if (char === '$') {
+                const firstContentChar = content[index + 1];
+                const lastContentChar = content[cursor - 1];
+                return (
+                    cursor > index + 1 &&
+                    firstContentChar !== undefined &&
+                    lastContentChar !== undefined &&
+                    !/\s/.test(firstContentChar) &&
+                    !/\s/.test(lastContentChar)
+                );
+            }
+        }
+
+        return false;
+    }
+
     function shouldEscapeShellVariable(content: string, index: number): boolean {
-        const match = content.slice(index).match(SHELL_VARIABLE_PATTERN);
-        if (!match) {
+        if (startsInlineMathSpan(content, index)) {
             return false;
         }
 
-        const nextChar = content[index + match[0].length];
-        return nextChar !== '$';
+        const match = content.slice(index).match(SHELL_VARIABLE_PATTERN);
+        return match !== null;
     }
 
     function escapeShellVariablesOutsideCode(content: string): string {

--- a/apps/desktop/src/components/MarkdownContent.vue
+++ b/apps/desktop/src/components/MarkdownContent.vue
@@ -151,8 +151,61 @@
         configureMarkstreamLabels(nextLocale);
     });
     const markdownContainerRef = ref<HTMLElement | null>(null);
+    const SHELL_VARIABLE_PATTERN =
+        /^\$(?:\{(?:env:)?[A-Za-z_][A-Za-z0-9_]*\}|env:[A-Za-z_][A-Za-z0-9_]*|[A-Za-z_][A-Za-z0-9_]*)/;
+
+    function shouldEscapeShellVariable(content: string, index: number): boolean {
+        const match = content.slice(index).match(SHELL_VARIABLE_PATTERN);
+        if (!match) {
+            return false;
+        }
+
+        const nextChar = content[index + match[0].length];
+        return nextChar !== '$';
+    }
+
+    function escapeShellVariablesOutsideCode(content: string): string {
+        let result = '';
+        let index = 0;
+        let inFence = false;
+        let inInlineCode = false;
+
+        while (index < content.length) {
+            if (!inInlineCode && content.startsWith('```', index)) {
+                inFence = !inFence;
+                result += '```';
+                index += 3;
+                continue;
+            }
+
+            const char = content[index];
+            if (!inFence && char === '`') {
+                inInlineCode = !inInlineCode;
+                result += char;
+                index += 1;
+                continue;
+            }
+
+            if (
+                !inFence &&
+                !inInlineCode &&
+                char === '$' &&
+                shouldEscapeShellVariable(content, index)
+            ) {
+                result += String.raw`\$`;
+                index += 1;
+                continue;
+            }
+
+            result += char;
+            index += 1;
+        }
+
+        return result;
+    }
+
     const markdownParseInput = computed(() => ({
-        content: props.content,
+        content: escapeShellVariablesOutsideCode(props.content),
         final: props.final,
         locale: locale.value,
     }));

--- a/apps/desktop/tests/components/MarkdownContent-i18n.test.ts
+++ b/apps/desktop/tests/components/MarkdownContent-i18n.test.ts
@@ -88,12 +88,12 @@ describe('MarkdownContent i18n', () => {
         mount(MarkdownContent, {
             props: {
                 content:
-                    'paths: $env:USERPROFILE\\Desktop, $HOME/project, ${USERPROFILE}\\Desktop, ${env:APPDATA}; math: $x$; code: `echo $HOME`',
+                    'paths: $env:USERPROFILE\\Desktop, $HOME/project, ${USERPROFILE}\\Desktop, ${env:APPDATA}; math: $x$ and $x+y$; code: `echo $HOME`',
             },
         });
 
         expect(parseMarkdownToStructureMock).toHaveBeenCalledWith(
-            'paths: \\$env:USERPROFILE\\Desktop, \\$HOME/project, \\${USERPROFILE}\\Desktop, \\${env:APPDATA}; math: $x$; code: `echo $HOME`',
+            'paths: \\$env:USERPROFILE\\Desktop, \\$HOME/project, \\${USERPROFILE}\\Desktop, \\${env:APPDATA}; math: $x$ and $x+y$; code: `echo $HOME`',
             expect.anything(),
             expect.anything()
         );

--- a/apps/desktop/tests/components/MarkdownContent-i18n.test.ts
+++ b/apps/desktop/tests/components/MarkdownContent-i18n.test.ts
@@ -82,6 +82,22 @@ describe('MarkdownContent i18n', () => {
         expect(languageMapMock.mermaid).toBe('Diagram');
     });
 
+    it('escapes shell variables so KaTeX does not treat them as inline math', async () => {
+        const { default: MarkdownContent } = await import('@components/MarkdownContent.vue');
+
+        mount(MarkdownContent, {
+            props: {
+                content:
+                    'paths: $env:USERPROFILE\\Desktop, $HOME/project, ${USERPROFILE}\\Desktop, ${env:APPDATA}; math: $x$; code: `echo $HOME`',
+            },
+        });
+
+        expect(parseMarkdownToStructureMock).toHaveBeenCalledWith(
+            'paths: \\$env:USERPROFILE\\Desktop, \\$HOME/project, \\${USERPROFILE}\\Desktop, \\${env:APPDATA}; math: $x$; code: `echo $HOME`',
+            expect.anything(),
+            expect.anything()
+        );
+    });
     it('updates markstream labels when locale changes after mount', async () => {
         const { setLocale } = await import('@/i18n');
         const { default: MarkdownContent } = await import('@components/MarkdownContent.vue');


### PR DESCRIPTION
## Summary

Prevents shell-style variables in assistant markdown text from being parsed as KaTeX inline math. This keeps paths and commands such as `$env:USERPROFILE\Desktop`, `$HOME/project`, and `${USERPROFILE}\Desktop` rendering as normal text while leaving inline code, fenced code, and closed math like `$x$` unchanged.

## Related issue or RFC

Link the issue or RFC:

- Related to #347

For code changes, link the tracking issue. Only documentation wording, link fixes, or comment-only cleanups may skip the issue-first flow.

## AI assistance disclosure

If AI tools materially assisted this contribution, disclose that here or point to the relevant commit trailer.

- Tool(s) used: Codex
- Scope of assistance: Debugged the markdown/KaTeX rendering issue, implemented the focused parser input guard, and added regression test coverage.
- Human review or rewrite performed: Author reviewed the final diff before opening the PR.
- Architecture or boundary impact: No architecture or cross-boundary changes; scoped to MarkdownContent input normalization.

## Testing evidence

List the commands you ran and the results you observed.

- `pnpm.cmd --filter @touchai/desktop test:unit --run tests/components/MarkdownContent-i18n.test.ts` - passed, 8 tests, in the original workspace with dependencies installed.
- `pnpm.cmd --filter @touchai/desktop test:unit --run tests/views/SearchView/components/ConversationPanel/AssistantMessage.test.ts` - passed, 8 tests, in the original workspace with dependencies installed.
- `git diff --check` - passed in the clean PR worktree.
- `pnpm.cmd --filter @touchai/desktop test:unit --run tests/components/MarkdownContent-i18n.test.ts` in the clean PR worktree could not run because that worktree does not have `node_modules` installed (`vitest` was not recognized).
- `pnpm test:pr` was not run locally; relying on CI for full-suite evidence.

Did you follow TDD (test-first) for feature and fix work? Strongly recommended. See [docs/testing/testing.md](../docs/testing/testing.md).

```text
pnpm test:pr
pnpm test:coverage:rust
pnpm test:e2e
```

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: None.
- database baseline or migration impact: None.
- release or packaging impact: None.

## Screenshots or recordings

N/A. The regression is covered by parser input tests.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [ ] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [ ] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.