### PR TITLE
ci(release): retry transient binary downloads

### DIFF
--- a/.github/workflows/velopack-build.yml
+++ b/.github/workflows/velopack-build.yml
@@ -237,7 +237,7 @@ jobs:
 
             - name: Build Tauri executable
               working-directory: apps/desktop
-              run: pnpm tauri build --no-bundle --ci
+              run: node scripts/ci/retry-release-command.mjs -- pnpm tauri build --no-bundle --ci
 
             - name: Stage Velopack input directory
               shell: pwsh
@@ -352,7 +352,7 @@ jobs:
 
             - name: Build macOS bundles
               working-directory: apps/desktop
-              run: pnpm tauri build --bundles app,dmg --ci
+              run: node scripts/ci/retry-release-command.mjs -- pnpm tauri build --bundles app,dmg --ci
 
             - name: Stage macOS release assets
               shell: bash
@@ -462,7 +462,7 @@ jobs:
 
             - name: Build Linux bundles
               working-directory: apps/desktop
-              run: pnpm tauri build --bundles appimage,deb,rpm --ci
+              run: node scripts/ci/retry-release-command.mjs -- pnpm tauri build --bundles appimage,deb,rpm --ci
 
             - name: Stage Linux release assets
               shell: bash

--- a/apps/desktop/scripts/ci/retry-release-command.mjs
+++ b/apps/desktop/scripts/ci/retry-release-command.mjs
@@ -1,0 +1,155 @@
+import { spawn } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+
+const DEFAULT_ATTEMPTS = 3;
+const DEFAULT_DELAY_MS = 30_000;
+
+const TRANSIENT_RELEASE_DOWNLOAD_PATTERNS = [
+    /\bhttp status:\s*50[234]\b/i,
+    /\bStatus\(50[234]\b/i,
+    /\b50[234]\s+Gateway\b/i,
+    /\bGateway Time-out\b/i,
+    /\bECONNRESET\b/i,
+    /\bETIMEDOUT\b/i,
+    /\bEAI_AGAIN\b/i,
+    /\bconnection timed out\b/i,
+    /\bnetwork timeout\b/i,
+];
+
+function parsePositiveInteger(value, fallback, label) {
+    if (value === undefined || value === null || value === '') {
+        return fallback;
+    }
+
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isFinite(parsed) || parsed < 1) {
+        throw new Error(`${label} must be a positive integer.`);
+    }
+
+    return parsed;
+}
+
+function sleep(ms) {
+    if (ms <= 0) {
+        return Promise.resolve();
+    }
+
+    return new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+}
+
+export function isTransientReleaseDownloadError(output) {
+    return TRANSIENT_RELEASE_DOWNLOAD_PATTERNS.some((pattern) => pattern.test(output));
+}
+
+export function spawnReleaseCommand(command, args, options = {}) {
+    return new Promise((resolve) => {
+        let output = '';
+        const child = spawn(command, args, {
+            cwd: options.cwd,
+            env: options.env,
+            shell: true,
+            stdio: ['inherit', 'pipe', 'pipe'],
+        });
+
+        child.stdout.on('data', (chunk) => {
+            output += chunk.toString();
+            process.stdout.write(chunk);
+        });
+
+        child.stderr.on('data', (chunk) => {
+            output += chunk.toString();
+            process.stderr.write(chunk);
+        });
+
+        child.on('error', (error) => {
+            output += `${error.message}\n`;
+            process.stderr.write(`${error.message}\n`);
+            resolve({ status: 1, output });
+        });
+
+        child.on('close', (code, signal) => {
+            if (typeof code === 'number') {
+                resolve({ status: code, output });
+                return;
+            }
+
+            output += `Command terminated by signal ${signal ?? 'unknown'}.\n`;
+            resolve({ status: 1, output });
+        });
+    });
+}
+
+export async function runReleaseCommandWithRetry(command, args, options) {
+    const attempts = options.attempts;
+    const delayMs = options.delayMs;
+    const log = options.log ?? console.warn;
+    const spawnCommand =
+        options.spawnCommand ??
+        ((nextCommand, nextArgs) =>
+            spawnReleaseCommand(nextCommand, nextArgs, {
+                cwd: options.cwd,
+                env: options.env,
+            }));
+
+    for (let attempt = 1; attempt <= attempts; attempt += 1) {
+        const result = await spawnCommand(command, args);
+        if (result.status === 0) {
+            return 0;
+        }
+
+        const canRetry = attempt < attempts && isTransientReleaseDownloadError(result.output ?? '');
+        if (!canRetry) {
+            return result.status;
+        }
+
+        log(
+            `Release command failed with a transient download error. Retrying attempt ${
+                attempt + 1
+            }/${attempts} in ${delayMs}ms.`
+        );
+        await sleep(delayMs);
+    }
+
+    return 1;
+}
+
+function parseArgs(argv) {
+    const separatorIndex = argv.indexOf('--');
+    const commandArgs = separatorIndex >= 0 ? argv.slice(separatorIndex + 1) : argv;
+    const [command, ...args] = commandArgs;
+
+    if (!command) {
+        throw new Error('Usage: node scripts/ci/retry-release-command.mjs -- <command> [...args]');
+    }
+
+    return { command, args };
+}
+
+async function main() {
+    const { command, args } = parseArgs(process.argv.slice(2));
+    const status = await runReleaseCommandWithRetry(command, args, {
+        attempts: parsePositiveInteger(
+            process.env.TOUCHAI_RELEASE_COMMAND_ATTEMPTS,
+            DEFAULT_ATTEMPTS,
+            'TOUCHAI_RELEASE_COMMAND_ATTEMPTS'
+        ),
+        delayMs: parsePositiveInteger(
+            process.env.TOUCHAI_RELEASE_COMMAND_RETRY_DELAY_MS,
+            DEFAULT_DELAY_MS,
+            'TOUCHAI_RELEASE_COMMAND_RETRY_DELAY_MS'
+        ),
+        cwd: process.cwd(),
+        env: process.env,
+    });
+
+    process.exit(status);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    main().catch((error) => {
+        console.error(error.message ?? error);
+        process.exit(1);
+    });
+}

--- a/apps/desktop/scripts/ci/retry-release-command.mjs
+++ b/apps/desktop/scripts/ci/retry-release-command.mjs
@@ -3,6 +3,7 @@ import { pathToFileURL } from 'node:url';
 
 const DEFAULT_ATTEMPTS = 3;
 const DEFAULT_DELAY_MS = 30_000;
+const DEFAULT_MAX_OUTPUT_TAIL_BYTES = 128 * 1024;
 
 const TRANSIENT_RELEASE_DOWNLOAD_PATTERNS = [
     /\bhttp status:\s*50[234]\b/i,
@@ -39,13 +40,23 @@ function sleep(ms) {
     });
 }
 
+function appendOutputTail(outputTail, chunk, maxTailBytes) {
+    const nextOutput = `${outputTail}${chunk}`;
+    if (Buffer.byteLength(nextOutput, 'utf8') <= maxTailBytes) {
+        return nextOutput;
+    }
+
+    return Buffer.from(nextOutput, 'utf8').subarray(-maxTailBytes).toString('utf8');
+}
+
 export function isTransientReleaseDownloadError(output) {
     return TRANSIENT_RELEASE_DOWNLOAD_PATTERNS.some((pattern) => pattern.test(output));
 }
 
 export function spawnReleaseCommand(command, args, options = {}) {
     return new Promise((resolve) => {
-        let output = '';
+        const maxTailBytes = options.maxTailBytes ?? DEFAULT_MAX_OUTPUT_TAIL_BYTES;
+        let outputTail = '';
         const child = spawn(command, args, {
             cwd: options.cwd,
             env: options.env,
@@ -54,29 +65,33 @@ export function spawnReleaseCommand(command, args, options = {}) {
         });
 
         child.stdout.on('data', (chunk) => {
-            output += chunk.toString();
+            outputTail = appendOutputTail(outputTail, chunk.toString(), maxTailBytes);
             process.stdout.write(chunk);
         });
 
         child.stderr.on('data', (chunk) => {
-            output += chunk.toString();
+            outputTail = appendOutputTail(outputTail, chunk.toString(), maxTailBytes);
             process.stderr.write(chunk);
         });
 
         child.on('error', (error) => {
-            output += `${error.message}\n`;
+            outputTail = appendOutputTail(outputTail, `${error.message}\n`, maxTailBytes);
             process.stderr.write(`${error.message}\n`);
-            resolve({ status: 1, output });
+            resolve({ status: 1, output: outputTail });
         });
 
         child.on('close', (code, signal) => {
             if (typeof code === 'number') {
-                resolve({ status: code, output });
+                resolve({ status: code, output: outputTail });
                 return;
             }
 
-            output += `Command terminated by signal ${signal ?? 'unknown'}.\n`;
-            resolve({ status: 1, output });
+            outputTail = appendOutputTail(
+                outputTail,
+                `Command terminated by signal ${signal ?? 'unknown'}.\n`,
+                maxTailBytes
+            );
+            resolve({ status: 1, output: outputTail });
         });
     });
 }
@@ -91,6 +106,7 @@ export async function runReleaseCommandWithRetry(command, args, options) {
             spawnReleaseCommand(nextCommand, nextArgs, {
                 cwd: options.cwd,
                 env: options.env,
+                maxTailBytes: options.maxTailBytes,
             }));
 
     for (let attempt = 1; attempt <= attempts; attempt += 1) {
@@ -139,6 +155,11 @@ async function main() {
             process.env.TOUCHAI_RELEASE_COMMAND_RETRY_DELAY_MS,
             DEFAULT_DELAY_MS,
             'TOUCHAI_RELEASE_COMMAND_RETRY_DELAY_MS'
+        ),
+        maxTailBytes: parsePositiveInteger(
+            process.env.TOUCHAI_RELEASE_COMMAND_OUTPUT_TAIL_BYTES,
+            DEFAULT_MAX_OUTPUT_TAIL_BYTES,
+            'TOUCHAI_RELEASE_COMMAND_OUTPUT_TAIL_BYTES'
         ),
         cwd: process.cwd(),
         env: process.env,

--- a/apps/desktop/tests/ci/release-workflow-environments.test.ts
+++ b/apps/desktop/tests/ci/release-workflow-environments.test.ts
@@ -68,6 +68,21 @@ describe('release workflow deployment environments', () => {
         expect(workflow).not.toMatch(/--noInst[\s\S]*--noPortable|--noPortable[\s\S]*--noInst/);
     });
 
+    it('retries release Tauri builds when external binary downloads transiently fail', async () => {
+        const workflow = await readWorkflow('velopack-build.yml');
+
+        expect(workflow).toContain(
+            'node scripts/ci/retry-release-command.mjs -- pnpm tauri build --no-bundle --ci'
+        );
+        expect(workflow).toContain(
+            'node scripts/ci/retry-release-command.mjs -- pnpm tauri build --bundles app,dmg --ci'
+        );
+        expect(workflow).toContain(
+            'node scripts/ci/retry-release-command.mjs -- pnpm tauri build --bundles appimage,deb,rpm --ci'
+        );
+        expect(workflow).not.toMatch(/run:\s+pnpm tauri build/);
+    });
+
     it('attaches public release assets to GitHub releases from the staged asset directory', async () => {
         const workflow = await readWorkflow('velopack-build.yml');
         const uploadLine = workflow.split('\n').find((line) => line.includes('gh release upload'));

--- a/apps/desktop/tests/ci/retry-release-command.test.ts
+++ b/apps/desktop/tests/ci/retry-release-command.test.ts
@@ -1,0 +1,87 @@
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { describe, expect, it, vi } from 'vitest';
+
+type RetryReleaseCommandModule = {
+    isTransientReleaseDownloadError: (output: string) => boolean;
+    runReleaseCommandWithRetry: (
+        command: string,
+        args: string[],
+        options: {
+            attempts: number;
+            delayMs: number;
+            cwd?: string;
+            env?: NodeJS.ProcessEnv;
+            log?: (message: string) => void;
+            spawnCommand: (
+                command: string,
+                args: string[]
+            ) => Promise<{ status: number; output: string }>;
+        }
+    ) => Promise<number>;
+};
+
+async function loadRetryModule(): Promise<RetryReleaseCommandModule | undefined> {
+    try {
+        const modulePath = join(process.cwd(), 'scripts/ci/retry-release-command.mjs');
+        return (await import(pathToFileURL(modulePath).href)) as RetryReleaseCommandModule;
+    } catch {
+        return undefined;
+    }
+}
+
+describe('retry release command', () => {
+    it('recognizes the GitHub 504 failures seen during release binary downloads', async () => {
+        const retryModule = await loadRetryModule();
+
+        expect(retryModule?.isTransientReleaseDownloadError).toBeTypeOf('function');
+        expect(
+            retryModule?.isTransientReleaseDownloadError(
+                'failed to prepare bundled rtk: Status(504, Response[status: 504, status_text: Gateway Time-out])'
+            )
+        ).toBe(true);
+        expect(
+            retryModule?.isTransientReleaseDownloadError(
+                'failed to bundle project `http status: 504`'
+            )
+        ).toBe(true);
+    });
+
+    it('retries transient release download failures and returns the successful status', async () => {
+        const retryModule = await loadRetryModule();
+        const spawnCommand = vi
+            .fn()
+            .mockResolvedValueOnce({
+                status: 1,
+                output: 'failed to bundle project `http status: 504`',
+            })
+            .mockResolvedValueOnce({ status: 0, output: 'release build complete' });
+
+        const status = await retryModule?.runReleaseCommandWithRetry('pnpm', ['tauri', 'build'], {
+            attempts: 3,
+            delayMs: 0,
+            spawnCommand,
+        });
+
+        expect(status).toBe(0);
+        expect(spawnCommand).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not retry non-transient command failures', async () => {
+        const retryModule = await loadRetryModule();
+        const spawnCommand = vi.fn().mockResolvedValue({
+            status: 1,
+            output: 'error[E0425]: cannot find function `resize_search_window` in this scope',
+        });
+
+        const status = await retryModule?.runReleaseCommandWithRetry('pnpm', ['tauri', 'build'], {
+            attempts: 3,
+            delayMs: 0,
+            spawnCommand,
+        });
+
+        expect(status).toBe(1);
+        expect(spawnCommand).toHaveBeenCalledTimes(1);
+    });
+});

--- a/apps/desktop/tests/ci/retry-release-command.test.ts
+++ b/apps/desktop/tests/ci/retry-release-command.test.ts
@@ -1,3 +1,5 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
@@ -5,6 +7,11 @@ import { describe, expect, it, vi } from 'vitest';
 
 type RetryReleaseCommandModule = {
     isTransientReleaseDownloadError: (output: string) => boolean;
+    spawnReleaseCommand: (
+        command: string,
+        args: string[],
+        options: { maxTailBytes?: number }
+    ) => Promise<{ status: number; output: string }>;
     runReleaseCommandWithRetry: (
         command: string,
         args: string[],
@@ -66,6 +73,33 @@ describe('retry release command', () => {
 
         expect(status).toBe(0);
         expect(spawnCommand).toHaveBeenCalledTimes(2);
+    });
+
+    it('keeps only a bounded output tail for long command logs', async () => {
+        const retryModule = await loadRetryModule();
+        const root = await mkdtemp(join(tmpdir(), 'touchai-retry-command-'));
+        const scriptPath = join(root, 'long-output.mjs');
+
+        try {
+            await writeFile(
+                scriptPath,
+                [
+                    "process.stdout.write('x'.repeat(200));",
+                    "process.stderr.write('failed to bundle project http status: 504');",
+                    'process.exit(1);',
+                ].join('')
+            );
+
+            const result = await retryModule?.spawnReleaseCommand('node', [scriptPath], {
+                maxTailBytes: 96,
+            });
+
+            expect(result?.status).toBe(1);
+            expect(result?.output.length).toBeLessThanOrEqual(96);
+            expect(result?.output).toContain('http status: 504');
+        } finally {
+            await rm(root, { recursive: true, force: true });
+        }
     });
 
     it('does not retry non-transient command failures', async () => {


### PR DESCRIPTION
## Summary

Release builds now run Tauri build commands through a retry wrapper that only retries transient external binary download failures.

This covers the failure modes from run 27119209569:

- bundled rtk download returning HTTP 504 during macOS build.rs execution
- Tauri Linux packaging tool downloads returning HTTP 504 during bundling

## Related issue or RFC

- Closes #441

## AI assistance disclosure

- Tool(s) used: Codex
- Scope of assistance: CI failure diagnosis, implementation, tests, and PR drafting
- Human review or rewrite performed: Local diff and test output reviewed before submission
- Architecture or boundary impact: No architecture or runtime boundary changes; CI/release packaging only

## Testing evidence

```text
pnpm --filter @touchai/desktop exec vitest run tests/ci/retry-release-command.test.ts tests/ci/release-workflow-environments.test.ts --configLoader runner
# 2 files passed, 13 tests passed

pnpm --filter @touchai/desktop exec vitest run tests/ci --configLoader runner
# 16 files passed, 62 tests passed

pnpm --filter @touchai/desktop type:check
# passed

pnpm --filter @touchai/desktop test:typecheck
# passed

pnpm --filter @touchai/desktop lint:check
# passed with existing warnings only, 0 errors

pnpm --filter @touchai/desktop format:check
# passed

cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml --all -- --check
# passed

pnpm --filter @touchai/desktop check:rust
# passed with existing unused warnings only

pnpm format:check
# passed
```

`pnpm --filter @touchai/desktop check` was also attempted locally, but the aggregate command timed out after 10 minutes. The equivalent subcommands above were run separately and completed.

Did you follow TDD? Yes: the retry wrapper tests were written and observed failing before the wrapper was implemented.

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: none
- database baseline or migration impact: none
- release or packaging impact: release build commands now retry transient external download failures up to three attempts by default; non-transient build errors still fail immediately

## Screenshots or recordings

Not applicable; CI/release workflow change only.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [x] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [x] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.