### PR TITLE
ci: format release please generated files

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -80,6 +80,13 @@ jobs:
               if: ${{ steps.release.outputs.prs_created == 'true' }}
               run: pnpm install --frozen-lockfile
 
+            - name: Sync Release Please lockfile version
+              if: ${{ steps.release.outputs.prs_created == 'true' }}
+              working-directory: apps/desktop
+              run: |
+                  release_version="$(node -e "console.log(JSON.parse(require('node:fs').readFileSync('package.json', 'utf8')).version)")"
+                  node scripts/ci/set-release-version.mjs "$release_version"
+
             - name: Format Release Please generated files
               if: ${{ steps.release.outputs.prs_created == 'true' }}
               run: |
@@ -100,7 +107,7 @@ jobs:
 
                   git config user.name "github-actions[bot]"
                   git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-                  git add .release-please-manifest.json apps/desktop/src-tauri/tauri.conf.json
+                  git add .release-please-manifest.json apps/desktop/src-tauri/Cargo.lock apps/desktop/src-tauri/tauri.conf.json
                   git commit -m "chore: format release please files"
                   git remote set-url origin "https://x-access-token:${RELEASE_PLEASE_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
                   git push origin HEAD:"$RELEASE_PR_BRANCH"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -49,6 +49,62 @@ jobs:
                   config-file: release-please-config.json
                   manifest-file: .release-please-manifest.json
 
+            - name: Read release PR branch
+              if: ${{ steps.release.outputs.prs_created == 'true' }}
+              id: release_pr
+              env:
+                  RELEASE_PRS: ${{ steps.release.outputs.prs }}
+              run: |
+                  release_pr_branch="$(
+                      node -e "const prs = JSON.parse(process.env.RELEASE_PRS || '[]'); const branch = prs[0]?.headBranchName; if (!branch) { throw new Error('Release Please did not expose a release PR branch.'); } console.log(branch);"
+                  )"
+                  echo "branch=$release_pr_branch" >> "$GITHUB_OUTPUT"
+
+            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+              if: ${{ steps.release.outputs.prs_created == 'true' }}
+              with:
+                  ref: ${{ steps.release_pr.outputs.branch }}
+                  token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+                  persist-credentials: false
+
+            - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
+              if: ${{ steps.release.outputs.prs_created == 'true' }}
+
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+              if: ${{ steps.release.outputs.prs_created == 'true' }}
+              with:
+                  node-version: 22
+                  cache: pnpm
+
+            - name: Install dependencies
+              if: ${{ steps.release.outputs.prs_created == 'true' }}
+              run: pnpm install --frozen-lockfile
+
+            - name: Format Release Please generated files
+              if: ${{ steps.release.outputs.prs_created == 'true' }}
+              run: |
+                  pnpm exec prettier --write \
+                    .release-please-manifest.json \
+                    apps/desktop/src-tauri/tauri.conf.json
+
+            - name: Push formatted release PR files
+              if: ${{ steps.release.outputs.prs_created == 'true' }}
+              env:
+                  RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+                  RELEASE_PR_BRANCH: ${{ steps.release_pr.outputs.branch }}
+              run: |
+                  if git diff --quiet; then
+                      echo "Release Please generated files already match repository formatting."
+                      exit 0
+                  fi
+
+                  git config user.name "github-actions[bot]"
+                  git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+                  git add .release-please-manifest.json apps/desktop/src-tauri/tauri.conf.json
+                  git commit -m "chore: format release please files"
+                  git remote set-url origin "https://x-access-token:${RELEASE_PLEASE_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+                  git push origin HEAD:"$RELEASE_PR_BRANCH"
+
     publish-release:
         name: Publish stable release
         needs: release-please

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -83,7 +83,7 @@ jobs:
             - name: Format Release Please generated files
               if: ${{ steps.release.outputs.prs_created == 'true' }}
               run: |
-                  pnpm exec prettier --write \
+                  pnpm exec prettier --write --ignore-path .prettierignore \
                     .release-please-manifest.json \
                     apps/desktop/src-tauri/tauri.conf.json
 

--- a/apps/desktop/tests/ci/release-codeowners-policy.test.ts
+++ b/apps/desktop/tests/ci/release-codeowners-policy.test.ts
@@ -58,6 +58,7 @@ describe('release CODEOWNERS policy', () => {
             '.release-please-manifest.json',
             'apps/desktop/CHANGELOG.md',
             'apps/desktop/package.json',
+            'apps/desktop/src-tauri/Cargo.lock',
             'apps/desktop/src-tauri/Cargo.toml',
             'apps/desktop/src-tauri/tauri.conf.json',
         ];

--- a/apps/desktop/tests/ci/release-workflow-environments.test.ts
+++ b/apps/desktop/tests/ci/release-workflow-environments.test.ts
@@ -28,6 +28,19 @@ describe('release workflow deployment environments', () => {
         expect(workflow).toContain('workflow_dispatch:');
     });
 
+    it('formats Release Please generated files before pushing the release PR branch', async () => {
+        const workflow = await readWorkflow('release-please.yml');
+
+        expect(workflow).toContain('Read release PR branch');
+        expect(workflow).toContain('Format Release Please generated files');
+        expect(workflow).toContain('Push formatted release PR files');
+        expect(workflow).toContain("steps.release.outputs.prs_created == 'true'");
+        expect(workflow).toContain('pnpm exec prettier --write');
+        expect(workflow).toContain('.release-please-manifest.json');
+        expect(workflow).toContain('apps/desktop/src-tauri/tauri.conf.json');
+        expect(workflow).toContain('git push origin HEAD:"$RELEASE_PR_BRANCH"');
+    });
+
     it('keeps stable releases on the protected release environment by default', async () => {
         const workflow = await readWorkflow('velopack-build.yml');
 

--- a/apps/desktop/tests/ci/release-workflow-environments.test.ts
+++ b/apps/desktop/tests/ci/release-workflow-environments.test.ts
@@ -36,6 +36,7 @@ describe('release workflow deployment environments', () => {
         expect(workflow).toContain('Push formatted release PR files');
         expect(workflow).toContain("steps.release.outputs.prs_created == 'true'");
         expect(workflow).toContain('pnpm exec prettier --write');
+        expect(workflow).toContain('--ignore-path .prettierignore');
         expect(workflow).toContain('.release-please-manifest.json');
         expect(workflow).toContain('apps/desktop/src-tauri/tauri.conf.json');
         expect(workflow).toContain('git push origin HEAD:"$RELEASE_PR_BRANCH"');

--- a/apps/desktop/tests/ci/release-workflow-environments.test.ts
+++ b/apps/desktop/tests/ci/release-workflow-environments.test.ts
@@ -32,12 +32,15 @@ describe('release workflow deployment environments', () => {
         const workflow = await readWorkflow('release-please.yml');
 
         expect(workflow).toContain('Read release PR branch');
+        expect(workflow).toContain('Sync Release Please lockfile version');
+        expect(workflow).toContain('node scripts/ci/set-release-version.mjs "$release_version"');
         expect(workflow).toContain('Format Release Please generated files');
         expect(workflow).toContain('Push formatted release PR files');
         expect(workflow).toContain("steps.release.outputs.prs_created == 'true'");
         expect(workflow).toContain('pnpm exec prettier --write');
         expect(workflow).toContain('--ignore-path .prettierignore');
         expect(workflow).toContain('.release-please-manifest.json');
+        expect(workflow).toContain('apps/desktop/src-tauri/Cargo.lock');
         expect(workflow).toContain('apps/desktop/src-tauri/tauri.conf.json');
         expect(workflow).toContain('git push origin HEAD:"$RELEASE_PR_BRANCH"');
     });


### PR DESCRIPTION
## Summary
- Detect the Release Please PR branch from the action output.
- Checkout the release PR branch, sync generated release versions including `Cargo.lock`, run Prettier on generated release files, and push fixes back only when needed.
- Add CI policy tests so the release workflow keeps the auto-format and lockfile-sync steps.

## Related issue or RFC

Related to TouchAI-org/TouchAI#410.

## AI assistance disclosure

- Tool(s) used: Codex.
- Scope of assistance: investigated the repeated Release Please formatting and lockfile drift, edited the release workflow, added CI policy coverage, and ran local verification.
- Human review or rewrite performed: maintainer review still required before merge.
- Architecture or boundary impact: release automation only; no runtime or schema boundary changes.

## Testing evidence

- `pnpm.cmd --filter @touchai/desktop test:unit tests/ci/release-workflow-environments.test.ts` passed.
- `pnpm.cmd --filter @touchai/desktop test:unit tests/ci/release-codeowners-policy.test.ts` passed.
- `pnpm.cmd --filter @touchai/desktop test:typecheck` passed before later targeted release-policy updates.
- `pnpm.cmd run format:check` passed.
- Commit hooks ran `pnpm check:rust` and `pnpm type:check`; both completed, with existing `try_lock_mutex` Rust warnings.
- `pnpm test:pr` was not run locally because this PR only changes release workflow policy and the targeted CI policy/type/format checks cover the changed surface; full CI is running on the PR.
- `pnpm test:e2e` was not run locally because this change does not touch desktop runtime, UI, or E2E paths.

TDD: yes. The release workflow policy test was added first and observed failing before the workflow implementation was added.

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: none.
- database baseline or migration impact: none.
- release or packaging impact: Release Please PR branches will receive an extra commit when generated files do not match repository Prettier style or when `Cargo.lock` needs the released package version synced.

## Screenshots or recordings

Not applicable; CI workflow-only change.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [x] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [ ] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.
