### PR TITLE
fix(desktop): cache browser discovery in settings

### DIFF
--- a/apps/desktop/src-tauri/src/core/browser/process.rs
+++ b/apps/desktop/src-tauri/src/core/browser/process.rs
@@ -8,6 +8,8 @@ use std::{
 
 #[cfg(target_os = "linux")]
 use std::ffi::OsString;
+#[cfg(windows)]
+use std::os::windows::process::CommandExt;
 
 use super::{
     endpoint::BrowserEndpoint,
@@ -17,6 +19,8 @@ use super::{
 use crate::core::system::paths::{app_directory_path, AppDirectory};
 
 const DEFAULT_BROWSER_DATA_DIR_NAME: &str = "browser-data";
+#[cfg(windows)]
+const CREATE_NO_WINDOW: u32 = 0x08000000;
 
 #[derive(Debug)]
 pub struct ManagedBrowserProcess {
@@ -409,7 +413,9 @@ fn windows_registry_browser_paths() -> Vec<(&'static str, &'static str, PathBuf)
     ];
 
     fn query_default_string(key: &str) -> Option<PathBuf> {
-        let output = Command::new("reg")
+        let mut command = Command::new("reg");
+        configure_windows_background_command(&mut command);
+        let output = command
             .args(["query", key, "/ve"])
             .stdin(Stdio::null())
             .stderr(Stdio::null())
@@ -452,7 +458,9 @@ fn windows_registry_browser_paths() -> Vec<(&'static str, &'static str, PathBuf)
 
 #[cfg(windows)]
 fn kill_process_tree(pid: u32) {
-    let _ = Command::new("taskkill")
+    let mut command = Command::new("taskkill");
+    configure_windows_background_command(&mut command);
+    let _ = command
         .args(["/PID", &pid.to_string(), "/T", "/F"])
         .stdin(Stdio::null())
         .stdout(Stdio::null())
@@ -480,6 +488,11 @@ fn kill_process_tree(pid: u32) {
 
 #[cfg(windows)]
 fn configure_child_group(_command: &mut Command) {}
+
+#[cfg(windows)]
+fn configure_windows_background_command(command: &mut Command) {
+    command.creation_flags(CREATE_NO_WINDOW);
+}
 
 #[cfg(unix)]
 fn configure_child_group(command: &mut Command) {

--- a/apps/desktop/src/components/CustomSelect.vue
+++ b/apps/desktop/src/components/CustomSelect.vue
@@ -33,6 +33,7 @@
 
     interface Emits {
         (e: 'update:modelValue', value: T): void;
+        (e: 'update:open', value: boolean): void;
     }
 
     const props = withDefaults(defineProps<Props>(), {
@@ -66,6 +67,11 @@
             selectOption(value as T);
         }
     };
+
+    const handleOpenChange = (value: boolean) => {
+        isOpen.value = value;
+        emit('update:open', value);
+    };
 </script>
 
 <template>
@@ -74,7 +80,7 @@
         :disabled="disabled"
         :open="isOpen"
         @update:model-value="handleSelectValue"
-        @update:open="isOpen = $event"
+        @update:open="handleOpenChange"
     >
         <SelectTrigger
             v-bind="attrs"

--- a/apps/desktop/src/views/SettingsView/components/Browser/index.vue
+++ b/apps/desktop/src/views/SettingsView/components/Browser/index.vue
@@ -3,7 +3,7 @@
     import CustomSelect from '@components/CustomSelect.vue';
     import { open } from '@tauri-apps/plugin-dialog';
     import { storeToRefs } from 'pinia';
-    import { computed, onBeforeUnmount, ref, watch } from 'vue';
+    import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 
     import { type MessageKey, t } from '@/i18n';
     import { native } from '@/services/NativeService';
@@ -21,6 +21,8 @@
     } from '@/stores/setting/sections/browser';
     import { useSettingsStore } from '@/stores/settings';
 
+    import { loadCachedDefaultBrowserDataPath, loadCachedInstalledBrowsers } from './runtimeCache';
+
     defineOptions({ name: 'SettingsBrowserSection' });
 
     const settingsStore = useSettingsStore();
@@ -37,6 +39,8 @@
     const installedBrowsers = ref<BrowserInstalledBrowser[]>([]);
     const browserDiscoveryError = ref<string | null>(null);
     const defaultBrowserDataPath = ref('');
+    const isDiscoveringInstalledBrowsers = ref(false);
+    let isUnmounted = false;
 
     const DEFAULT_BROWSER_VALUE = 'default';
     const CUSTOM_BROWSER_VALUE = 'custom';
@@ -269,30 +273,62 @@
         return parseBrowserSettingsConfig(serializeBrowserSettingsConfig(config));
     }
 
-    void loadInstalledBrowsers();
-    void loadDefaultBrowserDataPath();
-
-    async function loadInstalledBrowsers() {
+    async function loadInstalledBrowsers(options: { force?: boolean } = {}) {
+        const preserveCurrentBrowsers = installedBrowsers.value.length > 0;
+        isDiscoveringInstalledBrowsers.value = true;
         try {
             browserDiscoveryError.value = null;
-            installedBrowsers.value = await native.browser.discoverInstalled();
+            const browsers = await loadCachedInstalledBrowsers(
+                () => native.browser.discoverInstalled(),
+                options
+            );
+            if (isUnmounted) {
+                return;
+            }
+            installedBrowsers.value = browsers;
             const configuredPath = draft.value.browserExecutablePath.trim();
             isEditingCustomBrowserExecutable.value = Boolean(
                 configuredPath && !discoveredBrowserPaths.value.has(configuredPath)
             );
         } catch (error) {
+            if (isUnmounted) {
+                return;
+            }
             browserDiscoveryError.value = error instanceof Error ? error.message : String(error);
-            installedBrowsers.value = [];
+            if (!preserveCurrentBrowsers) {
+                installedBrowsers.value = [];
+            }
+        } finally {
+            if (!isUnmounted) {
+                isDiscoveringInstalledBrowsers.value = false;
+            }
         }
     }
 
     async function loadDefaultBrowserDataPath() {
         try {
-            defaultBrowserDataPath.value = await native.browser.defaultDataPath();
+            const path = await loadCachedDefaultBrowserDataPath(() =>
+                native.browser.defaultDataPath()
+            );
+            if (isUnmounted) {
+                return;
+            }
+            defaultBrowserDataPath.value = path;
         } catch (error) {
+            if (isUnmounted) {
+                return;
+            }
             console.error('[BrowserSettings] Failed to load default browser data path:', error);
             defaultBrowserDataPath.value = '';
         }
+    }
+
+    function handleBrowserExecutableDropdownOpen(open: boolean) {
+        if (!open || isDiscoveringInstalledBrowsers.value) {
+            return;
+        }
+
+        void loadInstalledBrowsers({ force: true });
     }
 
     function normalizeDomain(value: string): string {
@@ -334,7 +370,13 @@
 
     watch(draft, scheduleAutoSave, { deep: true });
 
+    onMounted(() => {
+        void loadInstalledBrowsers();
+        void loadDefaultBrowserDataPath();
+    });
+
     onBeforeUnmount(() => {
+        isUnmounted = true;
         if (autoSaveTimer) {
             clearTimeout(autoSaveTimer);
             autoSaveTimer = null;
@@ -478,6 +520,7 @@
                                     data-testid="browser-executable-select"
                                     :options="browserExecutableOptions"
                                     :disabled="!draft.enabled"
+                                    @update:open="handleBrowserExecutableDropdownOpen"
                                 />
                             </div>
                         </div>

--- a/apps/desktop/src/views/SettingsView/components/Browser/runtimeCache.ts
+++ b/apps/desktop/src/views/SettingsView/components/Browser/runtimeCache.ts
@@ -1,0 +1,60 @@
+import type { BrowserInstalledBrowser } from '@/services/NativeService/types';
+
+let installedBrowsersCache: BrowserInstalledBrowser[] | null = null;
+let installedBrowsersPromise: Promise<BrowserInstalledBrowser[]> | null = null;
+let defaultBrowserDataPathCache: string | null = null;
+let defaultBrowserDataPathPromise: Promise<string> | null = null;
+
+export async function loadCachedInstalledBrowsers(
+    loader: () => Promise<BrowserInstalledBrowser[]>,
+    options: { force?: boolean } = {}
+): Promise<BrowserInstalledBrowser[]> {
+    if (!options.force && installedBrowsersCache) {
+        return installedBrowsersCache;
+    }
+
+    if (installedBrowsersPromise) {
+        return installedBrowsersPromise;
+    }
+
+    installedBrowsersPromise = loader()
+        .then((browsers) => {
+            installedBrowsersCache = browsers;
+            return browsers;
+        })
+        .finally(() => {
+            installedBrowsersPromise = null;
+        });
+
+    return installedBrowsersPromise;
+}
+
+export async function loadCachedDefaultBrowserDataPath(
+    loader: () => Promise<string>
+): Promise<string> {
+    if (defaultBrowserDataPathCache) {
+        return defaultBrowserDataPathCache;
+    }
+
+    if (defaultBrowserDataPathPromise) {
+        return defaultBrowserDataPathPromise;
+    }
+
+    defaultBrowserDataPathPromise = loader()
+        .then((path) => {
+            defaultBrowserDataPathCache = path;
+            return path;
+        })
+        .finally(() => {
+            defaultBrowserDataPathPromise = null;
+        });
+
+    return defaultBrowserDataPathPromise;
+}
+
+export function resetBrowserRuntimeCacheForTests() {
+    installedBrowsersCache = null;
+    installedBrowsersPromise = null;
+    defaultBrowserDataPathCache = null;
+    defaultBrowserDataPathPromise = null;
+}

--- a/apps/desktop/tests/SettingsView/settingsBrowserSection.test.ts
+++ b/apps/desktop/tests/SettingsView/settingsBrowserSection.test.ts
@@ -1,10 +1,11 @@
-import { mockTauriCommand } from '@tests/utils/tauri';
+import { getTauriInvokeCalls, mockTauriCommand } from '@tests/utils/tauri';
 import { flushPromises, mount } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { setLocale } from '@/i18n';
 import BrowserSettingsView from '@/views/SettingsView/components/Browser/index.vue';
+import { resetBrowserRuntimeCacheForTests } from '@/views/SettingsView/components/Browser/runtimeCache';
 
 const updateBrowserSettingsMock = vi.hoisted(() => vi.fn(async () => undefined));
 const browserSettingsPatch = vi.hoisted(() => ({
@@ -40,9 +41,9 @@ vi.mock('@components/CustomSelect.vue', () => ({
     default: {
         name: 'CustomSelect',
         props: ['modelValue', 'options', 'disabled'],
-        emits: ['update:modelValue'],
+        emits: ['update:modelValue', 'update:open'],
         template:
-            '<select data-testid="custom-select" :disabled="disabled" :value="modelValue" @change="$emit(\'update:modelValue\', $event.target.value)"><option v-for="option in options" :key="option.value" :value="option.value">{{ option.label }}{{ option.description ? "|" + option.description : "" }}</option></select>',
+            '<select data-testid="custom-select" :disabled="disabled" :value="modelValue" @focus="$emit(\'update:open\', true)" @blur="$emit(\'update:open\', false)" @change="$emit(\'update:modelValue\', $event.target.value)"><option v-for="option in options" :key="option.value" :value="option.value">{{ option.label }}{{ option.description ? "|" + option.description : "" }}</option></select>',
     },
 }));
 
@@ -51,6 +52,7 @@ describe('Browser settings section', () => {
         setActivePinia(createPinia());
         setLocale('zh-CN');
         vi.useFakeTimers();
+        resetBrowserRuntimeCacheForTests();
         updateBrowserSettingsMock.mockClear();
         browserSettingsPatch.value = {};
         mockTauriCommand('browser_discover_installed', [
@@ -292,6 +294,34 @@ describe('Browser settings section', () => {
             }
         );
         expect(updateBrowserSettingsMock).not.toHaveBeenCalled();
+    });
+
+    it('reuses installed browser discovery across remounts in the same app runtime', async () => {
+        const firstWrapper = mount(BrowserSettingsView);
+        await flushPromises();
+
+        expect(getTauriInvokeCalls('browser_discover_installed')).toHaveLength(1);
+
+        firstWrapper.unmount();
+
+        const secondWrapper = mount(BrowserSettingsView);
+        await flushPromises();
+
+        expect(getTauriInvokeCalls('browser_discover_installed')).toHaveLength(1);
+
+        secondWrapper.unmount();
+    });
+
+    it('refreshes installed browsers asynchronously when the browser selector opens', async () => {
+        const wrapper = mount(BrowserSettingsView);
+        await flushPromises();
+
+        expect(getTauriInvokeCalls('browser_discover_installed')).toHaveLength(1);
+
+        await wrapper.get('[data-testid="browser-executable-select"]').trigger('focus');
+        await flushPromises();
+
+        expect(getTauriInvokeCalls('browser_discover_installed')).toHaveLength(2);
     });
 
     it('renders and saves the existing browser session policy', async () => {


### PR DESCRIPTION
> First external contributors may need to complete the `CLA Assistant` check before merge.
> For code changes, this PR must link the related issue or RFC in the section below.

## Summary

- Cache installed-browser discovery and the default browser data path for the current app runtime so Settings tab switches do not repeatedly invoke native discovery.
- Refresh installed browsers asynchronously when the browser executable dropdown opens, while preserving existing options if refresh fails.
- Run Windows `reg query` and `taskkill` helper commands with `CREATE_NO_WINDOW` so browser discovery/cleanup does not flash command windows or surface `reg.exe` dialogs.

## Related issue or RFC

Link the issue or RFC:

- Related to #444

For code changes, link the tracking issue. Only documentation wording, link fixes, or comment-only cleanups may skip the issue-first flow.

## AI assistance disclosure

If AI tools materially assisted this contribution, disclose that here or point to the relevant commit trailer.

- Tool(s) used: Codex
- Scope of assistance: implementation, local verification, PR description drafting
- Human review or rewrite performed: changes were reviewed during local testing and before commit
- Architecture or boundary impact: no new cross-boundary abstraction; adds a small browser settings runtime cache and one select open-state event

## Testing evidence

List the commands you ran and the results you observed.

- `pnpm exec vitest run --configLoader runner tests/SettingsView/settingsBrowserSection.test.ts --passWithNoTests` from `apps/desktop`: passed, 1 file / 15 tests.
- `cargo check --manifest-path src-tauri/Cargo.toml --lib` from `apps/desktop`: passed.
- `pnpm test:pr` from repo root: desktop checks passed through type check, test type check, lint check, format check, Rust check, 152 frontend test files / 963 tests, Rust tests, and frontend coverage. The final monorepo step failed at `@touchai/site build` because this local environment does not resolve the `astro` command (`'astro' is not recognized as an internal or external command`).
- Manual startup: `pnpm tauri dev` launched successfully after freeing local disk space; verified `target\\debug\\TouchAI.exe` and Vite `localhost:1420` were running.
- `pnpm test:e2e`: not run locally; this local desktop E2E harness was not exercised after the targeted/manual verification above, so CI is the first full E2E proof.

Did you follow TDD (test-first) for feature and fix work? Strongly recommended. See [docs/testing/testing.md](../docs/testing/testing.md).

```text
pnpm exec vitest run --configLoader runner tests/SettingsView/settingsBrowserSection.test.ts --passWithNoTests
cargo check --manifest-path src-tauri/Cargo.toml --lib
pnpm test:pr
```

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: limited browser runtime process-spawn behavior change on Windows; no AgentService, MCP, or schema impact.
- database baseline or migration impact: none.
- release or packaging impact: low; Windows helper process spawning now uses hidden/background creation flags for registry and taskkill helpers.

## Screenshots or recordings

No screenshots; behavior is a settings performance/process-spawn fix.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [ ] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [x] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [x] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [ ] I updated docs when behavior changed.