### PR TITLE
fix(agent-service): preserve request errors during auth cleanup

### DIFF
--- a/apps/desktop/src/services/AgentService/execution/runtime.ts
+++ b/apps/desktop/src/services/AgentService/execution/runtime.ts
@@ -414,11 +414,19 @@ export class AiConversationRuntime {
             return false;
         }
 
-        const { invalidateManagedAuthForError } = await import('@/services/AuthService');
-        return await invalidateManagedAuthForError({
-            providerId: model.provider_id,
-            error,
-        });
+        try {
+            const { invalidateManagedAuthForError } = await import('@/services/AuthService');
+            return await invalidateManagedAuthForError({
+                providerId: model.provider_id,
+                error,
+            });
+        } catch (authInvalidationError) {
+            console.warn(
+                '[AiConversationRuntime] Failed to invalidate managed auth after request failure:',
+                authInvalidationError
+            );
+            return false;
+        }
     }
 
     /**

--- a/apps/desktop/tests/services/AgentService/execution/runtime.test.ts
+++ b/apps/desktop/tests/services/AgentService/execution/runtime.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AiError, AiErrorCode } from '@/services/AgentService/contracts/errors';
+import { AiConversationRuntime } from '@/services/AgentService/execution/runtime';
+
+const authServiceMock = vi.hoisted(() => ({
+    invalidateManagedAuthForError: vi.fn(),
+}));
+
+vi.mock('@/services/AuthService', () => ({
+    invalidateManagedAuthForError: authServiceMock.invalidateManagedAuthForError,
+}));
+
+function createManagedMimoModel() {
+    return {
+        provider_id: 12,
+        provider_driver: 'mimo',
+        api_endpoint: 'https://hub.touch-ai.org/api/v1',
+        provider_config_json: JSON.stringify({
+            touchAiMode: 'managed',
+            managedAuth: { login: 'user' },
+        }),
+    };
+}
+
+describe('AiConversationRuntime managed auth invalidation', () => {
+    beforeEach(() => {
+        authServiceMock.invalidateManagedAuthForError.mockReset();
+        vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('keeps the original request error when managed auth cleanup fails', async () => {
+        const runtime = new AiConversationRuntime(
+            {} as ConstructorParameters<typeof AiConversationRuntime>[0],
+            {
+                prompt: 'hello',
+            }
+        );
+        const requestError = new AiError(
+            AiErrorCode.UNAUTHORIZED,
+            {
+                gatewayCode: 'invalid_or_revoked_api_key',
+                requiresRelogin: true,
+                statusCode: 401,
+            },
+            'invalid_or_revoked_api_key'
+        );
+        const cleanupError = new TypeError('n is not a function');
+
+        authServiceMock.invalidateManagedAuthForError.mockRejectedValue(cleanupError);
+
+        await expect(
+            (
+                runtime as unknown as {
+                    invalidateManagedAuthIfNeeded: (
+                        model: ReturnType<typeof createManagedMimoModel>,
+                        error: AiError
+                    ) => Promise<boolean>;
+                }
+            ).invalidateManagedAuthIfNeeded(createManagedMimoModel(), requestError)
+        ).resolves.toBe(false);
+
+        expect(authServiceMock.invalidateManagedAuthForError).toHaveBeenCalledWith({
+            providerId: 12,
+            error: requestError,
+        });
+        expect(console.warn).toHaveBeenCalledWith(
+            '[AiConversationRuntime] Failed to invalidate managed auth after request failure:',
+            cleanupError
+        );
+    });
+});


### PR DESCRIPTION
> First external contributors may need to complete the `CLA Assistant` check before merge.
> For code changes, this PR must link the related issue or RFC in the section below.

## Summary

Preserve the original AI request failure when TouchAI managed-auth cleanup fails after a gateway authentication error.

The installed app logs showed MiMo managed requests receiving `401 Unauthorized` / `invalid_or_revoked_api_key`, but the persisted turn error became `n is not a function`. That happened in a secondary cleanup path after the original request failure: if managed-auth invalidation throws, the runtime catch path can persist the cleanup exception instead of the real request error. This PR keeps cleanup failures diagnostic-only so the original request error remains visible to users.

## Related issue or RFC

Link the issue or RFC:

- Related to #411
- Related to #447

No accepted RFC: this is a narrow bug fix in the existing AgentService runtime error-handling path, with no new boundary or architecture.

## AI assistance disclosure

If AI tools materially assisted this contribution, disclose that here or point to the relevant commit trailer.

- Tool(s) used: OpenAI Codex
- Scope of assistance: log/database investigation, test-first regression, implementation, and local verification
- Human review or rewrite performed: local diff reviewed before commit
- Architecture or boundary impact: no new architecture or boundary; preserves existing request-error semantics when auth cleanup fails

## Testing evidence

List the commands you ran and the results you observed.

- TDD red: `pnpm.cmd --filter @touchai/desktop test:unit tests/services/AgentService/execution/runtime.test.ts` -> failed as expected with `TypeError: n is not a function` escaping managed-auth cleanup
- TDD green: `pnpm.cmd --filter @touchai/desktop test:unit tests/services/AgentService/execution/runtime.test.ts` -> 1 file / 1 test passed
- `pnpm.cmd --filter @touchai/desktop test:unit tests/services/AgentService/execution/runtime.test.ts tests/services/AgentService/execution/executor.test.ts tests/services/AgentService/execution/retry.test.ts tests/services/AgentService/execution/retry-i18n.test.ts tests/services/AgentService/infrastructure/providers/mimo.test.ts tests/services/AuthService/index.test.ts tests/services/AgentService/contracts/errors-i18n.test.ts` -> 7 files / 35 tests passed
- `pnpm.cmd --filter @touchai/desktop test:typecheck` -> passed
- `pnpm.cmd --filter @touchai/desktop type:check` -> passed
- `pnpm.cmd --filter @touchai/desktop build` -> passed; existing large chunk and plugin timing warnings only
- `pnpm.cmd test:pr` -> attempted, but failed locally during `pnpm check` at `check:rust` while compiling/linking Rust dependency `aws-lc-sys` with MSVC (`link.exe` exit code 1180 / `cc-rs` `cl.exe` exit code 1). Earlier JS/TS typecheck, lint, format checks in that command completed before the Rust toolchain failure. Relying on CI for the full PR gate.

Did you follow TDD (test-first) for feature and fix work? Strongly recommended. See [docs/testing/testing.md](../docs/testing/testing.md).

```text
pnpm test:pr
pnpm test:coverage:rust
pnpm test:e2e
```

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: AgentService runtime only; managed-auth cleanup failures are now logged and do not replace the original request error.
- database baseline or migration impact: none.
- release or packaging impact: none.

## Screenshots or recordings

No UI screenshot; behavior is covered by unit regression and local installed-app log/database investigation.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [ ] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [x] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [x] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.