### PR TITLE
fix: ignore unsafe hydrated release assets

### DIFF
--- a/apps/desktop/scripts/ci/hydrate-velopack-history.d.mts
+++ b/apps/desktop/scripts/ci/hydrate-velopack-history.d.mts
@@ -1,0 +1,5 @@
+export function hydrateVelopackHistory(
+    projectRoot: string,
+    releaseDir: string,
+    channel: string
+): Promise<void>;

--- a/apps/desktop/scripts/ci/hydrate-velopack-history.mjs
+++ b/apps/desktop/scripts/ci/hydrate-velopack-history.mjs
@@ -58,10 +58,22 @@ function updateAssetUrl(product, fileName) {
     return `${product.services.updates.baseUrl.replace(/\/+$/g, '')}/${encodeURIComponent(fileName)}`;
 }
 
+function isSafeAssetFileName(fileName) {
+    return (
+        typeof fileName === 'string' &&
+        fileName.trim() === fileName &&
+        fileName.length > 0 &&
+        !/[\\/]/u.test(fileName) &&
+        fileName !== '.' &&
+        fileName !== '..'
+    );
+}
+
 function isVelopackPackage(asset) {
     return (
         asset &&
         typeof asset.FileName === 'string' &&
+        isSafeAssetFileName(asset.FileName) &&
         asset.FileName.toLowerCase().endsWith('.nupkg')
     );
 }
@@ -83,9 +95,14 @@ export async function hydrateVelopackHistory(projectRoot, releaseDir, channel) {
 
     const feedText = await feedResponse.text();
     const feed = JSON.parse(feedText);
-    await writeFile(join(releaseDir, feedName), `${JSON.stringify(feed, null, 4)}\n`, 'utf8');
-
     const assets = Array.isArray(feed.Assets) ? feed.Assets.filter(isVelopackPackage) : [];
+    const hydratedFeed = Array.isArray(feed.Assets) ? { ...feed, Assets: assets } : feed;
+    await writeFile(
+        join(releaseDir, feedName),
+        `${JSON.stringify(hydratedFeed, null, 4)}\n`,
+        'utf8'
+    );
+
     for (const asset of assets) {
         const outputPath = join(releaseDir, asset.FileName);
         if (await fileExists(outputPath)) {

--- a/apps/desktop/tests/ci/hydrate-velopack-history.test.ts
+++ b/apps/desktop/tests/ci/hydrate-velopack-history.test.ts
@@ -1,0 +1,108 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it, vi } from 'vitest';
+
+type HydrateVelopackHistory = (
+    projectRoot: string,
+    releaseDir: string,
+    channel: string
+) => Promise<void>;
+
+async function loadHydrator(): Promise<HydrateVelopackHistory | undefined> {
+    try {
+        const module = await import('../../scripts/ci/hydrate-velopack-history.mjs');
+        return module.hydrateVelopackHistory as HydrateVelopackHistory;
+    } catch {
+        return undefined;
+    }
+}
+
+async function createFixture() {
+    const root = await mkdtemp(join(tmpdir(), 'touchai-velopack-history-'));
+    const releaseDir = join(root, 'release');
+    await mkdir(releaseDir, { recursive: true });
+    await writeFile(
+        join(root, 'product.json'),
+        JSON.stringify(
+            {
+                schemaVersion: 1,
+                services: {
+                    updates: {
+                        baseUrl: 'https://updates.example.test/touchai-app/v1',
+                    },
+                },
+            },
+            null,
+            4
+        )
+    );
+    return { root, releaseDir };
+}
+
+function createFetchMock() {
+    const safeFileName = 'TouchAI-beta-0.2.0-beta.1-windows-full.nupkg';
+    const unsafeFileName = '../escape.nupkg';
+    const feed = {
+        Assets: [
+            { FileName: safeFileName, Type: 'Full' },
+            { FileName: unsafeFileName, Type: 'Full' },
+            { FileName: 'release-notes.md', Type: 'Notes' },
+        ],
+    };
+
+    return {
+        safeFileName,
+        unsafeFileName,
+        fetchMock: vi.fn(async (input: string | URL | Request) => {
+            const url = input.toString();
+            if (url.endsWith('/releases.beta.json')) {
+                return new Response(JSON.stringify(feed), {
+                    headers: { 'content-type': 'application/json' },
+                });
+            }
+            if (url.endsWith(`/${encodeURIComponent(safeFileName)}`)) {
+                return new Response('safe package');
+            }
+
+            return new Response('not found', { status: 404 });
+        }) as unknown as typeof fetch,
+    };
+}
+
+describe('hydrateVelopackHistory', () => {
+    it('hydrates only safe package file names from an existing feed', async () => {
+        const hydrateVelopackHistory = await loadHydrator();
+        const { root, releaseDir } = await createFixture();
+        const { safeFileName, unsafeFileName, fetchMock } = createFetchMock();
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = fetchMock;
+
+        try {
+            expect(hydrateVelopackHistory).toBeTypeOf('function');
+            await hydrateVelopackHistory?.(root, releaseDir, 'beta');
+
+            await expect(readFile(join(releaseDir, safeFileName), 'utf8')).resolves.toBe(
+                'safe package'
+            );
+            await expect(readFile(join(root, 'escape.nupkg'), 'utf8')).rejects.toMatchObject({
+                code: 'ENOENT',
+            });
+
+            const hydratedFeed = JSON.parse(
+                await readFile(join(releaseDir, 'releases.beta.json'), 'utf8')
+            );
+            expect(
+                hydratedFeed.Assets.map((asset: { FileName: string }) => asset.FileName)
+            ).toEqual([safeFileName]);
+            expect(fetchMock).not.toHaveBeenCalledWith(
+                expect.stringContaining(encodeURIComponent(unsafeFileName)),
+                expect.anything()
+            );
+        } finally {
+            globalThis.fetch = originalFetch;
+            await rm(root, { recursive: true, force: true });
+        }
+    });
+});


### PR DESCRIPTION
## Summary

- Ignore unsafe Velopack history asset file names that contain path separators or empty path segments.
- Write the hydrated feed with only safe package entries so the release directory cannot be populated outside its intended folder.
- Add a regression test covering a traversal-style package name in the existing feed.

## Related issue or RFC

Related to https://github.com/TouchAI-org/TouchAI

## AI assistance disclosure

- Tool(s) used: AI assistant
- Scope of assistance: bug identification, patch drafting, and local verification
- Human review or rewrite performed: reviewed the diff and test output before publishing
- Architecture or boundary impact: none

## Testing evidence

```text
Vitest targeted: tests/ci/hydrate-velopack-history.test.ts --pool=vmThreads --fileParallelism=false passed (1 test)
Prettier check passed for the changed files
ESLint passed for the changed files
git diff --check passed
```

`pnpm test:pr` did not run locally because the Windows environment only exposes pnpm through Corepack while the hook expects a direct pnpm shim. CI should provide full-suite proof before merge.

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: none
- database baseline or migration impact: none
- release or packaging impact: Velopack history hydration now drops unsafe package names from hydrated feeds and downloaded package files

## Screenshots or recordings

Not applicable; this changes release history hydration logic covered by unit tests.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [ ] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [x] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.