### PR TITLE
fix: prune only matching release asset versions

### DIFF
--- a/apps/desktop/scripts/ci/plan-r2-release-asset-prune.mjs
+++ b/apps/desktop/scripts/ci/plan-r2-release-asset-prune.mjs
@@ -9,6 +9,7 @@ import {
     githubRepositoryFromProduct,
     isDownloadAssetName,
     relativeUpdatePath,
+    versionFromAssetName,
 } from '../update-release-assets.mjs';
 
 const GITHUB_API_BASE_URL = 'https://api.github.com';
@@ -50,6 +51,10 @@ function githubHeaders(token) {
         headers.set('authorization', `Bearer ${token}`);
     }
     return headers;
+}
+
+function releaseVersionFromTag(tagName) {
+    return String(tagName ?? '').replace(/^v/u, '');
 }
 
 async function fetchGithubReleases(repository, fetchImpl, token) {
@@ -102,9 +107,14 @@ export async function planR2ReleaseAssetPrune(projectRoot, channel, options = {}
     const keys = [];
 
     for (const release of staleReleases) {
+        const releaseVersion = releaseVersionFromTag(release?.tag_name);
         for (const asset of release.assets ?? []) {
             const fileName = asset?.name;
-            if (!isDownloadAssetName(fileName) || channelFromAssetName(fileName) !== channel) {
+            if (
+                !isDownloadAssetName(fileName) ||
+                channelFromAssetName(fileName) !== channel ||
+                versionFromAssetName(fileName) !== releaseVersion
+            ) {
                 continue;
             }
             keys.push(`${updatePath}/${fileName}`);

--- a/apps/desktop/tests/ci/plan-r2-release-asset-prune.test.ts
+++ b/apps/desktop/tests/ci/plan-r2-release-asset-prune.test.ts
@@ -70,6 +70,7 @@ describe('planR2ReleaseAssetPrune', () => {
                     release('v0.2.0-beta.2', '2026-05-22T00:00:00Z', [
                         'TouchAI-beta-0.2.0-beta.2-windows-full.nupkg',
                         'TouchAI-beta-0.2.0-beta.2-windows-delta.nupkg',
+                        'TouchAI-beta-0.2.0-beta.20-windows-full.nupkg',
                         'release-notes.md',
                     ]),
                     release('v0.2.0', '2026-05-21T00:00:00Z', ['TouchAI-0.2.0-windows-full.nupkg']),


### PR DESCRIPTION
## Summary

Fixes the R2 release asset prune planner so it only deletes download assets whose file version exactly matches the stale GitHub release tag. This prevents a newer same-channel asset from being pruned if it is attached to an older release by mistake.

## Related issue or RFC

Related to https://github.com/TouchAI-org/TouchAI release asset retention workflow.

## AI assistance disclosure

- Tool(s) used: AI assistant
- Scope of assistance: identified the release-script edge case, implemented the guard, and added a regression test.
- Human review or rewrite performed: reviewed the diff and local test output before opening the PR.
- Architecture or boundary impact: none; this stays within the CI release asset pruning script.

## Testing evidence

Targeted local checks passed:

```text
vitest run tests/ci/plan-r2-release-asset-prune.test.ts --pool=vmThreads --fileParallelism=false
pnpm --filter @touchai/desktop test:typecheck
pnpm exec prettier --check apps/desktop/scripts/ci/plan-r2-release-asset-prune.mjs apps/desktop/tests/ci/plan-r2-release-asset-prune.test.ts
pnpm exec eslint apps/desktop/scripts/ci/plan-r2-release-asset-prune.mjs apps/desktop/tests/ci/plan-r2-release-asset-prune.test.ts
git diff --check
```

I did not run the full `pnpm test:pr` suite locally because the change is limited to the release pruning script and its targeted regression test; CI should provide the full-suite proof.

TDD: regression case added with the fix to cover the unsafe prune scenario.

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: none.
- database baseline or migration impact: none.
- release or packaging impact: safer R2 cleanup; the planner now skips stale-release assets when the file version does not match the release tag.

## Screenshots or recordings

Not applicable; no UI changes.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [x] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [x] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.