### PR TITLE
ci(release): split update asset upload storage

### DIFF
--- a/.github/workflows/velopack-build.yml
+++ b/.github/workflows/velopack-build.yml
@@ -588,6 +588,11 @@ jobs:
                     --release-notes-file "$RUNNER_TEMP/release-notes/release-notes.md" \
                     --release-dir "$RUNNER_TEMP/touchai-release-assets"
 
+            - name: Stage current GitHub release assets
+              working-directory: apps/desktop
+              run: |
+                  node scripts/ci/stage-release-upload-assets.mjs "$RUNNER_TEMP/touchai-release-assets" "$RUNNER_TEMP/touchai-github-release-assets" "${{ inputs.version }}"
+
             - name: Upload public release assets to GitHub release
               shell: bash
               env:
@@ -595,7 +600,7 @@ jobs:
                   RELEASE_TAG: ${{ inputs.tag }}
               run: |
                   set -euo pipefail
-                  release_dir="$RUNNER_TEMP/touchai-release-assets"
+                  release_dir="$RUNNER_TEMP/touchai-github-release-assets"
                   shopt -s nullglob
                   assets=("$release_dir"/*)
                   if [ ${#assets[@]} -eq 0 ]; then

--- a/apps/desktop/scripts/ci/build-update-channels.mjs
+++ b/apps/desktop/scripts/ci/build-update-channels.mjs
@@ -2,6 +2,8 @@ import { copyFile, mkdir, readdir, readFile, rm, stat, writeFile } from 'node:fs
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
+import { versionFromAssetName } from '../update-release-assets.mjs';
+
 const REQUIRED_SEVERITIES = ['critical', 'security', 'recommended'];
 const DOWNLOAD_KINDS = ['installer', 'fullPackage', 'deltaPackage', 'updatePackage', 'asset'];
 const SEMVER_PATTERN =
@@ -433,7 +435,7 @@ function feedOutput(product, channel, channelConfig, generatedAt, options) {
     };
 }
 
-async function copyReleaseAssets(releaseDir, outputDir) {
+async function copyReleaseAssets(releaseDir, outputDir, version) {
     if (!releaseDir) {
         return;
     }
@@ -447,6 +449,9 @@ async function copyReleaseAssets(releaseDir, outputDir) {
             continue;
         }
         if (!downloadKindFromFileName(entry.name)) {
+            continue;
+        }
+        if (version && versionFromAssetName(entry.name) !== version) {
             continue;
         }
         await copyFile(join(releaseDir, entry.name), join(outputDir, entry.name));
@@ -498,7 +503,7 @@ export async function buildUpdateChannels(projectRoot, outputRoot, now = new Dat
 
     await rm(outputRoot, { recursive: true, force: true });
     await mkdir(outputDir, { recursive: true });
-    await copyReleaseAssets(release?.releaseDir, outputDir);
+    await copyReleaseAssets(release?.releaseDir, outputDir, release?.version ?? null);
 
     for (const [channel, channelConfig] of channelEntries(updates.channels)) {
         const output = feedOutput(product, channel, channelConfig, generatedAt, {

--- a/apps/desktop/scripts/ci/stage-release-upload-assets.d.mts
+++ b/apps/desktop/scripts/ci/stage-release-upload-assets.d.mts
@@ -1,0 +1,5 @@
+export function stageReleaseUploadAssets(
+    releaseDir: string,
+    outputDir: string,
+    options: { version: string }
+): Promise<string[]>;

--- a/apps/desktop/scripts/ci/stage-release-upload-assets.mjs
+++ b/apps/desktop/scripts/ci/stage-release-upload-assets.mjs
@@ -1,0 +1,64 @@
+import { copyFile, mkdir, readdir, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import {
+    assertNonEmptyString,
+    isDownloadAssetName,
+    versionFromAssetName,
+} from '../update-release-assets.mjs';
+
+function currentReleaseAssetName(fileName, version) {
+    return isDownloadAssetName(fileName) && versionFromAssetName(fileName) === version;
+}
+
+export async function stageReleaseUploadAssets(releaseDir, outputDir, options) {
+    assertNonEmptyString(releaseDir, 'release directory');
+    assertNonEmptyString(outputDir, 'output directory');
+    assertNonEmptyString(options?.version, 'release version');
+
+    await rm(outputDir, { recursive: true, force: true });
+    await mkdir(outputDir, { recursive: true });
+
+    const entries = await readdir(releaseDir, { withFileTypes: true });
+    const stagedNames = [];
+    for (const entry of entries) {
+        if (!entry.isFile() || !currentReleaseAssetName(entry.name, options.version)) {
+            continue;
+        }
+
+        await copyFile(join(releaseDir, entry.name), join(outputDir, entry.name));
+        stagedNames.push(entry.name);
+    }
+
+    stagedNames.sort((left, right) => left.localeCompare(right));
+    if (stagedNames.length === 0) {
+        throw new Error(`No current-version release assets found for ${options.version}.`);
+    }
+
+    return stagedNames;
+}
+
+function parseArgs(argv) {
+    const [releaseDir, outputDir, version] = argv;
+    if (!releaseDir || !outputDir || !version) {
+        throw new Error(
+            'Usage: node scripts/ci/stage-release-upload-assets.mjs <release-dir> <output-dir> <version>'
+        );
+    }
+
+    return { releaseDir, outputDir, version };
+}
+
+async function main() {
+    const { releaseDir, outputDir, version } = parseArgs(process.argv.slice(2));
+    const stagedNames = await stageReleaseUploadAssets(releaseDir, outputDir, { version });
+    console.log(`Staged ${stagedNames.length} current-version release asset(s) for ${version}.`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    main().catch((error) => {
+        console.error(error.message ?? error);
+        process.exit(1);
+    });
+}

--- a/apps/desktop/tests/ci/build-update-channels.test.ts
+++ b/apps/desktop/tests/ci/build-update-channels.test.ts
@@ -645,6 +645,9 @@ describe('buildUpdateChannels', () => {
             'manifest.json',
             'notes.md',
             'random.txt',
+            'TouchAI-beta-0.2.1-beta.1-windows-full.nupkg',
+            'TouchAI-beta-0.2.1-beta.1-windows-delta.nupkg',
+            'TouchAI-0.2.0-windows-full.nupkg',
         ];
 
         await mkdir(releaseDir, { recursive: true });

--- a/apps/desktop/tests/ci/release-workflow-environments.test.ts
+++ b/apps/desktop/tests/ci/release-workflow-environments.test.ts
@@ -90,8 +90,12 @@ describe('release workflow deployment environments', () => {
         const workflow = await readWorkflow('velopack-build.yml');
         const uploadLine = workflow.split('\n').find((line) => line.includes('gh release upload'));
 
+        expect(workflow).toContain('Stage current GitHub release assets');
+        expect(workflow).toContain(
+            'node scripts/ci/stage-release-upload-assets.mjs "$RUNNER_TEMP/touchai-release-assets" "$RUNNER_TEMP/touchai-github-release-assets" "${{ inputs.version }}"'
+        );
         expect(workflow).toContain('gh release upload "$RELEASE_TAG" "${assets[@]}" --clobber');
-        expect(workflow).toContain('release_dir="$RUNNER_TEMP/touchai-release-assets"');
+        expect(workflow).toContain('release_dir="$RUNNER_TEMP/touchai-github-release-assets"');
         expect(uploadLine).toBeDefined();
         expect(uploadLine ?? '').not.toContain('touchai-update-dist');
     });

--- a/apps/desktop/tests/ci/stage-release-upload-assets.test.ts
+++ b/apps/desktop/tests/ci/stage-release-upload-assets.test.ts
@@ -1,0 +1,92 @@
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+type StageReleaseUploadAssets = (
+    releaseDir: string,
+    outputDir: string,
+    options: { version: string }
+) => Promise<string[]>;
+
+async function loadStager(): Promise<StageReleaseUploadAssets | undefined> {
+    try {
+        const module = await import('../../scripts/ci/stage-release-upload-assets.mjs');
+        return module.stageReleaseUploadAssets as StageReleaseUploadAssets;
+    } catch {
+        return undefined;
+    }
+}
+
+async function createFixture() {
+    const root = await mkdtemp(join(tmpdir(), 'touchai-release-upload-assets-'));
+    const releaseDir = join(root, 'release');
+    const outputDir = join(root, 'github-release');
+    await mkdir(releaseDir, { recursive: true });
+    return { root, releaseDir, outputDir };
+}
+
+describe('stageReleaseUploadAssets', () => {
+    it('copies only current-version download assets for the GitHub release archive', async () => {
+        const stageReleaseUploadAssets = await loadStager();
+        const { root, releaseDir, outputDir } = await createFixture();
+        const copiedNames = [
+            'TouchAI-1.2.0-windows.msi',
+            'TouchAI-1.2.0-windows-full.nupkg',
+            'TouchAI-1.2.0-windows-delta.nupkg',
+            'TouchAI-1.2.0-macos.dmg',
+            'TouchAI-1.2.0-linux.AppImage',
+        ];
+        const ignoredNames = [
+            'TouchAI-1.1.1-windows-full.nupkg',
+            'TouchAI-1.1.1-windows-delta.nupkg',
+            'TouchAI-beta-1.3.0-beta.1-windows-full.nupkg',
+            'releases.stable.json',
+            'RELEASES',
+            'random.txt',
+        ];
+
+        for (const name of [...copiedNames, ...ignoredNames]) {
+            await writeFile(join(releaseDir, name), `asset:${name}`, 'utf8');
+        }
+        const expectedCopiedNames = [...copiedNames].sort((left, right) =>
+            left.localeCompare(right)
+        );
+
+        try {
+            expect(stageReleaseUploadAssets).toBeTypeOf('function');
+            await expect(
+                stageReleaseUploadAssets?.(releaseDir, outputDir, { version: '1.2.0' })
+            ).resolves.toEqual(expectedCopiedNames);
+
+            await expect(readdir(outputDir).then((names) => names.sort())).resolves.toEqual(
+                expectedCopiedNames
+            );
+            for (const name of copiedNames) {
+                await expect(readFile(join(outputDir, name), 'utf8')).resolves.toBe(
+                    `asset:${name}`
+                );
+            }
+        } finally {
+            await rm(root, { recursive: true, force: true });
+        }
+    });
+
+    it('fails fast when a release has no current-version download assets', async () => {
+        const stageReleaseUploadAssets = await loadStager();
+        const { root, releaseDir, outputDir } = await createFixture();
+
+        await writeFile(join(releaseDir, 'TouchAI-1.1.1-windows-full.nupkg'), 'old', 'utf8');
+        await writeFile(join(releaseDir, 'releases.stable.json'), '{}', 'utf8');
+
+        try {
+            expect(stageReleaseUploadAssets).toBeTypeOf('function');
+            await expect(
+                stageReleaseUploadAssets?.(releaseDir, outputDir, { version: '1.2.0' })
+            ).rejects.toThrow('No current-version release assets found for 1.2.0.');
+        } finally {
+            await rm(root, { recursive: true, force: true });
+        }
+    });
+});


### PR DESCRIPTION
﻿## Summary

Split release asset storage so GitHub Releases remain per-version cold archives, while R2 only carries the hot update feed and current-version downloadable assets.

- Keep the full Velopack staging directory for feed generation, including hydrated history.
- Upload only current-version downloadable assets to the matching GitHub Release.
- Copy only current-version downloadable assets into update-dist for R2 deployment; older feed entries can resolve through the existing Worker GitHub fallback.
- Add CI tests for GitHub upload filtering, R2 update-dist filtering, and workflow wiring.

## Related issue or RFC

- Closes #457

## AI assistance disclosure

- Tool(s) used: Codex
- Scope of assistance: release workflow diagnosis, CI script implementation, and test updates
- Human review or rewrite performed: diff and test output reviewed locally before PR creation
- Architecture or boundary impact: release/package CI only; no AgentService, runtime, MCP, or schema impact

## Testing evidence

```text
pnpm --filter @touchai/desktop exec vitest run --configLoader runner --testTimeout 20000 tests/ci
# 18 files, 70 tests passed; command exited 0, with a trailing local Vite 504 diagnostic

pnpm --filter @touchai/desktop exec vitest run --configLoader runner --passWithNoTests --testTimeout 20000
# 156 files, 976 tests passed; command exited 0, with a trailing local Vite 504 diagnostic

pnpm --filter @touchai/desktop test:typecheck
# passed

pnpm --filter @touchai/desktop lint:check
# passed with existing Vue warnings, 0 errors

pnpm format:check
# passed
```

`pnpm --filter @touchai/desktop test:unit` did not complete cleanly under the default 5s Vitest timeout in this local worktree; the equivalent command with `--testTimeout 20000` passed. `npx tsc --noEmit` timed out locally, while the repository typecheck command above passed.

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: none
- database baseline or migration impact: none
- release or packaging impact: GitHub release uploads now exclude hydrated historical `.nupkg` files; R2 deploy artifacts contain current-version downloads plus feed files, with older assets expected to be served from GitHub Release fallback when not hot in R2

## Screenshots or recordings

Not applicable; release CI change only.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [ ] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [x] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.
