### PR TITLE
fix: match release asset versions exactly

### DIFF
--- a/apps/desktop/scripts/ci/build-update-channels.mjs
+++ b/apps/desktop/scripts/ci/build-update-channels.mjs
@@ -320,7 +320,7 @@ async function releaseDownloadsFromDirectory(product, releaseDir, version) {
             continue;
         }
 
-        if (version && !entry.name.includes(version)) {
+        if (version && versionFromAssetName(entry.name) !== version) {
             continue;
         }
 

--- a/apps/desktop/tests/ci/build-update-channels.test.ts
+++ b/apps/desktop/tests/ci/build-update-channels.test.ts
@@ -268,6 +268,7 @@ describe('buildUpdateChannels', () => {
         const installerName = 'TouchAI-beta-0.1.1-beta.1-windows.msi';
         const fullPackageName = 'TouchAI-beta-0.1.1-beta.1-windows-full.nupkg';
         const deltaPackageName = 'TouchAI-beta-0.1.1-beta.1-windows-delta.nupkg';
+        const stalePrefixMatchName = 'TouchAI-beta-0.1.1-beta.10-windows-full.nupkg';
         const releaseTag = 'v0.1.1-beta.1';
         const expectedReleaseUrl = `${productFixture.repository.releasesUrl}/tag/${releaseTag}`;
         const expectedDownloadBaseUrl = productFixture.services.updates.baseUrl.replace(
@@ -279,6 +280,7 @@ describe('buildUpdateChannels', () => {
         await writeFile(join(releaseDir, installerName), 'installer');
         await writeFile(join(releaseDir, fullPackageName), 'full');
         await writeFile(join(releaseDir, deltaPackageName), 'delta');
+        await writeFile(join(releaseDir, stalePrefixMatchName), 'stale full');
         await writeFile(
             join(releaseDir, 'releases.beta.json'),
             JSON.stringify(


### PR DESCRIPTION
## Summary

- Match release asset versions with the parsed asset version instead of substring matching.
- Add a regression fixture where `0.1.1-beta.10` must not be included in the `0.1.1-beta.1` feed downloads.

## Related issue or RFC

Related to https://github.com/TouchAI-org/TouchAI

## AI assistance disclosure

- Tool(s) used: AI assistant
- Scope of assistance: bug identification, patch drafting, and local verification
- Human review or rewrite performed: reviewed the diff and test output before publishing
- Architecture or boundary impact: none

## Testing evidence

```text
Vitest targeted: tests/ci/build-update-channels.test.ts --pool=vmThreads --fileParallelism=false passed (9 tests)
Prettier check passed for the changed files
ESLint passed for the changed files
git diff --check passed
```

`pnpm test:pr` did not run locally because the Windows environment only exposes pnpm through Corepack while the hook expects a direct pnpm shim. CI should provide full-suite proof before merge.

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: none
- database baseline or migration impact: none
- release or packaging impact: release feed generation now excludes only wrong-version assets more strictly

## Screenshots or recordings

Not applicable; this changes release feed generation logic covered by unit tests.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [ ] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [x] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.