### PR TITLE
fix(markdown): keep renderer mounted on final output

### DIFF
--- a/apps/desktop/src/components/MarkdownContent.vue
+++ b/apps/desktop/src/components/MarkdownContent.vue
@@ -186,9 +186,10 @@
         showFontSizeButtons: false,
     });
 
-    const codeBlockMonacoOptions = Object.freeze({
+    const codeBlockMonacoOptions = computed(() => ({
         glyphMargin: false,
-    });
+        autoScrollInitial: !props.final,
+    }));
 
     const codeBlockLightTheme = 'one-light';
     const codeBlockDarkTheme = 'one-dark-pro';

--- a/apps/desktop/src/components/MarkdownContent.vue
+++ b/apps/desktop/src/components/MarkdownContent.vue
@@ -156,10 +156,7 @@
         final: props.final,
         locale: locale.value,
     }));
-    const markdownRenderKey = computed(
-        () =>
-            `${markdownParseInput.value.locale}:${props.variant}:${markdownParseInput.value.final}`
-    );
+    const markdownRenderKey = computed(() => `${markdownParseInput.value.locale}:${props.variant}`);
 
     const nodes = computed<ParsedNode[]>(() => {
         const input = markdownParseInput.value;

--- a/apps/desktop/tests/components/MarkdownContent-i18n.test.ts
+++ b/apps/desktop/tests/components/MarkdownContent-i18n.test.ts
@@ -32,11 +32,12 @@ vi.mock('markdown-it-emoji', () => ({
 vi.mock('markstream-vue', () => ({
     default: {
         name: 'MarkdownRender',
-        props: ['nodes'],
+        props: ['nodes', 'codeBlockMonacoOptions'],
         unmounted() {
             markdownRenderUnmountedMock();
         },
-        template: '<div data-testid="markdown-render">{{ nodes?.[0]?.label ?? "" }}</div>',
+        template:
+            '<div data-testid="markdown-render" :data-code-block-auto-scroll-initial="String(codeBlockMonacoOptions?.autoScrollInitial)">{{ nodes?.[0]?.label ?? "" }}</div>',
     },
     enableKatex: vi.fn(),
     enableMermaid: vi.fn(),
@@ -163,6 +164,34 @@ describe('MarkdownContent i18n', () => {
 
         expect(parseMarkdownToStructureMock).toHaveBeenCalledTimes(2);
         expect(markdownRenderUnmountedMock).not.toHaveBeenCalled();
+    });
+
+    it('disables Monaco initial auto-scroll for completed markdown restored from history', async () => {
+        const { default: MarkdownContent } = await import('@components/MarkdownContent.vue');
+
+        const wrapper = mount(MarkdownContent, {
+            props: {
+                content: '```ts\nconsole.log(1)\n```',
+                final: true,
+            },
+        });
+
+        const renderer = wrapper.get('[data-testid="markdown-render"]');
+        expect(renderer.attributes('data-code-block-auto-scroll-initial')).toBe('false');
+    });
+
+    it('keeps Monaco initial auto-scroll enabled while markdown is still streaming', async () => {
+        const { default: MarkdownContent } = await import('@components/MarkdownContent.vue');
+
+        const wrapper = mount(MarkdownContent, {
+            props: {
+                content: '```ts\nconsole.log(1)',
+                final: false,
+            },
+        });
+
+        const renderer = wrapper.get('[data-testid="markdown-render"]');
+        expect(renderer.attributes('data-code-block-auto-scroll-initial')).toBe('true');
     });
 
     it('marks rendered markdown as not eligible for global DOM localization', async () => {

--- a/apps/desktop/tests/components/MarkdownContent-i18n.test.ts
+++ b/apps/desktop/tests/components/MarkdownContent-i18n.test.ts
@@ -4,20 +4,26 @@ import { nextTick } from 'vue';
 
 import { clipboardService } from '@/services/ClipboardService';
 
-const { languageMapMock, notifyMock, parseMarkdownToStructureMock, setDefaultI18nMapMock } =
-    vi.hoisted(() => {
-        type MarkdownNodeFixture = {
-            type: string;
-            label?: string;
-        };
+const {
+    languageMapMock,
+    markdownRenderUnmountedMock,
+    notifyMock,
+    parseMarkdownToStructureMock,
+    setDefaultI18nMapMock,
+} = vi.hoisted(() => {
+    type MarkdownNodeFixture = {
+        type: string;
+        label?: string;
+    };
 
-        return {
-            languageMapMock: {} as Record<string, string>,
-            notifyMock: vi.fn(),
-            parseMarkdownToStructureMock: vi.fn<() => MarkdownNodeFixture[]>(() => []),
-            setDefaultI18nMapMock: vi.fn(),
-        };
-    });
+    return {
+        languageMapMock: {} as Record<string, string>,
+        markdownRenderUnmountedMock: vi.fn(),
+        notifyMock: vi.fn(),
+        parseMarkdownToStructureMock: vi.fn<() => MarkdownNodeFixture[]>(() => []),
+        setDefaultI18nMapMock: vi.fn(),
+    };
+});
 
 vi.mock('markdown-it-emoji', () => ({
     full: {},
@@ -27,6 +33,9 @@ vi.mock('markstream-vue', () => ({
     default: {
         name: 'MarkdownRender',
         props: ['nodes'],
+        unmounted() {
+            markdownRenderUnmountedMock();
+        },
         template: '<div data-testid="markdown-render">{{ nodes?.[0]?.label ?? "" }}</div>',
     },
     enableKatex: vi.fn(),
@@ -132,6 +141,28 @@ describe('MarkdownContent i18n', () => {
 
         expect(parseMarkdownToStructureMock).toHaveBeenCalledTimes(2);
         expect(wrapper.get('[data-testid="markdown-render"]').text()).toBe('Plain text');
+    });
+
+    it('keeps the markdown renderer mounted when streaming content becomes final', async () => {
+        parseMarkdownToStructureMock.mockImplementation(() => [
+            {
+                type: 'text',
+                label: 'done',
+            },
+        ]);
+        const { default: MarkdownContent } = await import('@components/MarkdownContent.vue');
+
+        const wrapper = mount(MarkdownContent, {
+            props: {
+                content: 'done',
+                final: false,
+            },
+        });
+
+        await wrapper.setProps({ final: true });
+
+        expect(parseMarkdownToStructureMock).toHaveBeenCalledTimes(2);
+        expect(markdownRenderUnmountedMock).not.toHaveBeenCalled();
     });
 
     it('marks rendered markdown as not eligible for global DOM localization', async () => {


### PR DESCRIPTION
## Summary

Fixes the completion-time flash in the desktop conversation view by keeping the markdown renderer mounted when streamed output transitions from live to final.

`MarkdownContent` still re-parses with the final flag, but `MarkdownRender` is no longer keyed by `final`, so long answers and code-heavy responses settle in place instead of remounting.

## Related issue or RFC

Link the issue or RFC:

- Closes #418
- Related to #

For code changes, link the tracking issue. Only documentation wording, link fixes, or comment-only cleanups may skip the issue-first flow.

## AI assistance disclosure

If AI tools materially assisted this contribution, disclose that here or point to the relevant commit trailer.

- Tool(s) used: Codex
- Scope of assistance: Root-cause investigation, patch authoring, regression test, local verification, issue and PR drafting
- Human review or rewrite performed: Pending maintainer/user review
- Architecture or boundary impact: None; frontend rendering behavior only

## Testing evidence

List the commands you ran and the results you observed.

- Every code PR: `pnpm test:pr` (includes type check, lint, format, all tests, and frontend coverage)
- Rust behavior / test changes: `pnpm test:coverage:rust` (requires cargo-tarpaulin, or rely on CI)
- Desktop startup / window / search / popup / settings / E2E harness / workflow changes: `pnpm test:e2e`
- If any command could not run locally, state the exact blocker and rely on CI evidence before merge.

Did you follow TDD (test-first) for feature and fix work? Strongly recommended. See [docs/testing/testing.md](../docs/testing/testing.md).

```text
pnpm exec vitest run tests/components/MarkdownContent-i18n.test.ts --configLoader runner
# Red: failed before the fix because MarkdownRender unmounted when final changed.
# Green: 6 tests passed after the fix.

$env:TEMP='E:\TouchAI\tmp\issue-418-markdown-final-flash'; $env:TMP='E:\TouchAI\tmp\issue-418-markdown-final-flash'; pnpm exec vitest run tests/components/MarkdownContent-i18n.test.ts tests/SearchView/autoShrinkPolicy.test.ts tests/SearchView/windowSizing.test.ts --configLoader runner
# 3 files passed, 30 tests passed.

pnpm exec vue-tsc -p tsconfig.vitest.json --noEmit
# Blocked by pre-existing DesktopContextService test typing errors in the current local workspace:
# tests/services/DesktopContextService/tool-payload.test.ts references clipboard, selectedText, screenshot, and activeWindow on DesktopContextToolPayload without narrowing unavailable payloads.
```

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: None
- database baseline or migration impact: None
- release or packaging impact: None

## Screenshots or recordings

Not included; this is a renderer remount regression covered by unit test.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [ ] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [x] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [x] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.