### PR TITLE
fix: hide model dropdown popup on unmount

### DIFF
--- a/apps/desktop/src/views/SearchView/composables/useModelDropdownPopup.ts
+++ b/apps/desktop/src/views/SearchView/composables/useModelDropdownPopup.ts
@@ -204,12 +204,29 @@ export function useModelDropdownPopup(options: UseModelDropdownPopupOptions) {
 
     onUnmounted(() => {
         disposed = true;
+        const closingIdentity =
+            activePopupId !== null
+                ? {
+                      popupId: activePopupId,
+                      windowLabel: 'popup-model-dropdown-popup',
+                      popupSessionVersion: parsePopupSessionVersion(activePopupId),
+                  }
+                : null;
+        const shouldHidePopup = hasActivePopupSession || isOpen.value;
         cleanupFn?.();
         cleanupFn = null;
         activePopupId = null;
         hasActivePopupSession = false;
         isOpen.value = false;
         onPopupSessionEnd?.();
+
+        if (!shouldHidePopup || !closingIdentity) {
+            return;
+        }
+
+        void popupManager.hide(closingIdentity).catch((error) => {
+            console.error('[SearchView] Failed to hide model dropdown popup on unmount:', error);
+        });
     });
 
     /**

--- a/apps/desktop/tests/composables/SearchView/useModelDropdownPopup.test.ts
+++ b/apps/desktop/tests/composables/SearchView/useModelDropdownPopup.test.ts
@@ -216,6 +216,31 @@ describe('useModelDropdownPopup', () => {
         mounted.unmount();
     });
 
+    it('hides the current popup session on unmount when the popup is still open', async () => {
+        const onPopupSessionEnd = vi.fn();
+        const mounted = await mountComposable(() =>
+            useModelDropdownPopup({
+                getAnchorElement: () => document.createElement('button'),
+                getPopupData: () => createPopupData(),
+                isModelDropdownActive: () => true,
+                onModelSelect: () => undefined,
+                onModelSearchQueryChange: () => undefined,
+                onClose: () => undefined,
+                onPopupSessionEnd,
+            })
+        );
+
+        await mounted.result.open();
+        mounted.unmount();
+
+        expect(popupManager.hide).toHaveBeenCalledWith({
+            popupId: 'popup-model-dropdown-popup:1',
+            popupSessionVersion: 1,
+            windowLabel: 'popup-model-dropdown-popup',
+        });
+        expect(onPopupSessionEnd).toHaveBeenCalledTimes(1);
+    });
+
     it('closes the active popup session with the current identity', async () => {
         const onPopupSessionEnd = vi.fn();
         const mounted = await mountComposable(() =>


### PR DESCRIPTION
## Summary

- Hide the active model dropdown popup when its composable unmounts.
- Add a regression test for the open-popup unmount cleanup path.

## Related issue or RFC

Related to https://github.com/TouchAI-org/TouchAI

## AI assistance disclosure

- Tool(s) used: AI assistant
- Scope of assistance: bug identification, patch drafting, and local verification
- Human review or rewrite performed: reviewed the diff and test output before publishing
- Architecture or boundary impact: none

## Testing evidence

```text
Vitest targeted: tests/composables/SearchView/useModelDropdownPopup.test.ts --pool=threads passed (7 tests)
Prettier check passed for the changed files
git diff --check passed
```

`pnpm test:pr` did not run locally because the Windows environment only exposed pnpm through Corepack and the Git hook expected a direct pnpm shim. CI is expected to provide the full proof for the broader suite.

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: none
- database baseline or migration impact: none
- release or packaging impact: none

## Screenshots or recordings

Not applicable; this is popup lifecycle cleanup covered by unit tests.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [ ] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [ ] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.