### PR TITLE
ci: keep release please PRs green

### DIFF
--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -27,4 +27,5 @@ jobs:
               env:
                   PR_BODY: ${{ github.event.pull_request.body || '' }}
                   PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+                  PR_HEAD_REPO_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name }}
               run: node apps/desktop/scripts/ci/pr-template-check.js

--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -26,4 +26,5 @@ jobs:
             - name: Validate PR body structure and linkage
               env:
                   PR_BODY: ${{ github.event.pull_request.body || '' }}
+                  PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
               run: node apps/desktop/scripts/ci/pr-template-check.js

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -108,7 +108,7 @@ jobs:
                   git config user.name "github-actions[bot]"
                   git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
                   git add .release-please-manifest.json apps/desktop/src-tauri/Cargo.lock apps/desktop/src-tauri/tauri.conf.json
-                  git commit -m "chore: format release please files"
+                  git commit --no-verify -m "chore: format release please files"
                   git remote set-url origin "https://x-access-token:${RELEASE_PLEASE_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
                   git push origin HEAD:"$RELEASE_PR_BRANCH"
 

--- a/apps/desktop/scripts/ci/pr-template-check.js
+++ b/apps/desktop/scripts/ci/pr-template-check.js
@@ -31,6 +31,9 @@ function isReleasePleaseGeneratedBody(body) {
 
 function isReleasePleasePr(body, options) {
     return (
+        options?.headRepoFullName &&
+        options?.baseRepository &&
+        options.headRepoFullName === options.baseRepository &&
         options?.headRef?.startsWith(RELEASE_PLEASE_HEAD_PREFIX) &&
         isReleasePleaseGeneratedBody(body)
     );
@@ -84,6 +87,8 @@ function main() {
     const body = process.env.PR_BODY ?? '';
     const error = validatePrTemplateBody(body, {
         headRef: process.env.PR_HEAD_REF ?? '',
+        headRepoFullName: process.env.PR_HEAD_REPO_FULL_NAME ?? '',
+        baseRepository: process.env.GITHUB_REPOSITORY ?? '',
     });
 
     if (error) {

--- a/apps/desktop/scripts/ci/pr-template-check.js
+++ b/apps/desktop/scripts/ci/pr-template-check.js
@@ -12,9 +12,28 @@ const REQUIRED_HEADERS = [
 
 const ISSUE_REFERENCE_PATTERN =
     /(?:\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|related to)\s+#\d+\b|(?:^|\s)#\d+\b|TouchAI-org\/TouchAI#\d+\b|https:\/\/github\.com\/[^/\s]+\/[^/\s]+(?:\/(?:issues|pull|discussions)\/\d+)?\b)/im;
+const RELEASE_PLEASE_HEAD_PREFIX = 'release-please--branches--';
 
 function normalizeBody(body) {
     return body.replace(/\r\n/g, '\n');
+}
+
+function isReleasePleaseGeneratedBody(body) {
+    const normalizedBody = normalizeBody(body).trim();
+
+    return (
+        normalizedBody.startsWith(':robot: I have created a release *beep* *boop*\n---') &&
+        normalizedBody.includes(
+            'This PR was generated with [Release Please](https://github.com/googleapis/release-please)'
+        )
+    );
+}
+
+function isReleasePleasePr(body, options) {
+    return (
+        options?.headRef?.startsWith(RELEASE_PLEASE_HEAD_PREFIX) &&
+        isReleasePleaseGeneratedBody(body)
+    );
 }
 
 export function extractMarkdownSection(body, header) {
@@ -32,14 +51,20 @@ export function extractMarkdownSection(body, header) {
     return section.trim();
 }
 
-export function validatePrTemplateBody(body) {
+export function validatePrTemplateBody(body, options = {}) {
+    const normalizedBody = normalizeBody(body);
+
+    if (isReleasePleasePr(normalizedBody, options)) {
+        return null;
+    }
+
     for (const header of REQUIRED_HEADERS) {
-        if (!body.includes(header)) {
+        if (!normalizedBody.includes(header)) {
             return `Missing required PR template section: ${header}`;
         }
     }
 
-    const relatedSection = extractMarkdownSection(body, '## Related issue or RFC');
+    const relatedSection = extractMarkdownSection(normalizedBody, '## Related issue or RFC');
     if (relatedSection === null) {
         return 'Missing body for "## Related issue or RFC".';
     }
@@ -57,7 +82,9 @@ export function validatePrTemplateBody(body) {
 
 function main() {
     const body = process.env.PR_BODY ?? '';
-    const error = validatePrTemplateBody(body);
+    const error = validatePrTemplateBody(body, {
+        headRef: process.env.PR_HEAD_REF ?? '',
+    });
 
     if (error) {
         console.error(error);

--- a/apps/desktop/tests/ci/pr-template-check.test.js
+++ b/apps/desktop/tests/ci/pr-template-check.test.js
@@ -30,6 +30,8 @@ describe('validatePrTemplateBody', () => {
         expect(
             validatePrTemplateBody(releasePleaseBody, {
                 headRef: 'release-please--branches--main--components--TouchAI',
+                headRepoFullName: 'TouchAI-org/TouchAI',
+                baseRepository: 'TouchAI-org/TouchAI',
             })
         ).toBeNull();
     });
@@ -38,6 +40,16 @@ describe('validatePrTemplateBody', () => {
         expect(
             validatePrTemplateBody(releasePleaseBody, {
                 headRef: 'feature/release-text',
+            })
+        ).toBe('Missing required PR template section: ## Summary');
+    });
+
+    it('does not allow fork branches to spoof Release Please PRs', () => {
+        expect(
+            validatePrTemplateBody(releasePleaseBody, {
+                headRef: 'release-please--branches--main--components--TouchAI',
+                headRepoFullName: 'attacker/TouchAI',
+                baseRepository: 'TouchAI-org/TouchAI',
             })
         ).toBe('Missing required PR template section: ## Summary');
     });
@@ -74,5 +86,8 @@ describe('PR template check workflow', () => {
         );
 
         expect(workflow).toContain('PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}');
+        expect(workflow).toContain(
+            'PR_HEAD_REPO_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name }}'
+        );
     });
 });

--- a/apps/desktop/tests/ci/pr-template-check.test.js
+++ b/apps/desktop/tests/ci/pr-template-check.test.js
@@ -1,0 +1,78 @@
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { validatePrTemplateBody } from '../../scripts/ci/pr-template-check.js';
+
+const testDirectory = dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = resolve(testDirectory, '../../../..');
+
+const releasePleaseBody = [
+    ':robot: I have created a release *beep* *boop*',
+    '---',
+    '',
+    '',
+    '## [1.1.2](https://github.com/TouchAI-org/TouchAI/compare/v1.1.1...v1.1.2) (2026-06-09)',
+    '',
+    '',
+    '### Bug Fixes',
+    '',
+    '* **agent-service:** preserve request errors during auth cleanup ([#448](https://github.com/TouchAI-org/TouchAI/issues/448)) ([ee1f698](https://github.com/TouchAI-org/TouchAI/commit/ee1f698ff76fbc7bd09104439087b5fc114d032f))',
+    '',
+    '---',
+    'This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).',
+].join('\n');
+
+describe('validatePrTemplateBody', () => {
+    it('allows Release Please generated release PR bodies on the release branch', () => {
+        expect(
+            validatePrTemplateBody(releasePleaseBody, {
+                headRef: 'release-please--branches--main--components--TouchAI',
+            })
+        ).toBeNull();
+    });
+
+    it('does not allow arbitrary branches to bypass the PR template with release text', () => {
+        expect(
+            validatePrTemplateBody(releasePleaseBody, {
+                headRef: 'feature/release-text',
+            })
+        ).toBe('Missing required PR template section: ## Summary');
+    });
+
+    it('continues to require related issue linkage for regular PR templates', () => {
+        const body = [
+            '## Summary',
+            'Adds the thing.',
+            '## Related issue or RFC',
+            'N/A',
+            '## AI assistance disclosure',
+            'No AI assistance.',
+            '## Testing evidence',
+            'pnpm test',
+            '## Risk notes',
+            'Low.',
+            '## Screenshots or recordings',
+            'N/A',
+            '## Checklist',
+            '- [x] Tests pass',
+        ].join('\n');
+
+        expect(validatePrTemplateBody(body, { headRef: 'feature/regular-pr' })).toBe(
+            '"## Related issue or RFC" must include an issue, RFC, or repository link.'
+        );
+    });
+});
+
+describe('PR template check workflow', () => {
+    it('passes the pull request head ref to the validator', async () => {
+        const workflow = await readFile(
+            resolve(repositoryRoot, '.github/workflows/pr-template-check.yml'),
+            'utf8'
+        );
+
+        expect(workflow).toContain('PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}');
+    });
+});

--- a/apps/desktop/tests/ci/release-workflow-environments.test.ts
+++ b/apps/desktop/tests/ci/release-workflow-environments.test.ts
@@ -42,6 +42,9 @@ describe('release workflow deployment environments', () => {
         expect(workflow).toContain('.release-please-manifest.json');
         expect(workflow).toContain('apps/desktop/src-tauri/Cargo.lock');
         expect(workflow).toContain('apps/desktop/src-tauri/tauri.conf.json');
+        expect(workflow).toContain(
+            'git commit --no-verify -m "chore: format release please files"'
+        );
         expect(workflow).toContain('git push origin HEAD:"$RELEASE_PR_BRANCH"');
     });
 


### PR DESCRIPTION
## Summary
Fixes the two release automation failure modes seen on #449:

- allow Release Please generated PR bodies when the PR comes from the release-please branch
- push Release Please formatting commits with `--no-verify` so Husky pre-commit hooks do not block automation-only metadata commits

## Related issue or RFC
Related to #449.

## AI assistance disclosure
AI assisted with CI log analysis, regression tests, and implementation.

## Testing evidence
- `pnpm.cmd --dir apps/desktop exec vitest run --configLoader runner tests/ci/pr-template-check.test.js tests/ci/release-workflow-environments.test.ts`
- `pnpm.cmd format:check`
- `pnpm.cmd lint:check`
- `pnpm.cmd type:check`
- `pnpm.cmd test:typecheck`

## Risk notes
Low. Changes are limited to release/PR CI workflows and PR-template validation for Release Please branches.

## Screenshots or recordings
N/A.

## Checklist
- [x] Added regression tests for Release Please PR template handling.
- [x] Added workflow coverage for `--no-verify` release formatting commits.
- [x] Verified local CI-equivalent frontend checks.