### PR TITLE
fix(clipboard): sanitize rich clipboard content

### DIFF
--- a/apps/desktop/src-tauri/src/core/system/clipboard/html.rs
+++ b/apps/desktop/src-tauri/src/core/system/clipboard/html.rs
@@ -105,7 +105,8 @@ impl<'a> HtmlClipboardFragmentExtractor<'a> {
     /// 处理开始标签并更新上下文。
     fn handle_start_tag(&mut self, tag: &StartTag<()>) {
         let tag_name = tag_name_to_string(&tag.name);
-        let is_hidden = is_hidden_html_element(&tag.attributes);
+        let is_hidden =
+            is_hidden_html_element(&tag.attributes) || is_non_visible_html_element(&tag_name);
 
         if is_hidden {
             self.skip_hidden_depth += 1;
@@ -299,6 +300,14 @@ fn is_void_html_tag(tag_name: &str) -> bool {
             | "source"
             | "track"
             | "wbr"
+    )
+}
+
+/// 判断标签内容是否不属于用户可见正文。
+fn is_non_visible_html_element(tag_name: &str) -> bool {
+    matches!(
+        tag_name,
+        "head" | "style" | "script" | "noscript" | "template" | "meta" | "link" | "title"
     )
 }
 
@@ -534,5 +543,39 @@ fn extract_html_text(html: &str) -> Option<String> {
         None
     } else {
         Some(normalized)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{extract_html_clipboard_fragments, ClipboardHtmlFragment};
+
+    #[test]
+    fn html_fragment_extraction_skips_word_style_metadata() {
+        let html = r#"
+            <html>
+                <head>
+                    <style>
+                        p.MsoNormal { margin: 0cm; font-size: 11pt; }
+                        .apple-converted-space { white-space: pre; }
+                    </style>
+                    <script>window.__officePaste = true;</script>
+                </head>
+                <body>
+                    <p class="MsoNormal">Visible Word text</p>
+                    <style>.late-rule { color: red; }</style>
+                    <p>Second line</p>
+                </body>
+            </html>
+        "#;
+
+        let fragments = extract_html_clipboard_fragments(html, None);
+
+        assert_eq!(
+            fragments,
+            vec![ClipboardHtmlFragment::Text(
+                "Visible Word text\nSecond line".to_string()
+            )]
+        );
     }
 }

--- a/apps/desktop/src-tauri/src/core/system/clipboard/html.rs
+++ b/apps/desktop/src-tauri/src/core/system/clipboard/html.rs
@@ -183,8 +183,7 @@ pub(super) fn should_keep_clipboard_image(
         return true;
     };
 
-    let html_lower = html.to_ascii_lowercase();
-    if html_lower.contains("<img") {
+    if contains_visible_html_image(html) {
         return true;
     }
 
@@ -258,6 +257,51 @@ fn extract_html_text(html: &str) -> Option<String> {
     } else {
         Some(normalized)
     }
+}
+
+fn contains_visible_html_image(html: &str) -> bool {
+    let mut skip_hidden_depth = 0usize;
+    let mut tag_stack: Vec<(String, bool)> = Vec::new();
+
+    for token in Tokenizer::new(html) {
+        match token {
+            Ok(Token::StartTag(tag)) => {
+                let tag_name = tag_name_to_string(&tag.name);
+                let is_hidden = is_hidden_html_element(&tag.attributes)
+                    || is_non_visible_html_element(&tag_name);
+
+                if tag_name == "img" && skip_hidden_depth == 0 && !is_hidden {
+                    return true;
+                }
+
+                if is_hidden {
+                    skip_hidden_depth += 1;
+                }
+
+                if is_void_html_tag(&tag_name) || tag.self_closing {
+                    if is_hidden {
+                        skip_hidden_depth = skip_hidden_depth.saturating_sub(1);
+                    }
+                } else {
+                    tag_stack.push((tag_name, is_hidden));
+                }
+            }
+            Ok(Token::EndTag(tag)) => {
+                let tag_name = tag_name_to_string(&tag.name);
+                while let Some((open_tag_name, is_hidden)) = tag_stack.pop() {
+                    if is_hidden {
+                        skip_hidden_depth = skip_hidden_depth.saturating_sub(1);
+                    }
+                    if open_tag_name == tag_name {
+                        break;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    false
 }
 
 /// 从 img 标签属性中选择图片来源。
@@ -380,7 +424,6 @@ fn resolve_html_reference(source: &str, source_url: Option<&str>) -> Option<Stri
         .and_then(|value| Url::parse(value).ok())
         .and_then(|base_url| base_url.join(source).ok())
         .map(|url| url.to_string())
-        .or_else(|| Some(source.to_string()))
 }
 
 /// 判断字符串是否像图片引用。
@@ -533,6 +576,25 @@ mod tests {
     }
 
     #[test]
+    fn html_image_extraction_prefers_resolvable_img_source_over_relative_anchor_href() {
+        let html = r#"
+            <a href="full.png">
+                <img src="https://example.com/thumb.png" alt="Preview">
+            </a>
+        "#;
+
+        let images = extract_html_clipboard_images(html, None);
+
+        assert_eq!(
+            images,
+            vec![ClipboardHtmlImage {
+                source: "https://example.com/thumb.png".to_string(),
+                path: None,
+            }]
+        );
+    }
+
+    #[test]
     fn should_drop_native_image_when_html_text_matches_plain_text() {
         assert!(!should_keep_clipboard_image(
             Some("Visible Word text Second line"),
@@ -548,6 +610,15 @@ mod tests {
         assert!(should_keep_clipboard_image(
             Some("Visible"),
             Some("<p>Visible</p><img src=\"clip.png\">"),
+            false
+        ));
+    }
+
+    #[test]
+    fn should_drop_native_image_when_only_hidden_html_image_exists() {
+        assert!(!should_keep_clipboard_image(
+            Some("Visible"),
+            Some("<p>Visible</p><img style=\"display:none\" src=\"hidden.png\">"),
             false
         ));
     }

--- a/apps/desktop/src-tauri/src/core/system/clipboard/html.rs
+++ b/apps/desktop/src-tauri/src/core/system/clipboard/html.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2026. 千诚. Licensed under GPL v3.
 
-//! 剪贴板 HTML 片段解析。
+//! 剪贴板 HTML 元信息解析。
 
 use clipboard_rs::{Clipboard, ClipboardContext};
 use html5gum::{HtmlString, Spanned, StartTag, Token, Tokenizer};
@@ -12,7 +12,7 @@ use std::{
 
 use super::{
     image::{normalize_clipboard_file_path, path_has_known_image_extension},
-    payload::{ClipboardHtmlFragment, ClipboardPayloadFragment},
+    payload::{ClipboardHtmlImage, ClipboardPayloadFragment},
 };
 
 const CLIPBOARD_HTML_FORMAT: &str = "HTML Format";
@@ -47,62 +47,46 @@ fn extract_cf_html_source_url(raw: &str) -> Option<String> {
     None
 }
 
-/// 从 HTML 中提取有序的文本和图片片段。
-pub(super) fn extract_html_clipboard_fragments(
+/// 从 HTML 中提取图片来源。正文富文本转换由前端复用 DOMPurify/Turndown 完成。
+pub(super) fn extract_html_clipboard_images(
     html: &str,
     source_url: Option<&str>,
-) -> Vec<ClipboardHtmlFragment> {
-    HtmlClipboardFragmentExtractor::new(source_url).extract(html)
+) -> Vec<ClipboardHtmlImage> {
+    HtmlImageSourceExtractor::new(source_url).extract(html)
 }
 
-struct HtmlClipboardFragmentExtractor<'a> {
+struct HtmlImageSourceExtractor<'a> {
     source_url: Option<&'a str>,
-    text_buffer: String,
-    fragments: Vec<ClipboardHtmlFragment>,
+    image_sources: Vec<ClipboardHtmlImage>,
     anchor_stack: Vec<Option<String>>,
     tag_stack: Vec<(String, bool)>,
     skip_hidden_depth: usize,
 }
 
-impl<'a> HtmlClipboardFragmentExtractor<'a> {
-    /// 创建 HTML 剪贴板片段提取器。
+impl<'a> HtmlImageSourceExtractor<'a> {
     fn new(source_url: Option<&'a str>) -> Self {
         Self {
             source_url,
-            text_buffer: String::new(),
-            fragments: Vec::new(),
+            image_sources: Vec::new(),
             anchor_stack: Vec::new(),
             tag_stack: Vec::new(),
             skip_hidden_depth: 0,
         }
     }
 
-    /// 扫描 HTML token 并输出有序片段。
-    fn extract(mut self, html: &str) -> Vec<ClipboardHtmlFragment> {
-        //1. tokenizer 只负责容错切分 HTML，避免本地继续维护脆弱的标签/属性扫描器。
-        //2. 本地状态只保留剪贴板业务需要的上下文：隐藏层级、外层链接和片段顺序。
+    fn extract(mut self, html: &str) -> Vec<ClipboardHtmlImage> {
         for token in Tokenizer::new(html) {
             match token {
-                Ok(token) => self.handle_token(token),
+                Ok(Token::StartTag(tag)) => self.handle_start_tag(&tag),
+                Ok(Token::EndTag(tag)) => self.handle_end_tag(&tag_name_to_string(&tag.name)),
+                Ok(Token::String(_) | Token::Comment(_) | Token::Doctype(_) | Token::Error(_)) => {}
                 Err(error) => match error {},
             }
         }
 
-        self.flush_text();
-        self.fragments
+        self.image_sources
     }
 
-    /// 根据 token 类型更新片段状态。
-    fn handle_token(&mut self, token: Token) {
-        match token {
-            Token::StartTag(tag) => self.handle_start_tag(&tag),
-            Token::EndTag(tag) => self.handle_end_tag(&tag_name_to_string(&tag.name)),
-            Token::String(text) => self.push_html_text(&text.value),
-            Token::Comment(_) | Token::Doctype(_) | Token::Error(_) => {}
-        }
-    }
-
-    /// 处理开始标签并更新上下文。
     fn handle_start_tag(&mut self, tag: &StartTag<()>) {
         let tag_name = tag_name_to_string(&tag.name);
         let is_hidden =
@@ -115,20 +99,14 @@ impl<'a> HtmlClipboardFragmentExtractor<'a> {
         match tag_name.as_str() {
             "a" => {
                 let href = html_attr_string(&tag.attributes, b"href")
-                    .and_then(|href| resolve_html_image_reference(&href, self.source_url));
+                    .and_then(|href| resolve_html_reference(&href, self.source_url));
                 self.anchor_stack.push(href);
             }
-            "br" => self.push_line_break(),
-            "p" | "div" | "li" | "tr" => self.push_block_break(),
             "img" => {
                 if self.skip_hidden_depth == 0 {
                     if let Some(source) = self.choose_image_source(&tag.attributes) {
-                        // 图片前先落盘文字片段，后续 draft offset 才能还原 text/image/text。
-                        self.flush_text();
-                        push_unique_html_fragment(
-                            &mut self.fragments,
-                            ClipboardHtmlFragment::ImageSource(source),
-                        );
+                        self.image_sources
+                            .push(ClipboardHtmlImage { source, path: None });
                     }
                 }
             }
@@ -142,20 +120,20 @@ impl<'a> HtmlClipboardFragmentExtractor<'a> {
         }
     }
 
-    /// 处理结束标签并关闭相关上下文。
     fn handle_end_tag(&mut self, tag_name: &str) {
-        match tag_name {
-            "a" => {
+        while let Some((open_tag_name, is_hidden)) = self.tag_stack.pop() {
+            if is_hidden {
+                self.skip_hidden_depth = self.skip_hidden_depth.saturating_sub(1);
+            }
+            if open_tag_name == "a" {
                 self.anchor_stack.pop();
             }
-            "p" | "div" | "li" | "tr" => self.push_block_break(),
-            _ => {}
+            if open_tag_name == tag_name {
+                break;
+            }
         }
-
-        self.close_tag_stack(tag_name);
     }
 
-    /// 关闭 void 或自闭合标签带来的临时上下文。
     fn close_self_contained_tag(&mut self, tag_name: &str, is_hidden: bool) {
         if tag_name == "a" {
             self.anchor_stack.pop();
@@ -165,225 +143,120 @@ impl<'a> HtmlClipboardFragmentExtractor<'a> {
         }
     }
 
-    /// 从标签栈中关闭指定标签。
-    fn close_tag_stack(&mut self, tag_name: &str) {
-        while let Some((open_tag_name, is_hidden)) = self.tag_stack.pop() {
-            if is_hidden {
-                self.skip_hidden_depth = self.skip_hidden_depth.saturating_sub(1);
-            }
-            if open_tag_name == tag_name {
-                break;
-            }
-        }
-    }
-
-    /// 选择当前图片标签最合适的图片来源。
     fn choose_image_source(&self, img_attrs: &HtmlAttributes) -> Option<String> {
-        //1. 富文本复制常把缩略图包在原图链接里，优先使用外层 href。
         if let Some(anchor_href) = self.anchor_stack.iter().rev().flatten().next() {
             if looks_like_image_reference(anchor_href) {
                 return Some(anchor_href.clone());
             }
         }
 
-        //2. 找不到外层原图链接时，再回退到 img 自身的 srcset/src。
         choose_html_image_source(img_attrs, self.source_url)
     }
-
-    /// 将 HTML string token 追加到文本缓冲区。
-    fn push_html_text(&mut self, text: &HtmlString) {
-        if self.skip_hidden_depth > 0 {
-            return;
-        }
-
-        self.push_text(&html_string_to_string(text));
-    }
-
-    /// 将文本追加到当前文本缓冲区。
-    fn push_text(&mut self, text: &str) {
-        for ch in text.chars() {
-            if ch.is_whitespace() || ch == '\u{00a0}' {
-                if !self.text_buffer.ends_with([' ', '\n']) {
-                    self.text_buffer.push(' ');
-                }
-                continue;
-            }
-
-            self.text_buffer.push(ch);
-        }
-    }
-
-    /// 向文本缓冲区追加换行。
-    fn push_line_break(&mut self) {
-        if self.skip_hidden_depth > 0 {
-            return;
-        }
-        if !self.text_buffer.ends_with('\n') {
-            self.text_buffer.push('\n');
-        }
-    }
-
-    /// 在块级元素边界追加换行。
-    fn push_block_break(&mut self) {
-        if self.skip_hidden_depth > 0 || self.text_buffer.is_empty() {
-            return;
-        }
-        if !self.text_buffer.ends_with('\n') {
-            self.text_buffer.push('\n');
-        }
-    }
-
-    /// 将文本缓冲区落盘为片段。
-    fn flush_text(&mut self) {
-        let text = self.text_buffer.trim().to_string();
-        self.text_buffer.clear();
-        if text.is_empty() {
-            return;
-        }
-
-        push_unique_html_fragment(&mut self.fragments, ClipboardHtmlFragment::Text(text));
-    }
 }
 
-/// 向 HTML 片段列表追加去重后的片段。
-fn push_unique_html_fragment(
-    fragments: &mut Vec<ClipboardHtmlFragment>,
-    fragment: ClipboardHtmlFragment,
-) {
-    if fragments.last() == Some(&fragment) {
-        return;
-    }
-
-    match fragment {
-        ClipboardHtmlFragment::Text(text) => {
-            if text.is_empty() {
-                return;
-            }
-
-            if let Some(ClipboardHtmlFragment::Text(previous)) = fragments.last_mut() {
-                previous.push_str(&text);
-                return;
-            }
-
-            fragments.push(ClipboardHtmlFragment::Text(text));
-        }
-        ClipboardHtmlFragment::ImageSource(source) => {
-            if fragments.iter().any(|existing| {
-                matches!(existing, ClipboardHtmlFragment::ImageSource(existing_source) if existing_source == &source)
-            }) {
-                return;
-            }
-            fragments.push(ClipboardHtmlFragment::ImageSource(source));
-        }
-    }
-}
-
-/// 将 tag name 转为小写字符串。
-fn tag_name_to_string(name: &HtmlString) -> String {
-    html_string_to_string(name).to_ascii_lowercase()
-}
-
-/// 判断标签是否是无闭合内容的 void 标签。
-fn is_void_html_tag(tag_name: &str) -> bool {
-    matches!(
-        tag_name,
-        "area"
-            | "base"
-            | "br"
-            | "col"
-            | "embed"
-            | "hr"
-            | "img"
-            | "input"
-            | "link"
-            | "meta"
-            | "source"
-            | "track"
-            | "wbr"
-    )
-}
-
-/// 判断标签内容是否不属于用户可见正文。
-fn is_non_visible_html_element(tag_name: &str) -> bool {
-    matches!(
-        tag_name,
-        "head" | "style" | "script" | "noscript" | "template" | "meta" | "link" | "title"
-    )
-}
-
-/// 判断 HTML 元素是否应视为隐藏内容。
-fn is_hidden_html_element(attrs: &HtmlAttributes) -> bool {
-    if has_html_attr(attrs, b"hidden") {
-        return true;
-    }
-
-    html_attr_string(attrs, b"style")
-        .map(|style| normalize_hidden_style(&style))
-        .is_some_and(|style| {
-            style.contains("display:none")
-                || style.contains("visibility:hidden")
-                || style.contains("opacity:0")
-        })
-}
-
-/// 归一化内联样式以便判断隐藏状态。
-fn normalize_hidden_style(style: &str) -> String {
-    style
-        .chars()
-        .filter(|ch| !ch.is_whitespace())
-        .collect::<String>()
-        .to_ascii_lowercase()
-}
-
-/// 判断属性列表中是否存在指定属性。
-fn has_html_attr(attrs: &HtmlAttributes, name: &[u8]) -> bool {
-    attrs.contains_key(name)
-}
-
-/// 从属性列表读取指定属性值。
-fn html_attr_string(attrs: &HtmlAttributes, name: &[u8]) -> Option<String> {
-    attrs
-        .get(name)
-        .map(|value| html_string_to_string(&value.value))
-}
-
-/// 将 tokenizer 字节串转为 Rust 字符串。
-fn html_string_to_string(value: &HtmlString) -> String {
-    String::from_utf8_lossy(value.as_ref()).into_owned()
-}
-
-/// 将 HTML 片段映射为前端 payload fragments。
-pub(super) fn build_payload_fragments_from_html(
-    html_fragments: &[ClipboardHtmlFragment],
-    image_path_by_source: &HashMap<&str, String>,
+/// 从图片 source 到已缓存本地路径的映射中生成前端附件 fragment。
+pub(super) fn build_payload_fragments_from_html_images(
+    html_images: &[ClipboardHtmlImage],
+    image_path_by_source: &HashMap<String, String>,
 ) -> Vec<ClipboardPayloadFragment> {
-    html_fragments
+    html_images
         .iter()
-        .filter_map(|fragment| match fragment {
-            ClipboardHtmlFragment::Text(text) => {
-                Some(ClipboardPayloadFragment::Text { text: text.clone() })
-            }
-            ClipboardHtmlFragment::ImageSource(source) => image_path_by_source
-                .get(source.as_str())
-                .map(|path| ClipboardPayloadFragment::Image { path: path.clone() }),
+        .filter_map(|image| {
+            image_path_by_source
+                .get(&image.source)
+                .map(|path| ClipboardPayloadFragment::Image { path: path.clone() })
         })
         .collect()
 }
 
-/// 从 payload fragments 中拼出纯文本内容。
-pub(super) fn build_payload_text(fragments: &[ClipboardPayloadFragment]) -> Option<String> {
-    let text = fragments
-        .iter()
-        .filter_map(|fragment| match fragment {
-            ClipboardPayloadFragment::Text { text } => Some(text.as_str()),
-            ClipboardPayloadFragment::Image { .. } | ClipboardPayloadFragment::File { .. } => None,
-        })
-        .collect::<String>();
+/// 判断剪贴板 native 图片通道是否应保留。
+pub(super) fn should_keep_clipboard_image(
+    text: Option<&str>,
+    html: Option<&str>,
+    has_files: bool,
+) -> bool {
+    if has_files {
+        return true;
+    }
 
-    if text.trim().is_empty() {
+    let Some(html) = html.map(str::trim).filter(|value| !value.is_empty()) else {
+        return true;
+    };
+
+    let html_lower = html.to_ascii_lowercase();
+    if html_lower.contains("<img") {
+        return true;
+    }
+
+    // 有些系统会把纯文字的 HTML 副本也暴露为 Image；文本一致时丢弃这类伪图片。
+    let normalized_text = text.map(normalize_clipboard_text_for_compare);
+    let normalized_html_text = extract_html_text(html);
+
+    if normalized_text.is_some()
+        && normalized_html_text.is_some()
+        && normalized_text == normalized_html_text
+    {
+        return false;
+    }
+
+    true
+}
+
+/// 归一化剪贴板文本用于相等比较。
+fn normalize_clipboard_text_for_compare(value: &str) -> String {
+    value.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// 从 HTML 中提取粗略纯文本。这里仅用于判断 native image 是否为伪图片。
+fn extract_html_text(html: &str) -> Option<String> {
+    let mut text = String::new();
+    let mut skip_hidden_depth = 0usize;
+    let mut tag_stack: Vec<(String, bool)> = Vec::new();
+
+    for token in Tokenizer::new(html) {
+        match token {
+            Ok(Token::StartTag(tag)) => {
+                let tag_name = tag_name_to_string(&tag.name);
+                let is_hidden = is_hidden_html_element(&tag.attributes)
+                    || is_non_visible_html_element(&tag_name);
+                if is_hidden {
+                    skip_hidden_depth += 1;
+                }
+                if is_void_html_tag(&tag_name) || tag.self_closing {
+                    if is_hidden {
+                        skip_hidden_depth = skip_hidden_depth.saturating_sub(1);
+                    }
+                } else {
+                    tag_stack.push((tag_name, is_hidden));
+                }
+            }
+            Ok(Token::EndTag(tag)) => {
+                let tag_name = tag_name_to_string(&tag.name);
+                while let Some((open_tag_name, is_hidden)) = tag_stack.pop() {
+                    if is_hidden {
+                        skip_hidden_depth = skip_hidden_depth.saturating_sub(1);
+                    }
+                    if open_tag_name == tag_name {
+                        break;
+                    }
+                }
+            }
+            Ok(Token::String(value)) => {
+                if skip_hidden_depth == 0 {
+                    text.push_str(&html_string_to_string(&value.value));
+                    text.push(' ');
+                }
+            }
+            Ok(Token::Comment(_) | Token::Doctype(_) | Token::Error(_)) => {}
+            Err(error) => match error {},
+        }
+    }
+
+    let normalized = normalize_clipboard_text_for_compare(&text);
+    if normalized.is_empty() {
         None
     } else {
-        Some(text)
+        Some(normalized)
     }
 }
 
@@ -472,6 +345,44 @@ fn resolve_html_image_reference(source: &str, source_url: Option<&str>) -> Optio
         .map(|url| url.to_string())
 }
 
+fn resolve_html_reference(source: &str, source_url: Option<&str>) -> Option<String> {
+    let source = source.trim();
+    if source.is_empty() {
+        return None;
+    }
+
+    let lower_source = source.to_ascii_lowercase();
+    if lower_source.starts_with("javascript:")
+        || lower_source.starts_with("vbscript:")
+        || lower_source.starts_with("data:text/html")
+    {
+        return None;
+    }
+
+    if lower_source.starts_with('#') {
+        return Some(source.to_string());
+    }
+    if Path::new(source).is_absolute() {
+        return Some(source.to_string());
+    }
+    if let Ok(url) = Url::parse(source) {
+        if matches!(
+            url.scheme(),
+            "http" | "https" | "file" | "mailto" | "tel" | "ftp"
+        ) {
+            return Some(url.to_string());
+        }
+
+        return None;
+    }
+
+    source_url
+        .and_then(|value| Url::parse(value).ok())
+        .and_then(|base_url| base_url.join(source).ok())
+        .map(|url| url.to_string())
+        .or_else(|| Some(source.to_string()))
+}
+
 /// 判断字符串是否像图片引用。
 fn looks_like_image_reference(source: &str) -> bool {
     let lower_source = source.to_ascii_lowercase();
@@ -490,92 +401,154 @@ fn looks_like_image_reference(source: &str) -> bool {
     path_has_known_image_extension(source)
 }
 
-/// 判断剪贴板 native 图片通道是否应保留。
-pub(super) fn should_keep_clipboard_image(
-    text: Option<&str>,
-    html: Option<&str>,
-    has_files: bool,
-) -> bool {
-    if has_files {
-        return true;
-    }
-
-    let Some(html) = html.map(str::trim).filter(|value| !value.is_empty()) else {
-        return true;
-    };
-
-    let html_lower = html.to_ascii_lowercase();
-    if html_lower.contains("<img") {
-        return true;
-    }
-
-    // 有些系统会把纯文字的 HTML 副本也暴露为 Image；文本一致时丢弃这类伪图片。
-    let normalized_text = text.map(normalize_clipboard_text_for_compare);
-    let normalized_html_text = extract_html_text(html);
-
-    if normalized_text.is_some()
-        && normalized_html_text.is_some()
-        && normalized_text == normalized_html_text
-    {
-        return false;
-    }
-
-    true
+/// 将 tokenizer tag name 转为统一小写字符串。
+fn tag_name_to_string(value: &HtmlString) -> String {
+    html_string_to_string(value).to_ascii_lowercase()
 }
 
-/// 归一化剪贴板文本用于相等比较。
-fn normalize_clipboard_text_for_compare(value: &str) -> String {
-    value.split_whitespace().collect::<Vec<_>>().join(" ")
+fn is_void_html_tag(tag_name: &str) -> bool {
+    matches!(
+        tag_name,
+        "area"
+            | "base"
+            | "br"
+            | "col"
+            | "embed"
+            | "hr"
+            | "img"
+            | "input"
+            | "link"
+            | "meta"
+            | "source"
+            | "track"
+            | "wbr"
+    )
 }
 
-/// 从 HTML 中提取粗略纯文本。
-fn extract_html_text(html: &str) -> Option<String> {
-    let text = extract_html_clipboard_fragments(html, None)
-        .into_iter()
-        .filter_map(|fragment| match fragment {
-            ClipboardHtmlFragment::Text(text) => Some(text),
-            ClipboardHtmlFragment::ImageSource(_) => None,
+/// 判断标签内容是否不属于用户可见正文。
+fn is_non_visible_html_element(tag_name: &str) -> bool {
+    matches!(
+        tag_name,
+        "head" | "style" | "script" | "noscript" | "template" | "meta" | "link" | "title"
+    )
+}
+
+/// 判断 HTML 元素是否应视为隐藏内容。
+fn is_hidden_html_element(attrs: &HtmlAttributes) -> bool {
+    if has_html_attr(attrs, b"hidden") {
+        return true;
+    }
+
+    html_attr_string(attrs, b"style")
+        .map(|style| normalize_hidden_style(&style))
+        .is_some_and(|style| {
+            style.contains("display:none")
+                || style.contains("visibility:hidden")
+                || style.contains("opacity:0")
         })
-        .collect::<String>();
+}
 
-    let normalized = normalize_clipboard_text_for_compare(&text);
-    if normalized.is_empty() {
-        None
-    } else {
-        Some(normalized)
-    }
+/// 归一化内联样式以便判断隐藏状态。
+fn normalize_hidden_style(style: &str) -> String {
+    style
+        .chars()
+        .filter(|ch| !ch.is_whitespace())
+        .collect::<String>()
+        .to_ascii_lowercase()
+}
+
+/// 判断属性列表中是否存在指定属性。
+fn has_html_attr(attrs: &HtmlAttributes, name: &[u8]) -> bool {
+    attrs.contains_key(name)
+}
+
+/// 从属性列表读取指定属性值。
+fn html_attr_string(attrs: &HtmlAttributes, name: &[u8]) -> Option<String> {
+    attrs
+        .get(name)
+        .map(|value| html_string_to_string(&value.value))
+}
+
+/// 将 tokenizer 字节串转为 Rust 字符串。
+fn html_string_to_string(value: &HtmlString) -> String {
+    String::from_utf8_lossy(value.as_ref()).into_owned()
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{extract_html_clipboard_fragments, ClipboardHtmlFragment};
+    use super::{extract_html_clipboard_images, should_keep_clipboard_image, ClipboardHtmlImage};
 
     #[test]
-    fn html_fragment_extraction_skips_word_style_metadata() {
+    fn html_image_extraction_skips_hidden_images_and_uses_anchor_originals() {
         let html = r#"
-            <html>
-                <head>
-                    <style>
-                        p.MsoNormal { margin: 0cm; font-size: 11pt; }
-                        .apple-converted-space { white-space: pre; }
-                    </style>
-                    <script>window.__officePaste = true;</script>
-                </head>
-                <body>
-                    <p class="MsoNormal">Visible Word text</p>
-                    <style>.late-rule { color: red; }</style>
-                    <p>Second line</p>
-                </body>
-            </html>
+            <p>Before</p>
+            <img style="display: none" src="hidden.png">
+            <a href="https://example.com/full.png">
+                <img src="thumb.png" alt="Preview">
+            </a>
+            <img srcset="small.jpg 320w, large.jpg 960w" src="fallback.jpg">
         "#;
 
-        let fragments = extract_html_clipboard_fragments(html, None);
+        let images =
+            extract_html_clipboard_images(html, Some("https://example.com/post/index.html"));
 
         assert_eq!(
-            fragments,
-            vec![ClipboardHtmlFragment::Text(
-                "Visible Word text\nSecond line".to_string()
-            )]
+            images,
+            vec![
+                ClipboardHtmlImage {
+                    source: "https://example.com/full.png".to_string(),
+                    path: None,
+                },
+                ClipboardHtmlImage {
+                    source: "https://example.com/post/large.jpg".to_string(),
+                    path: None,
+                },
+            ]
         );
+    }
+
+    #[test]
+    fn html_image_extraction_preserves_repeated_visible_image_occurrences() {
+        let html = r#"
+            <img src="https://example.com/reused.png">
+            <p>Between</p>
+            <img src="https://example.com/reused.png">
+        "#;
+
+        let images = extract_html_clipboard_images(html, None);
+
+        assert_eq!(
+            images,
+            vec![
+                ClipboardHtmlImage {
+                    source: "https://example.com/reused.png".to_string(),
+                    path: None,
+                },
+                ClipboardHtmlImage {
+                    source: "https://example.com/reused.png".to_string(),
+                    path: None,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn should_drop_native_image_when_html_text_matches_plain_text() {
+        assert!(!should_keep_clipboard_image(
+            Some("Visible Word text Second line"),
+            Some(
+                r#"<html><head><style>p{color:red}</style></head><body><p>Visible Word text</p><p>Second line</p></body></html>"#
+            ),
+            false
+        ));
+    }
+
+    #[test]
+    fn should_keep_native_image_when_html_contains_image() {
+        assert!(should_keep_clipboard_image(
+            Some("Visible"),
+            Some("<p>Visible</p><img src=\"clip.png\">"),
+            false
+        ));
     }
 }

--- a/apps/desktop/src-tauri/src/core/system/clipboard/payload.rs
+++ b/apps/desktop/src-tauri/src/core/system/clipboard/payload.rs
@@ -14,6 +14,9 @@ pub struct ClipboardPayload {
     pub snapshot_id: String,
     pub observed_at: u64,
     pub text: Option<String>,
+    pub html: Option<String>,
+    pub html_source_url: Option<String>,
+    pub html_images: Vec<ClipboardHtmlImage>,
     pub image_paths: Vec<String>,
     pub file_paths: Vec<String>,
     pub fragments: Vec<ClipboardPayloadFragment>,
@@ -27,11 +30,21 @@ pub enum ClipboardPayloadFragment {
     File { path: String },
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClipboardHtmlImage {
+    pub source: String,
+    pub path: Option<String>,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(super) struct ClipboardSnapshot {
     pub(super) snapshot_id: String,
     pub(super) observed_at: u64,
     pub(super) text: Option<String>,
+    pub(super) html: Option<String>,
+    pub(super) html_source_url: Option<String>,
+    pub(super) html_images: Vec<ClipboardHtmlImage>,
     pub(super) image_paths: Vec<String>,
     pub(super) file_paths: Vec<String>,
     pub(super) fragments: Vec<ClipboardPayloadFragment>,
@@ -44,17 +57,14 @@ impl ClipboardSnapshot {
             snapshot_id: self.snapshot_id,
             observed_at: self.observed_at,
             text: self.text,
+            html: self.html,
+            html_source_url: self.html_source_url,
+            html_images: self.html_images,
             image_paths: self.image_paths,
             file_paths: self.file_paths,
             fragments: self.fragments,
         }
     }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(super) enum ClipboardHtmlFragment {
-    Text(String),
-    ImageSource(String),
 }
 
 /// 基于标准化内容生成剪贴板快照 ID。

--- a/apps/desktop/src-tauri/src/core/system/clipboard/runtime.rs
+++ b/apps/desktop/src-tauri/src/core/system/clipboard/runtime.rs
@@ -26,6 +26,8 @@ use super::{
     payload::{build_snapshot_id, ClipboardPayload, ClipboardPayloadFragment, ClipboardSnapshot},
 };
 
+const MAX_HTML_IMAGE_RESOLUTIONS: usize = 20;
+
 #[derive(Default)]
 struct ClipboardRuntimeState {
     latest_snapshot: Option<ClipboardSnapshot>,
@@ -309,7 +311,7 @@ impl ClipboardRuntime {
 
         //3. watcher 只观察轻量快照；显式粘贴/auto-paste 消费时才解析 HTML 外链图片。
         if mode.should_resolve_external_images() {
-            for image in &mut html_images {
+            for image in html_images.iter_mut().take(MAX_HTML_IMAGE_RESOLUTIONS) {
                 match self
                     .inner
                     .image_cache
@@ -340,21 +342,23 @@ impl ClipboardRuntime {
             }
         } else if let Some(text) = &fallback_text {
             fragments.insert(0, ClipboardPayloadFragment::Text { text: text.clone() });
-            for image_path in &normalized_image_paths {
-                fragments.push(ClipboardPayloadFragment::Image {
-                    path: image_path.clone(),
-                });
-            }
-            for file_path in &normalized_files {
-                fragments.push(ClipboardPayloadFragment::File {
-                    path: file_path.clone(),
-                });
-            }
+            append_payload_attachment_fragments(
+                &mut fragments,
+                &normalized_image_paths,
+                &normalized_files,
+            );
+        } else {
+            append_payload_attachment_fragments(
+                &mut fragments,
+                &normalized_image_paths,
+                &normalized_files,
+            );
         }
 
-        let snapshot_text_identity = fallback_text.as_deref().or(html.as_deref());
+        let snapshot_content_identity =
+            build_snapshot_content_identity(fallback_text.as_deref(), html.as_deref());
 
-        if snapshot_text_identity.is_none()
+        if snapshot_content_identity.is_none()
             && normalized_image_paths.is_empty()
             && normalized_files.is_empty()
             && html_images.is_empty()
@@ -365,7 +369,7 @@ impl ClipboardRuntime {
 
         Ok(Some(ClipboardSnapshot {
             snapshot_id: build_snapshot_id(
-                snapshot_text_identity,
+                snapshot_content_identity.as_deref(),
                 &image_identity_keys,
                 &normalized_files,
             ),
@@ -408,4 +412,72 @@ fn now_millis() -> u64 {
         .duration_since(UNIX_EPOCH)
         .map(|duration| duration.as_millis() as u64)
         .unwrap_or(0)
+}
+
+fn append_payload_attachment_fragments(
+    fragments: &mut Vec<ClipboardPayloadFragment>,
+    image_paths: &[String],
+    file_paths: &[String],
+) {
+    for image_path in image_paths {
+        fragments.push(ClipboardPayloadFragment::Image {
+            path: image_path.clone(),
+        });
+    }
+    for file_path in file_paths {
+        fragments.push(ClipboardPayloadFragment::File {
+            path: file_path.clone(),
+        });
+    }
+}
+
+fn build_snapshot_content_identity(text: Option<&str>, html: Option<&str>) -> Option<String> {
+    match (text, html) {
+        (Some(text), Some(html)) => Some(format!("text:{text}\nhtml:{html}")),
+        (Some(text), None) => Some(format!("text:{text}")),
+        (None, Some(html)) => Some(format!("html:{html}")),
+        (None, None) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        append_payload_attachment_fragments, build_snapshot_content_identity,
+        ClipboardPayloadFragment,
+    };
+
+    #[test]
+    fn attachment_only_payloads_still_emit_fragments() {
+        let mut fragments = Vec::new();
+
+        append_payload_attachment_fragments(
+            &mut fragments,
+            &[String::from("D:/clip/image.png")],
+            &[String::from("D:/clip/file.pdf")],
+        );
+
+        assert_eq!(
+            fragments,
+            vec![
+                ClipboardPayloadFragment::Image {
+                    path: String::from("D:/clip/image.png")
+                },
+                ClipboardPayloadFragment::File {
+                    path: String::from("D:/clip/file.pdf")
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn snapshot_identity_includes_html_when_plain_text_matches() {
+        assert_ne!(
+            build_snapshot_content_identity(Some("Docs"), Some("<p>Docs</p>")),
+            build_snapshot_content_identity(
+                Some("Docs"),
+                Some("<p><a href=\"https://example.com\">Docs</a></p>")
+            )
+        );
+    }
 }

--- a/apps/desktop/src-tauri/src/core/system/clipboard/runtime.rs
+++ b/apps/desktop/src-tauri/src/core/system/clipboard/runtime.rs
@@ -19,14 +19,11 @@ use std::{
 
 use super::{
     html::{
-        build_payload_fragments_from_html, build_payload_text, extract_html_clipboard_fragments,
+        build_payload_fragments_from_html_images, extract_html_clipboard_images,
         read_clipboard_html_source_url, should_keep_clipboard_image,
     },
     image::{hash_value, push_unique, split_clipboard_file_paths, ClipboardImageCache},
-    payload::{
-        build_snapshot_id, ClipboardHtmlFragment, ClipboardPayload, ClipboardPayloadFragment,
-        ClipboardSnapshot,
-    },
+    payload::{build_snapshot_id, ClipboardPayload, ClipboardPayloadFragment, ClipboardSnapshot},
 };
 
 #[derive(Default)]
@@ -274,24 +271,17 @@ impl ClipboardRuntime {
             (text, html, html_source_url, image, file_paths)
         };
 
-        //2. 将文本、文件、native 图片和 HTML 片段归一到同一个 payload 语义。
+        //2. 将文本、文件、native 图片和 HTML 图片归一到同一个 payload 语义。
         let fallback_text = text.filter(|value| !value.trim().is_empty());
-        let html_fragments = html
+        let mut html_images = html
             .as_deref()
-            .map(|html| extract_html_clipboard_fragments(html, html_source_url.as_deref()))
+            .map(|html| extract_html_clipboard_images(html, html_source_url.as_deref()))
             .unwrap_or_default();
-        let html_image_sources = html_fragments
-            .iter()
-            .filter_map(|fragment| match fragment {
-                ClipboardHtmlFragment::ImageSource(source) => Some(source.clone()),
-                ClipboardHtmlFragment::Text(_) => None,
-            })
-            .collect::<Vec<_>>();
         let (file_image_paths, normalized_files) = split_clipboard_file_paths(file_paths);
         let mut normalized_image_paths = Vec::new();
         let mut image_identity_keys = Vec::new();
         let mut fragments = Vec::new();
-        let mut html_image_path_by_source: HashMap<&str, String> = HashMap::new();
+        let mut html_image_path_by_source: HashMap<String, String> = HashMap::new();
 
         for image_path in file_image_paths {
             image_identity_keys.push(format!("file:{image_path}"));
@@ -313,31 +303,36 @@ impl ClipboardRuntime {
             push_unique(&mut normalized_image_paths, path);
         }
 
-        for source in &html_image_sources {
-            image_identity_keys.push(format!("html:{}", hash_value(source)));
+        for image in &html_images {
+            image_identity_keys.push(format!("html:{}", hash_value(&image.source)));
         }
 
         //3. watcher 只观察轻量快照；显式粘贴/auto-paste 消费时才解析 HTML 外链图片。
         if mode.should_resolve_external_images() {
-            for source in &html_image_sources {
-                match self.inner.image_cache.resolve_html_image_source(source) {
+            for image in &mut html_images {
+                match self
+                    .inner
+                    .image_cache
+                    .resolve_html_image_source(&image.source)
+                {
                     Ok(Some((path, _hash))) => {
-                        html_image_path_by_source.insert(source.as_str(), path.clone());
+                        html_image_path_by_source.insert(image.source.clone(), path.clone());
+                        image.path = Some(path.clone());
                         push_unique(&mut normalized_image_paths, path);
                     }
                     Ok(None) => {}
                     Err(error) => warn!(
                         "Failed to resolve clipboard HTML image '{}': {}",
-                        source, error
+                        image.source, error
                     ),
                 }
             }
         }
 
-        //4. 优先保留 HTML 的 text/image 顺序；无 HTML 结构时再回退为文本后接附件。
-        if !html_fragments.is_empty() {
+        //4. 文本和 HTML 正文由前端使用现有 DOMPurify/Turndown 归一化；Rust 只附加附件。
+        if html.is_some() {
             fragments =
-                build_payload_fragments_from_html(&html_fragments, &html_image_path_by_source);
+                build_payload_fragments_from_html_images(&html_images, &html_image_path_by_source);
             for file_path in &normalized_files {
                 fragments.push(ClipboardPayloadFragment::File {
                     path: file_path.clone(),
@@ -357,28 +352,28 @@ impl ClipboardRuntime {
             }
         }
 
-        let normalized_text = if !html_fragments.is_empty() {
-            build_payload_text(&fragments)
-        } else {
-            fallback_text
-        };
+        let snapshot_text_identity = fallback_text.as_deref().or(html.as_deref());
 
-        if normalized_text.is_none()
+        if snapshot_text_identity.is_none()
             && normalized_image_paths.is_empty()
             && normalized_files.is_empty()
-            && html_image_sources.is_empty()
+            && html_images.is_empty()
+            && html.is_none()
         {
             return Ok(None);
         }
 
         Ok(Some(ClipboardSnapshot {
             snapshot_id: build_snapshot_id(
-                normalized_text.as_deref(),
+                snapshot_text_identity,
                 &image_identity_keys,
                 &normalized_files,
             ),
             observed_at: now_millis(),
-            text: normalized_text,
+            text: fallback_text,
+            html,
+            html_source_url,
+            html_images,
             image_paths: normalized_image_paths,
             file_paths: normalized_files,
             fragments,

--- a/apps/desktop/src/components/MarkdownContent.vue
+++ b/apps/desktop/src/components/MarkdownContent.vue
@@ -9,6 +9,7 @@
         data-no-i18n="true"
         translate="no"
         @click="handleMarkdownClick"
+        @copy="handleMarkdownCopy"
     >
         <MarkdownRender
             :key="markdownRenderKey"
@@ -275,6 +276,270 @@
     const codeBlockLightTheme = 'one-light';
     const codeBlockDarkTheme = 'one-dark-pro';
     const codeBlockThemes = [codeBlockLightTheme, codeBlockDarkTheme];
+    const clipboardBlockTags = new Set([
+        'address',
+        'article',
+        'aside',
+        'blockquote',
+        'dd',
+        'div',
+        'dl',
+        'dt',
+        'figcaption',
+        'figure',
+        'footer',
+        'h1',
+        'h2',
+        'h3',
+        'h4',
+        'h5',
+        'h6',
+        'header',
+        'hr',
+        'li',
+        'main',
+        'nav',
+        'ol',
+        'p',
+        'pre',
+        'section',
+        'ul',
+    ]);
+
+    function escapeClipboardHtml(value: string): string {
+        return value
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;');
+    }
+
+    function normalizeClipboardCellText(cell: HTMLTableCellElement): string {
+        return (cell.textContent ?? '').replace(/\s+/g, ' ').trim();
+    }
+
+    function serializeTableSectionForClipboard(
+        section: HTMLTableSectionElement | null,
+        sectionTag: 'thead' | 'tbody' | 'tfoot'
+    ): { html: string; textRows: string[] } {
+        if (!section) {
+            return { html: '', textRows: [] };
+        }
+
+        let html = `<${sectionTag}>`;
+        const textRows: string[] = [];
+
+        for (const row of Array.from(section.rows)) {
+            html += '<tr>';
+            const textCells: string[] = [];
+
+            for (const cell of Array.from(row.cells)) {
+                const tag = cell.tagName.toLowerCase() === 'th' ? 'th' : 'td';
+                const text = normalizeClipboardCellText(cell);
+                const colspan = cell.colSpan > 1 ? ` colspan="${cell.colSpan}"` : '';
+                const rowspan = cell.rowSpan > 1 ? ` rowspan="${cell.rowSpan}"` : '';
+
+                html += `<${tag}${colspan}${rowspan}>${escapeClipboardHtml(text)}</${tag}>`;
+                textCells.push(text);
+            }
+
+            html += '</tr>';
+            textRows.push(textCells.join('\t'));
+        }
+
+        html += `</${sectionTag}>`;
+        return { html, textRows };
+    }
+
+    function serializeLooseTableRowsForClipboard(table: HTMLTableElement) {
+        const sectionRows = new Set<HTMLTableRowElement>([
+            ...Array.from(table.tHead?.rows ?? []),
+            ...Array.from(table.tBodies).flatMap((section) => Array.from(section.rows)),
+            ...Array.from(table.tFoot?.rows ?? []),
+        ]);
+        const looseRows = Array.from(table.rows).filter((row) => !sectionRows.has(row));
+
+        if (!looseRows.length) {
+            return { html: '', textRows: [] };
+        }
+
+        let html = '<tbody>';
+        const textRows: string[] = [];
+
+        for (const row of looseRows) {
+            html += '<tr>';
+            const textCells: string[] = [];
+
+            for (const cell of Array.from(row.cells)) {
+                const tag = cell.tagName.toLowerCase() === 'th' ? 'th' : 'td';
+                const text = normalizeClipboardCellText(cell);
+                const colspan = cell.colSpan > 1 ? ` colspan="${cell.colSpan}"` : '';
+                const rowspan = cell.rowSpan > 1 ? ` rowspan="${cell.rowSpan}"` : '';
+
+                html += `<${tag}${colspan}${rowspan}>${escapeClipboardHtml(text)}</${tag}>`;
+                textCells.push(text);
+            }
+
+            html += '</tr>';
+            textRows.push(textCells.join('\t'));
+        }
+
+        html += '</tbody>';
+        return { html, textRows };
+    }
+
+    function serializeTableForClipboard(table: HTMLTableElement): { html: string; text: string } {
+        const sections = [
+            serializeTableSectionForClipboard(table.tHead, 'thead'),
+            ...Array.from(table.tBodies).map((section) =>
+                serializeTableSectionForClipboard(section, 'tbody')
+            ),
+            serializeLooseTableRowsForClipboard(table),
+            serializeTableSectionForClipboard(table.tFoot, 'tfoot'),
+        ];
+
+        return {
+            html: `<table>${sections.map((section) => section.html).join('')}</table>`,
+            text: sections
+                .flatMap((section) => section.textRows)
+                .filter(Boolean)
+                .join('\n'),
+        };
+    }
+
+    function cloneSelectedMarkdownContents(): HTMLDivElement | null {
+        const container = markdownContainerRef.value;
+        const selection = window.getSelection();
+        if (!container || !selection || selection.rangeCount === 0 || selection.isCollapsed) {
+            return null;
+        }
+
+        const wrapper = document.createElement('div');
+        for (let index = 0; index < selection.rangeCount; index += 1) {
+            const range = selection.getRangeAt(index);
+            if (!range.intersectsNode(container)) {
+                continue;
+            }
+
+            wrapper.append(range.cloneContents());
+        }
+
+        return wrapper.hasChildNodes() ? wrapper : null;
+    }
+
+    function replaceRenderedTablesWithSemanticTables(root: HTMLElement) {
+        for (const table of Array.from(root.querySelectorAll<HTMLTableElement>('table'))) {
+            const template = document.createElement('template');
+            template.innerHTML = serializeTableForClipboard(table).html;
+            const semanticTable = template.content.firstElementChild;
+
+            if (semanticTable instanceof HTMLTableElement) {
+                table.replaceWith(semanticTable);
+            }
+        }
+    }
+
+    function normalizeClipboardPlainText(value: string): string {
+        return value
+            .replace(/\u00a0/g, ' ')
+            .replace(/[ \t]+\n/g, '\n')
+            .replace(/\n[ \t]+/g, '\n')
+            .replace(/\n{2,}/g, '\n')
+            .trim();
+    }
+
+    function serializeNodePlainTextForClipboard(node: Node): string {
+        if (node.nodeType === Node.TEXT_NODE) {
+            return node.textContent ?? '';
+        }
+
+        if (!(node instanceof HTMLElement)) {
+            return Array.from(node.childNodes).map(serializeNodePlainTextForClipboard).join('');
+        }
+
+        const tagName = node.tagName.toLowerCase();
+        if (tagName === 'br') {
+            return '\n';
+        }
+        if (node instanceof HTMLTableElement) {
+            return `\n${serializeTableForClipboard(node).text}\n`;
+        }
+
+        const text = Array.from(node.childNodes).map(serializeNodePlainTextForClipboard).join('');
+        if (!clipboardBlockTags.has(tagName)) {
+            return text;
+        }
+
+        const trimmed = text.trim();
+        return trimmed ? `\n${trimmed}\n` : '';
+    }
+
+    function serializeSelectionPlainTextForClipboard(root: Node): string {
+        return normalizeClipboardPlainText(
+            Array.from(root.childNodes).map(serializeNodePlainTextForClipboard).join('')
+        );
+    }
+
+    function findSelectedMarkdownTables(): HTMLTableElement[] {
+        const container = markdownContainerRef.value;
+        const selection = window.getSelection();
+        if (!container || !selection || selection.rangeCount === 0 || selection.isCollapsed) {
+            return [];
+        }
+
+        const tables = Array.from(container.querySelectorAll<HTMLTableElement>('table'));
+        if (!tables.length) {
+            return [];
+        }
+
+        const selectedTables: HTMLTableElement[] = [];
+        for (let index = 0; index < selection.rangeCount; index += 1) {
+            const range = selection.getRangeAt(index);
+            for (const table of tables) {
+                if (range.intersectsNode(table) && !selectedTables.includes(table)) {
+                    selectedTables.push(table);
+                }
+            }
+        }
+
+        return selectedTables;
+    }
+
+    function handleMarkdownCopy(event: ClipboardEvent) {
+        const clipboardData = event.clipboardData;
+        if (!clipboardData) {
+            return;
+        }
+
+        const selectedTables = findSelectedMarkdownTables();
+        if (!selectedTables.length) {
+            return;
+        }
+
+        const selectedContents = cloneSelectedMarkdownContents();
+        if (selectedContents?.querySelector('table')) {
+            replaceRenderedTablesWithSemanticTables(selectedContents);
+            clipboardData.setData('text/html', selectedContents.innerHTML);
+            clipboardData.setData(
+                'text/plain',
+                serializeSelectionPlainTextForClipboard(selectedContents)
+            );
+        } else {
+            const serializedTables = selectedTables.map(serializeTableForClipboard);
+            clipboardData.setData(
+                'text/html',
+                serializedTables.map((table) => table.html).join('')
+            );
+            clipboardData.setData(
+                'text/plain',
+                serializedTables
+                    .map((table) => table.text)
+                    .filter(Boolean)
+                    .join('\n\n')
+            );
+        }
+        event.preventDefault();
+    }
 
     async function handleMarkdownClick(event: MouseEvent) {
         const target = event.target as HTMLElement | null;

--- a/apps/desktop/src/components/MarkdownContent.vue
+++ b/apps/desktop/src/components/MarkdownContent.vue
@@ -372,6 +372,10 @@
         return (cell.textContent ?? '').replace(/\s+/g, ' ').trim();
     }
 
+    function serializeClipboardTableCellHtml(cell: HTMLTableCellElement): string {
+        return serializeChildrenHtmlForClipboard(cell).trim();
+    }
+
     const clipboardTableAttributes =
         ' border="1" cellspacing="0" cellpadding="4" style="border-collapse: collapse;"';
     const clipboardCellStyle = ' style="border: 1px solid #000; padding: 4px;"';
@@ -406,7 +410,7 @@
                 const colspan = cell.colSpan > 1 ? ` colspan="${cell.colSpan}"` : '';
                 const rowspan = cell.rowSpan > 1 ? ` rowspan="${cell.rowSpan}"` : '';
 
-                html += `<${tag}${colspan}${rowspan}${clipboardCellStyle}>${escapeClipboardHtml(text)}</${tag}>`;
+                html += `<${tag}${colspan}${rowspan}${clipboardCellStyle}>${serializeClipboardTableCellHtml(cell)}</${tag}>`;
                 textCells.push(text);
             }
 
@@ -443,7 +447,7 @@
                 const colspan = cell.colSpan > 1 ? ` colspan="${cell.colSpan}"` : '';
                 const rowspan = cell.rowSpan > 1 ? ` rowspan="${cell.rowSpan}"` : '';
 
-                html += `<${tag}${colspan}${rowspan}${clipboardCellStyle}>${escapeClipboardHtml(text)}</${tag}>`;
+                html += `<${tag}${colspan}${rowspan}${clipboardCellStyle}>${serializeClipboardTableCellHtml(cell)}</${tag}>`;
                 textCells.push(text);
             }
 
@@ -919,6 +923,24 @@
         }
     }
 
+    function cloneRangeInsideMarkdownContainer(range: Range, container: HTMLElement): Range | null {
+        if (!range.intersectsNode(container)) {
+            return null;
+        }
+
+        const clippedRange = document.createRange();
+        clippedRange.selectNodeContents(container);
+
+        if (container.contains(range.startContainer)) {
+            clippedRange.setStart(range.startContainer, range.startOffset);
+        }
+        if (container.contains(range.endContainer)) {
+            clippedRange.setEnd(range.endContainer, range.endOffset);
+        }
+
+        return clippedRange.collapsed ? null : clippedRange;
+    }
+
     function cloneSelectedMarkdownContents(): HTMLDivElement | null {
         const container = markdownContainerRef.value;
         const selection = window.getSelection();
@@ -933,11 +955,16 @@
                 continue;
             }
 
-            const selectedContent = range.cloneContents();
+            const clippedRange = cloneRangeInsideMarkdownContainer(range, container);
+            if (!clippedRange) {
+                continue;
+            }
+
+            const selectedContent = clippedRange.cloneContents();
             wrapTopLevelListItemsForClipboard(
                 selectedContent,
-                findSingleClipboardListParent(range),
-                range
+                findSingleClipboardListParent(clippedRange),
+                clippedRange
             );
             wrapper.append(selectedContent);
         }

--- a/apps/desktop/src/components/MarkdownContent.vue
+++ b/apps/desktop/src/components/MarkdownContent.vue
@@ -375,6 +375,15 @@
     const clipboardTableAttributes =
         ' border="1" cellspacing="0" cellpadding="4" style="border-collapse: collapse;"';
     const clipboardCellStyle = ' style="border: 1px solid #000; padding: 4px;"';
+    const clipboardAllowedLinkProtocols = new Set([
+        'file:',
+        'ftp:',
+        'http:',
+        'https:',
+        'mailto:',
+        'tel:',
+    ]);
+    const clipboardAllowedImageProtocols = new Set(['blob:', 'cid:', 'file:', 'http:', 'https:']);
 
     function serializeTableSectionForClipboard(
         section: HTMLTableSectionElement | null,
@@ -465,23 +474,45 @@
         };
     }
 
-    function isSafeClipboardUrl(value: string): boolean {
-        const normalized = Array.from(value.trim())
+    function normalizeClipboardUrl(value: string): string {
+        return Array.from(value.trim())
             .filter((char) => {
                 const charCode = char.charCodeAt(0);
                 return charCode > 0x1f && charCode !== 0x7f && !/\s/.test(char);
             })
-            .join('')
-            .toLowerCase();
+            .join('');
+    }
+
+    function getClipboardUrlProtocol(value: string): string | null {
+        const protocolMatch = /^([a-z][a-z0-9+.-]*:)/i.exec(value);
+        return protocolMatch?.[1]?.toLowerCase() ?? null;
+    }
+
+    function isSafeClipboardHref(value: string): boolean {
+        const normalized = normalizeClipboardUrl(value);
         if (!normalized) {
             return false;
         }
 
-        return !(
-            normalized.startsWith('javascript:') ||
-            normalized.startsWith('data:text/html') ||
-            normalized.startsWith('vbscript:')
-        );
+        if (normalized.startsWith('#')) {
+            return true;
+        }
+
+        const protocol = getClipboardUrlProtocol(normalized);
+        return protocol ? clipboardAllowedLinkProtocols.has(protocol) : true;
+    }
+
+    function isSafeClipboardImageSource(value: string): boolean {
+        const normalized = normalizeClipboardUrl(value);
+        if (!normalized || normalized.startsWith('#')) {
+            return false;
+        }
+        if (/^data:image\//i.test(normalized)) {
+            return true;
+        }
+
+        const protocol = getClipboardUrlProtocol(normalized);
+        return protocol ? clipboardAllowedImageProtocols.has(protocol) : true;
     }
 
     function isClipboardSkippedElement(element: HTMLElement): boolean {
@@ -613,7 +644,7 @@
 
     function serializeImageForClipboard(image: HTMLImageElement): string {
         const source = image.getAttribute('src')?.trim();
-        if (!source || !isSafeClipboardUrl(source)) {
+        if (!source || !isSafeClipboardImageSource(source)) {
             return '';
         }
 
@@ -710,7 +741,7 @@
             const title = node.getAttribute('title')?.trim();
             const attributes: string[] = [];
 
-            if (href && isSafeClipboardUrl(href)) {
+            if (href && isSafeClipboardHref(href)) {
                 attributes.push(`href="${escapeClipboardHtml(href)}"`);
             }
             if (title) {
@@ -955,7 +986,8 @@
             return `\n${serializeTableForClipboard(node).text}\n`;
         }
         if (node instanceof HTMLImageElement) {
-            return node.alt ? `[${node.alt}]` : '';
+            const source = node.getAttribute('src')?.trim();
+            return source && isSafeClipboardImageSource(source) && node.alt ? `[${node.alt}]` : '';
         }
         if (tagName === 'pre') {
             return `\n${node.textContent ?? ''}\n`;
@@ -966,7 +998,7 @@
             );
             const href = node.getAttribute('href')?.trim();
 
-            if (text && href && isSafeClipboardUrl(href) && text !== href) {
+            if (text && href && isSafeClipboardHref(href) && text !== href) {
                 return `[${text}](${escapeMarkdownLinkDestination(href)})`;
             }
 

--- a/apps/desktop/src/components/MarkdownContent.vue
+++ b/apps/desktop/src/components/MarkdownContent.vue
@@ -305,6 +305,60 @@
         'section',
         'ul',
     ]);
+    const clipboardSemanticTags = new Set([
+        'a',
+        'blockquote',
+        'br',
+        'code',
+        'del',
+        'em',
+        'h1',
+        'h2',
+        'h3',
+        'h4',
+        'h5',
+        'h6',
+        'hr',
+        'i',
+        'img',
+        'li',
+        'ol',
+        'p',
+        'pre',
+        's',
+        'strong',
+        'sub',
+        'sup',
+        'table',
+        'tbody',
+        'td',
+        'tfoot',
+        'th',
+        'thead',
+        'tr',
+        'u',
+        'ul',
+    ]);
+    const clipboardSkippedTags = new Set([
+        'button',
+        'canvas',
+        'input',
+        'option',
+        'script',
+        'select',
+        'style',
+        'svg',
+        'textarea',
+    ]);
+    const clipboardTableStructureTags = new Set([
+        'table',
+        'tbody',
+        'td',
+        'tfoot',
+        'th',
+        'thead',
+        'tr',
+    ]);
 
     function escapeClipboardHtml(value: string): string {
         return value
@@ -317,6 +371,10 @@
     function normalizeClipboardCellText(cell: HTMLTableCellElement): string {
         return (cell.textContent ?? '').replace(/\s+/g, ' ').trim();
     }
+
+    const clipboardTableAttributes =
+        ' border="1" cellspacing="0" cellpadding="4" style="border-collapse: collapse;"';
+    const clipboardCellStyle = ' style="border: 1px solid #000; padding: 4px;"';
 
     function serializeTableSectionForClipboard(
         section: HTMLTableSectionElement | null,
@@ -339,7 +397,7 @@
                 const colspan = cell.colSpan > 1 ? ` colspan="${cell.colSpan}"` : '';
                 const rowspan = cell.rowSpan > 1 ? ` rowspan="${cell.rowSpan}"` : '';
 
-                html += `<${tag}${colspan}${rowspan}>${escapeClipboardHtml(text)}</${tag}>`;
+                html += `<${tag}${colspan}${rowspan}${clipboardCellStyle}>${escapeClipboardHtml(text)}</${tag}>`;
                 textCells.push(text);
             }
 
@@ -376,7 +434,7 @@
                 const colspan = cell.colSpan > 1 ? ` colspan="${cell.colSpan}"` : '';
                 const rowspan = cell.rowSpan > 1 ? ` rowspan="${cell.rowSpan}"` : '';
 
-                html += `<${tag}${colspan}${rowspan}>${escapeClipboardHtml(text)}</${tag}>`;
+                html += `<${tag}${colspan}${rowspan}${clipboardCellStyle}>${escapeClipboardHtml(text)}</${tag}>`;
                 textCells.push(text);
             }
 
@@ -399,12 +457,435 @@
         ];
 
         return {
-            html: `<table>${sections.map((section) => section.html).join('')}</table>`,
+            html: `<table${clipboardTableAttributes}>${sections.map((section) => section.html).join('')}</table>`,
             text: sections
                 .flatMap((section) => section.textRows)
                 .filter(Boolean)
                 .join('\n'),
         };
+    }
+
+    function isSafeClipboardUrl(value: string): boolean {
+        const normalized = Array.from(value.trim())
+            .filter((char) => {
+                const charCode = char.charCodeAt(0);
+                return charCode > 0x1f && charCode !== 0x7f && !/\s/.test(char);
+            })
+            .join('')
+            .toLowerCase();
+        if (!normalized) {
+            return false;
+        }
+
+        return !(
+            normalized.startsWith('javascript:') ||
+            normalized.startsWith('data:text/html') ||
+            normalized.startsWith('vbscript:')
+        );
+    }
+
+    function isClipboardSkippedElement(element: HTMLElement): boolean {
+        if (
+            clipboardSkippedTags.has(element.tagName.toLowerCase()) ||
+            element.hidden ||
+            element.getAttribute('aria-hidden') === 'true'
+        ) {
+            return true;
+        }
+
+        const normalizedStyle = element.getAttribute('style')?.replace(/\s+/g, '').toLowerCase();
+
+        return Boolean(
+            normalizedStyle?.includes('display:none') ||
+            normalizedStyle?.includes('visibility:hidden') ||
+            normalizedStyle?.includes('opacity:0')
+        );
+    }
+
+    function isClipboardInlineBoundaryNode(node: Node | null): boolean {
+        if (!node) {
+            return false;
+        }
+        if (node.nodeType === Node.TEXT_NODE) {
+            return Boolean(node.textContent?.trim());
+        }
+        if (!(node instanceof HTMLElement) || isClipboardSkippedElement(node)) {
+            return false;
+        }
+
+        const tagName = node.tagName.toLowerCase();
+        return !clipboardBlockTags.has(tagName) && !clipboardTableStructureTags.has(tagName);
+    }
+
+    function findClipboardBoundarySibling(node: Node, direction: 'previous' | 'next'): Node | null {
+        let sibling = direction === 'previous' ? node.previousSibling : node.nextSibling;
+        while (sibling) {
+            if (sibling.nodeType === Node.TEXT_NODE) {
+                if (sibling.textContent?.trim()) {
+                    return sibling;
+                }
+            } else if (!(sibling instanceof HTMLElement) || !isClipboardSkippedElement(sibling)) {
+                return sibling;
+            }
+
+            sibling = direction === 'previous' ? sibling.previousSibling : sibling.nextSibling;
+        }
+
+        return null;
+    }
+
+    function hasPreviousWhitespaceInSkippedSiblingRun(node: Node): boolean {
+        let sibling = node.previousSibling;
+        while (sibling) {
+            if (sibling.nodeType === Node.TEXT_NODE) {
+                return !sibling.textContent?.trim();
+            }
+            if (sibling instanceof HTMLElement && isClipboardSkippedElement(sibling)) {
+                sibling = sibling.previousSibling;
+                continue;
+            }
+
+            return false;
+        }
+
+        return false;
+    }
+
+    function serializeTextHtmlForClipboard(textNode: Text): string {
+        const value = textNode.textContent ?? '';
+        const hasInlineBefore = isClipboardInlineBoundaryNode(
+            findClipboardBoundarySibling(textNode, 'previous')
+        );
+        const hasInlineAfter = isClipboardInlineBoundaryNode(
+            findClipboardBoundarySibling(textNode, 'next')
+        );
+
+        if (!value.trim()) {
+            return hasInlineBefore &&
+                hasInlineAfter &&
+                !hasPreviousWhitespaceInSkippedSiblingRun(textNode)
+                ? ' '
+                : '';
+        }
+
+        let normalized = value.replace(/\s+/g, ' ');
+        if (!hasInlineBefore || hasPreviousWhitespaceInSkippedSiblingRun(textNode)) {
+            normalized = normalized.trimStart();
+        }
+        if (!hasInlineAfter) {
+            normalized = normalized.trimEnd();
+        }
+
+        return normalized ? escapeClipboardHtml(normalized) : '';
+    }
+
+    function serializeTextPlainTextForClipboard(textNode: Text): string {
+        const value = textNode.textContent ?? '';
+        const hasInlineBefore = isClipboardInlineBoundaryNode(
+            findClipboardBoundarySibling(textNode, 'previous')
+        );
+        const hasInlineAfter = isClipboardInlineBoundaryNode(
+            findClipboardBoundarySibling(textNode, 'next')
+        );
+
+        if (!value.trim()) {
+            return hasInlineBefore &&
+                hasInlineAfter &&
+                !hasPreviousWhitespaceInSkippedSiblingRun(textNode)
+                ? ' '
+                : '';
+        }
+
+        let normalized = value.replace(/\s+/g, ' ');
+        if (!hasInlineBefore || hasPreviousWhitespaceInSkippedSiblingRun(textNode)) {
+            normalized = normalized.trimStart();
+        }
+        if (!hasInlineAfter) {
+            normalized = normalized.trimEnd();
+        }
+
+        return normalized;
+    }
+
+    function escapeMarkdownLinkDestination(value: string): string {
+        return value.replace(/\\/g, '\\\\').replace(/\)/g, '\\)');
+    }
+
+    function serializeImageForClipboard(image: HTMLImageElement): string {
+        const source = image.getAttribute('src')?.trim();
+        if (!source || !isSafeClipboardUrl(source)) {
+            return '';
+        }
+
+        const attributes = [`src="${escapeClipboardHtml(source)}"`];
+        const alt = image.getAttribute('alt')?.trim();
+        const title = image.getAttribute('title')?.trim();
+
+        if (alt) {
+            attributes.push(`alt="${escapeClipboardHtml(alt)}"`);
+        }
+        if (title) {
+            attributes.push(`title="${escapeClipboardHtml(title)}"`);
+        }
+
+        return `<img ${attributes.join(' ')}>`;
+    }
+
+    function serializeChildrenHtmlForClipboard(node: Node): string {
+        return Array.from(node.childNodes).map(serializeNodeHtmlForClipboard).join('');
+    }
+
+    function serializeListItemChildrenHtmlForClipboard(listItem: HTMLElement): string {
+        return Array.from(listItem.childNodes)
+            .map((child) => serializeListItemChildHtmlForClipboard(child))
+            .join('');
+    }
+
+    function serializeListItemChildHtmlForClipboard(child: Node): string {
+        if (child instanceof HTMLParagraphElement) {
+            return serializeChildrenHtmlForClipboard(child);
+        }
+
+        if (child instanceof HTMLElement && shouldUnwrapClipboardListItemElement(child)) {
+            return serializeListItemChildrenHtmlForClipboard(child);
+        }
+
+        return serializeNodeHtmlForClipboard(child);
+    }
+
+    function shouldUnwrapClipboardListItemElement(element: HTMLElement): boolean {
+        const tagName = element.tagName.toLowerCase();
+        if (tagName === 'p') {
+            return true;
+        }
+
+        return (
+            tagName === 'div' ||
+            tagName === 'span' ||
+            element.classList.contains('markdown-renderer') ||
+            element.classList.contains('node-slot') ||
+            element.classList.contains('node-content')
+        );
+    }
+
+    function serializeNodeHtmlForClipboard(node: Node): string {
+        if (node.nodeType === Node.TEXT_NODE) {
+            return serializeTextHtmlForClipboard(node as Text);
+        }
+
+        if (!(node instanceof HTMLElement)) {
+            return serializeChildrenHtmlForClipboard(node);
+        }
+
+        const tagName = node.tagName.toLowerCase();
+        if (isClipboardSkippedElement(node)) {
+            return '';
+        }
+        if (node instanceof HTMLTableElement) {
+            return serializeTableForClipboard(node).html;
+        }
+        if (node instanceof HTMLImageElement) {
+            return serializeImageForClipboard(node);
+        }
+        if (tagName === 'br') {
+            return '<br>';
+        }
+        if (tagName === 'hr') {
+            return '<hr>';
+        }
+        if (tagName === 'pre') {
+            return `<pre><code>${escapeClipboardHtml(node.textContent ?? '')}</code></pre>`;
+        }
+
+        const children =
+            tagName === 'li'
+                ? serializeListItemChildrenHtmlForClipboard(node)
+                : serializeChildrenHtmlForClipboard(node);
+        if (!children || !clipboardSemanticTags.has(tagName)) {
+            return children;
+        }
+
+        if (tagName === 'a') {
+            const href = node.getAttribute('href')?.trim();
+            const title = node.getAttribute('title')?.trim();
+            const attributes: string[] = [];
+
+            if (href && isSafeClipboardUrl(href)) {
+                attributes.push(`href="${escapeClipboardHtml(href)}"`);
+            }
+            if (title) {
+                attributes.push(`title="${escapeClipboardHtml(title)}"`);
+            }
+
+            return `<a${attributes.length ? ` ${attributes.join(' ')}` : ''}>${children}</a>`;
+        }
+        if (tagName === 'ol') {
+            const attributes: string[] = [];
+            const start = parseClipboardIntegerAttribute(node, 'start');
+            const type = node.getAttribute('type')?.trim();
+
+            if (start !== null && start !== 1) {
+                attributes.push(`start="${start}"`);
+            }
+            if (node.hasAttribute('reversed')) {
+                attributes.push('reversed');
+            }
+            if (type && ['1', 'a', 'A', 'i', 'I'].includes(type)) {
+                attributes.push(`type="${type}"`);
+            }
+
+            return `<ol${attributes.length ? ` ${attributes.join(' ')}` : ''}>${children}</ol>`;
+        }
+        if (tagName === 'li') {
+            const value = parseClipboardIntegerAttribute(node, 'value');
+            const attributes = value !== null ? ` value="${value}"` : '';
+
+            return `<li${attributes}>${children}</li>`;
+        }
+
+        return `<${tagName}>${children}</${tagName}>`;
+    }
+
+    function serializeSelectionHtmlForClipboard(root: Node): string {
+        return serializeChildrenHtmlForClipboard(root).trim();
+    }
+
+    type ClipboardListElement = HTMLOListElement | HTMLUListElement;
+
+    function parseClipboardIntegerAttribute(element: Element, name: string): number | null {
+        const rawValue = element.getAttribute(name)?.trim();
+        if (!rawValue) {
+            return null;
+        }
+
+        const parsed = Number.parseInt(rawValue, 10);
+        return Number.isFinite(parsed) ? parsed : null;
+    }
+
+    function getClipboardElementForRangeNode(node: Node): HTMLElement | null {
+        if (node instanceof HTMLElement) {
+            return node;
+        }
+
+        return node.parentElement;
+    }
+
+    function closestClipboardListElement(node: Node): ClipboardListElement | null {
+        const element = getClipboardElementForRangeNode(node);
+        const list = element?.closest('ol, ul');
+
+        return list instanceof HTMLOListElement || list instanceof HTMLUListElement ? list : null;
+    }
+
+    function findSingleClipboardListParent(range: Range): ClipboardListElement | null {
+        const startList = closestClipboardListElement(range.startContainer);
+        const endList = closestClipboardListElement(range.endContainer);
+
+        return startList && startList === endList ? startList : null;
+    }
+
+    function directClipboardListItems(list: ClipboardListElement): HTMLLIElement[] {
+        return Array.from(list.children).filter(
+            (child): child is HTMLLIElement => child instanceof HTMLLIElement
+        );
+    }
+
+    function resolveOrderedListStartForRange(list: HTMLOListElement, range: Range): number | null {
+        const items = directClipboardListItems(list);
+        const selectedItemIndex = items.findIndex((item) => range.intersectsNode(item));
+        if (selectedItemIndex < 0) {
+            return null;
+        }
+
+        const reversed = list.hasAttribute('reversed');
+        let nextNumber =
+            parseClipboardIntegerAttribute(list, 'start') ?? (reversed ? items.length : 1);
+
+        for (let index = 0; index <= selectedItemIndex; index += 1) {
+            const item = items[index];
+            if (!item) {
+                return null;
+            }
+
+            const itemNumber = parseClipboardIntegerAttribute(item, 'value') ?? nextNumber;
+            if (index === selectedItemIndex) {
+                return itemNumber;
+            }
+
+            nextNumber = itemNumber + (reversed ? -1 : 1);
+        }
+
+        return null;
+    }
+
+    function applyClipboardListAttributes(
+        targetList: ClipboardListElement,
+        sourceList: ClipboardListElement,
+        range: Range
+    ) {
+        if (
+            !(targetList instanceof HTMLOListElement) ||
+            !(sourceList instanceof HTMLOListElement)
+        ) {
+            return;
+        }
+
+        const start = resolveOrderedListStartForRange(sourceList, range);
+        const type = sourceList.getAttribute('type')?.trim();
+
+        if (start !== null && (start !== 1 || sourceList.hasAttribute('start'))) {
+            targetList.setAttribute('start', String(start));
+        }
+        if (sourceList.hasAttribute('reversed')) {
+            targetList.setAttribute('reversed', '');
+        }
+        if (type && ['1', 'a', 'A', 'i', 'I'].includes(type)) {
+            targetList.setAttribute('type', type);
+        }
+    }
+
+    function isIgnorableClipboardWhitespaceNode(node: Node): boolean {
+        return node.nodeType === Node.TEXT_NODE && !(node.textContent ?? '').trim();
+    }
+
+    function wrapTopLevelListItemsForClipboard(
+        root: DocumentFragment | HTMLElement,
+        sourceList: ClipboardListElement | null,
+        range: Range
+    ) {
+        if (!sourceList) {
+            return;
+        }
+
+        let child: Node | null = root.firstChild;
+        while (child) {
+            if (!(child instanceof HTMLLIElement)) {
+                child = child.nextSibling;
+                continue;
+            }
+
+            const list = document.createElement(sourceList.tagName.toLowerCase()) as
+                | HTMLOListElement
+                | HTMLUListElement;
+            applyClipboardListAttributes(list, sourceList, range);
+            root.insertBefore(list, child);
+
+            while (child) {
+                if (isIgnorableClipboardWhitespaceNode(child)) {
+                    const nextSibling: Node | null = child.nextSibling;
+                    child.parentNode?.removeChild(child);
+                    child = nextSibling;
+                    continue;
+                }
+                if (!(child instanceof HTMLLIElement)) {
+                    break;
+                }
+
+                const nextSibling: Node | null = child.nextSibling;
+                list.appendChild(child);
+                child = nextSibling;
+            }
+        }
     }
 
     function cloneSelectedMarkdownContents(): HTMLDivElement | null {
@@ -421,7 +902,13 @@
                 continue;
             }
 
-            wrapper.append(range.cloneContents());
+            const selectedContent = range.cloneContents();
+            wrapTopLevelListItemsForClipboard(
+                selectedContent,
+                findSingleClipboardListParent(range),
+                range
+            );
+            wrapper.append(selectedContent);
         }
 
         return wrapper.hasChildNodes() ? wrapper : null;
@@ -450,7 +937,7 @@
 
     function serializeNodePlainTextForClipboard(node: Node): string {
         if (node.nodeType === Node.TEXT_NODE) {
-            return node.textContent ?? '';
+            return serializeTextPlainTextForClipboard(node as Text);
         }
 
         if (!(node instanceof HTMLElement)) {
@@ -458,14 +945,62 @@
         }
 
         const tagName = node.tagName.toLowerCase();
+        if (isClipboardSkippedElement(node)) {
+            return '';
+        }
         if (tagName === 'br') {
             return '\n';
         }
         if (node instanceof HTMLTableElement) {
             return `\n${serializeTableForClipboard(node).text}\n`;
         }
+        if (node instanceof HTMLImageElement) {
+            return node.alt ? `[${node.alt}]` : '';
+        }
+        if (tagName === 'pre') {
+            return `\n${node.textContent ?? ''}\n`;
+        }
+        if (tagName === 'a') {
+            const text = normalizeClipboardPlainText(
+                Array.from(node.childNodes).map(serializeNodePlainTextForClipboard).join('')
+            );
+            const href = node.getAttribute('href')?.trim();
+
+            if (text && href && isSafeClipboardUrl(href) && text !== href) {
+                return `[${text}](${escapeMarkdownLinkDestination(href)})`;
+            }
+
+            return text;
+        }
+        if (tagName === 'ul' || tagName === 'ol') {
+            const listItems = Array.from(node.children).filter(
+                (child): child is HTMLLIElement => child instanceof HTMLLIElement
+            );
+            const reversed = tagName === 'ol' && node.hasAttribute('reversed');
+            let nextNumber =
+                tagName === 'ol'
+                    ? (parseClipboardIntegerAttribute(node, 'start') ??
+                      (reversed ? listItems.length : 1))
+                    : 1;
+            const listText = listItems
+                .map((item) => {
+                    const itemNumber =
+                        tagName === 'ol'
+                            ? (parseClipboardIntegerAttribute(item, 'value') ?? nextNumber)
+                            : nextNumber;
+                    nextNumber = itemNumber + (reversed ? -1 : 1);
+                    const marker = tagName === 'ol' ? `${itemNumber}. ` : '- ';
+                    return `${marker}${serializeSelectionPlainTextForClipboard(item)}`;
+                })
+                .join('\n');
+
+            return listText ? `\n${listText}\n` : '';
+        }
 
         const text = Array.from(node.childNodes).map(serializeNodePlainTextForClipboard).join('');
+        if (tagName === 'li') {
+            return normalizeClipboardPlainText(text);
+        }
         if (!clipboardBlockTags.has(tagName)) {
             return text;
         }
@@ -480,64 +1015,23 @@
         );
     }
 
-    function findSelectedMarkdownTables(): HTMLTableElement[] {
-        const container = markdownContainerRef.value;
-        const selection = window.getSelection();
-        if (!container || !selection || selection.rangeCount === 0 || selection.isCollapsed) {
-            return [];
-        }
-
-        const tables = Array.from(container.querySelectorAll<HTMLTableElement>('table'));
-        if (!tables.length) {
-            return [];
-        }
-
-        const selectedTables: HTMLTableElement[] = [];
-        for (let index = 0; index < selection.rangeCount; index += 1) {
-            const range = selection.getRangeAt(index);
-            for (const table of tables) {
-                if (range.intersectsNode(table) && !selectedTables.includes(table)) {
-                    selectedTables.push(table);
-                }
-            }
-        }
-
-        return selectedTables;
-    }
-
     function handleMarkdownCopy(event: ClipboardEvent) {
         const clipboardData = event.clipboardData;
         if (!clipboardData) {
             return;
         }
 
-        const selectedTables = findSelectedMarkdownTables();
-        if (!selectedTables.length) {
+        const selectedContents = cloneSelectedMarkdownContents();
+        if (!selectedContents) {
             return;
         }
 
-        const selectedContents = cloneSelectedMarkdownContents();
-        if (selectedContents?.querySelector('table')) {
-            replaceRenderedTablesWithSemanticTables(selectedContents);
-            clipboardData.setData('text/html', selectedContents.innerHTML);
-            clipboardData.setData(
-                'text/plain',
-                serializeSelectionPlainTextForClipboard(selectedContents)
-            );
-        } else {
-            const serializedTables = selectedTables.map(serializeTableForClipboard);
-            clipboardData.setData(
-                'text/html',
-                serializedTables.map((table) => table.html).join('')
-            );
-            clipboardData.setData(
-                'text/plain',
-                serializedTables
-                    .map((table) => table.text)
-                    .filter(Boolean)
-                    .join('\n\n')
-            );
-        }
+        replaceRenderedTablesWithSemanticTables(selectedContents);
+        clipboardData.setData('text/html', serializeSelectionHtmlForClipboard(selectedContents));
+        clipboardData.setData(
+            'text/plain',
+            serializeSelectionPlainTextForClipboard(selectedContents)
+        );
         event.preventDefault();
     }
 

--- a/apps/desktop/src/services/ClipboardService/html.ts
+++ b/apps/desktop/src/services/ClipboardService/html.ts
@@ -24,7 +24,7 @@ interface HtmlClipboardFeatures {
 
 const turndownService = createTurndownService();
 const clipboardAllowedUriRegexp =
-    /^(?:(?:(?:https?|mailto|tel|ftp|file|blob|cid):|data:image\/|[^a-z]|[a-z+.-]+(?:[^a-z+.-:]|$)))/i;
+    /^(?:(?:https?|mailto|tel|ftp|file|blob|cid):|data:image\/|[^a-z]|[a-z0-9+.-]+(?:[^a-z0-9+.-:]|$))/i;
 
 export function normalizeClipboardPayload(
     payload: ClipboardPayload | null,
@@ -59,7 +59,7 @@ function convertClipboardHtmlToMarkdown(html: string, sourceUrl: string | null):
     });
     const document = new DOMParser().parseFromString(String(cleanHtml), 'text/html');
     pruneClipboardArtifacts(document);
-    absolutizeClipboardReferences(document, sourceUrl);
+    sanitizeClipboardReferences(document, sourceUrl);
 
     const markdown = normalizeMarkdown(
         turndownService.turndown(document.body || document.documentElement)
@@ -477,19 +477,11 @@ function isHiddenInlineStyle(style: string): boolean {
     );
 }
 
-function absolutizeClipboardReferences(document: Document, sourceUrl: string | null): void {
-    if (!sourceUrl) {
-        return;
-    }
-
-    const base = parseUrl(sourceUrl);
-    if (!base) {
-        return;
-    }
-
+function sanitizeClipboardReferences(document: Document, sourceUrl: string | null): void {
+    const base = sourceUrl ? parseUrl(sourceUrl) : null;
     document.querySelectorAll<HTMLAnchorElement>('a[href]').forEach((link) => {
-        const href = resolveUrl(link.getAttribute('href'), base);
-        if (href && isAllowedLinkUrl(href)) {
+        const href = sanitizeClipboardLinkHref(link.getAttribute('href'), base);
+        if (href) {
             link.href = href;
         } else {
             link.removeAttribute('href');
@@ -497,8 +489,8 @@ function absolutizeClipboardReferences(document: Document, sourceUrl: string | n
     });
 
     document.querySelectorAll<HTMLImageElement>('img[src]').forEach((image) => {
-        const source = resolveUrl(image.getAttribute('src'), base);
-        if (source && isAllowedImageUrl(source)) {
+        const source = sanitizeClipboardImageSource(image.getAttribute('src'), base);
+        if (source) {
             image.src = source;
         } else {
             image.removeAttribute('src');
@@ -524,6 +516,55 @@ function resolveUrl(value: string | null, base: URL): string | null {
     } catch {
         return null;
     }
+}
+
+function getUrlProtocol(value: string): string | null {
+    const protocolMatch = /^([a-z][a-z0-9+.-]*:)/i.exec(value.trim());
+    return protocolMatch?.[1]?.toLowerCase() ?? null;
+}
+
+function sanitizeClipboardLinkHref(value: string | null, base: URL | null): string | null {
+    const normalized = value?.trim();
+    if (!normalized) {
+        return null;
+    }
+    if (normalized.startsWith('#')) {
+        return normalized;
+    }
+
+    const resolved = base ? resolveUrl(normalized, base) : normalized;
+    if (!resolved) {
+        return null;
+    }
+
+    const protocol = getUrlProtocol(resolved);
+    if (!protocol) {
+        return resolved;
+    }
+
+    return isAllowedLinkUrl(resolved) ? resolved : null;
+}
+
+function sanitizeClipboardImageSource(value: string | null, base: URL | null): string | null {
+    const normalized = value?.trim();
+    if (!normalized) {
+        return null;
+    }
+    if (/^data:image\//i.test(normalized)) {
+        return normalized;
+    }
+
+    const resolved = base ? resolveUrl(normalized, base) : normalized;
+    if (!resolved) {
+        return null;
+    }
+
+    const protocol = getUrlProtocol(resolved);
+    if (!protocol) {
+        return resolved;
+    }
+
+    return isAllowedImageUrl(resolved) ? resolved : null;
 }
 
 function isAllowedLinkUrl(value: string): boolean {

--- a/apps/desktop/src/services/ClipboardService/html.ts
+++ b/apps/desktop/src/services/ClipboardService/html.ts
@@ -1,0 +1,633 @@
+﻿import DOMPurify from 'dompurify';
+import TurndownService from 'turndown';
+
+import type {
+    ClipboardHtmlImage,
+    ClipboardPayload,
+    ClipboardPayloadFragment,
+} from '@/services/NativeService/types';
+
+interface HtmlClipboardText {
+    markdown: string | null;
+    features: HtmlClipboardFeatures;
+}
+
+interface HtmlClipboardFeatures {
+    hasBlockquote: boolean;
+    hasCode: boolean;
+    hasHeading: boolean;
+    hasImage: boolean;
+    hasLink: boolean;
+    hasList: boolean;
+    hasTable: boolean;
+}
+
+const turndownService = createTurndownService();
+const clipboardAllowedUriRegexp =
+    /^(?:(?:(?:https?|mailto|tel|ftp|file|blob|cid):|data:image\/|[^a-z]|[a-z+.-]+(?:[^a-z+.-:]|$)))/i;
+
+export function normalizeClipboardPayload(
+    payload: ClipboardPayload | null,
+    options: { preservePlainText?: boolean } = {}
+): ClipboardPayload | null {
+    if (!payload?.html?.trim()) {
+        return payload;
+    }
+
+    const htmlText = convertClipboardHtmlToMarkdown(payload.html, payload.htmlSourceUrl ?? null);
+    const text = chooseClipboardText(payload.text, htmlText, options.preservePlainText ?? false);
+    const fragments = buildClipboardFragments({
+        text,
+        htmlText,
+        htmlImages: payload.htmlImages ?? [],
+        imagePaths: payload.imagePaths ?? [],
+        nativeFragments: payload.fragments,
+    });
+
+    return {
+        ...payload,
+        text,
+        fragments: fragments.length > 0 ? fragments : payload.fragments,
+    };
+}
+
+function convertClipboardHtmlToMarkdown(html: string, sourceUrl: string | null): HtmlClipboardText {
+    const cleanHtml = DOMPurify.sanitize(html, {
+        USE_PROFILES: { html: true },
+        FORBID_TAGS: ['style', 'script', 'noscript', 'template', 'meta', 'link', 'title'],
+        ALLOWED_URI_REGEXP: clipboardAllowedUriRegexp,
+    });
+    const document = new DOMParser().parseFromString(String(cleanHtml), 'text/html');
+    pruneClipboardArtifacts(document);
+    absolutizeClipboardReferences(document, sourceUrl);
+
+    const markdown = normalizeMarkdown(
+        turndownService.turndown(document.body || document.documentElement)
+    );
+
+    return {
+        markdown: markdown || null,
+        features: detectHtmlClipboardFeatures(document),
+    };
+}
+
+function chooseClipboardText(
+    plainText: string | null,
+    htmlText: HtmlClipboardText,
+    preservePlainText: boolean
+): string | null {
+    const plain = normalizePlainText(plainText, preservePlainText);
+    const plainForDecision = normalizePlainText(plainText);
+    if (!htmlText.markdown) {
+        return plain;
+    }
+    if (!plainForDecision) {
+        return htmlText.markdown;
+    }
+
+    return shouldPreferHtmlMarkdown(plainForDecision, htmlText) ? htmlText.markdown : plain;
+}
+
+function buildClipboardFragments(input: {
+    text: string | null;
+    htmlText: HtmlClipboardText;
+    htmlImages: ClipboardHtmlImage[];
+    imagePaths: string[];
+    nativeFragments: ClipboardPayloadFragment[] | undefined;
+}): ClipboardPayloadFragment[] {
+    const { text, htmlText, htmlImages, imagePaths, nativeFragments } = input;
+    const fileFragments = (nativeFragments ?? []).filter(
+        (fragment): fragment is Extract<ClipboardPayloadFragment, { type: 'file' }> =>
+            fragment.type === 'file'
+    );
+    const fallbackImagePaths = buildFallbackImagePaths(imagePaths, nativeFragments);
+    const orderedMarkdown = htmlText.markdown ?? text;
+
+    if (!text?.trim()) {
+        return [
+            ...fallbackImagePaths.map(
+                (path) => ({ type: 'image', path }) as ClipboardPayloadFragment
+            ),
+            ...fileFragments,
+        ];
+    }
+
+    if (orderedMarkdown && (htmlImages.length > 0 || fallbackImagePaths.length > 0)) {
+        const orderedFragments = splitMarkdownImagesIntoFragments(
+            orderedMarkdown,
+            htmlImages,
+            fallbackImagePaths
+        );
+        if (orderedFragments.length > 0) {
+            return [
+                ...orderedFragments,
+                ...fallbackImagePaths.map(
+                    (path) => ({ type: 'image', path }) as ClipboardPayloadFragment
+                ),
+                ...fileFragments,
+            ];
+        }
+    }
+
+    return [
+        { type: 'text', text },
+        ...fallbackImagePaths.map((path) => ({ type: 'image', path }) as ClipboardPayloadFragment),
+        ...fileFragments,
+    ];
+}
+
+function splitMarkdownImagesIntoFragments(
+    markdown: string,
+    htmlImages: ClipboardHtmlImage[],
+    fallbackImagePaths: string[]
+): ClipboardPayloadFragment[] {
+    const fragments: ClipboardPayloadFragment[] = [];
+    let textBuffer = '';
+    let imageIndex = 0;
+    let remaining = markdown;
+
+    while (remaining) {
+        const imageStart = remaining.indexOf('![');
+        if (imageStart < 0) {
+            textBuffer += remaining;
+            break;
+        }
+
+        const parsed = parseMarkdownImageOccurrence(remaining, imageStart);
+        if (!parsed) {
+            textBuffer += remaining.slice(0, imageStart);
+            textBuffer += remaining.slice(imageStart, imageStart + 2);
+            remaining = remaining.slice(imageStart + 2);
+            continue;
+        }
+
+        textBuffer += remaining.slice(0, parsed.start);
+        const image = htmlImages[imageIndex];
+        imageIndex += 1;
+        const imagePath = image?.path ?? shiftFirstClipboardImagePath(fallbackImagePaths);
+        if (imagePath) {
+            removeFirstMatchingClipboardImagePath(fallbackImagePaths, imagePath);
+            pushTextFragment(fragments, textBuffer);
+            textBuffer = '';
+            fragments.push({ type: 'image', path: imagePath });
+        } else {
+            textBuffer += remaining.slice(imageStart, imageStart + parsed.length);
+        }
+
+        remaining = remaining.slice(imageStart + parsed.length);
+    }
+
+    pushTextFragment(fragments, textBuffer);
+    return fragments;
+}
+
+function parseMarkdownImageOccurrence(
+    markdown: string,
+    imageStart: number
+): { start: number; length: number } | null {
+    const imageToken = parseMarkdownImageToken(markdown.slice(imageStart));
+    if (!imageToken) {
+        return null;
+    }
+
+    const imageEnd = imageStart + imageToken.length;
+    if (
+        imageStart > 0 &&
+        markdown[imageStart - 1] === '[' &&
+        markdown[imageEnd] === ']' &&
+        markdown[imageEnd + 1] === '('
+    ) {
+        const linkDestinationEnd = findMarkdownDestinationEnd(markdown, imageEnd + 2);
+        if (linkDestinationEnd >= 0) {
+            const linkedImageStart = imageStart - 1;
+            return {
+                start: linkedImageStart,
+                length: linkDestinationEnd - linkedImageStart + 1,
+            };
+        }
+    }
+
+    return { start: imageStart, length: imageToken.length };
+}
+
+function parseMarkdownImageToken(markdown: string): { length: number } | null {
+    if (!markdown.startsWith('![')) {
+        return null;
+    }
+
+    const labelEnd = findUnescapedChar(markdown, ']', 2);
+    if (labelEnd < 0 || markdown[labelEnd + 1] !== '(') {
+        return null;
+    }
+
+    const destinationEnd = findMarkdownDestinationEnd(markdown, labelEnd + 2);
+    if (destinationEnd < 0) {
+        return null;
+    }
+
+    return { length: destinationEnd + 1 };
+}
+
+function findUnescapedChar(value: string, target: string, start: number): number {
+    let escaped = false;
+    for (let index = start; index < value.length; index += 1) {
+        const char = value[index];
+        if (escaped) {
+            escaped = false;
+            continue;
+        }
+        if (char === '\\') {
+            escaped = true;
+            continue;
+        }
+        if (char === target) {
+            return index;
+        }
+    }
+
+    return -1;
+}
+
+function findMarkdownDestinationEnd(value: string, start: number): number {
+    let escaped = false;
+    let angleDepth = 0;
+    for (let index = start; index < value.length; index += 1) {
+        const char = value[index];
+        if (escaped) {
+            escaped = false;
+            continue;
+        }
+        if (char === '\\') {
+            escaped = true;
+            continue;
+        }
+        if (char === '<') {
+            angleDepth += 1;
+            continue;
+        }
+        if (char === '>' && angleDepth > 0) {
+            angleDepth -= 1;
+            continue;
+        }
+        if (char === ')' && angleDepth === 0) {
+            return index;
+        }
+    }
+
+    return -1;
+}
+
+function pushTextFragment(fragments: ClipboardPayloadFragment[], text: string): void {
+    const normalized = text
+        .replace(/\r\n/g, '\n')
+        .replace(/\r/g, '\n')
+        .replace(/^\n+|\n+$/g, '');
+    if (normalized.length > 0) {
+        fragments.push({
+            type: 'text',
+            text: normalized.includes('\n') ? normalized.trim() : normalized,
+        });
+    }
+}
+
+function buildFallbackImagePaths(
+    imagePaths: string[],
+    nativeFragments: ClipboardPayloadFragment[] | undefined
+): string[] {
+    const paths = [
+        ...imagePaths,
+        ...(nativeFragments ?? [])
+            .filter(
+                (fragment): fragment is Extract<ClipboardPayloadFragment, { type: 'image' }> =>
+                    fragment.type === 'image'
+            )
+            .map((fragment) => fragment.path),
+    ];
+
+    return Array.from(new Set(paths));
+}
+
+function shiftFirstClipboardImagePath(paths: string[]): string | null {
+    return paths.length > 0 ? (paths.shift() ?? null) : null;
+}
+
+function removeFirstMatchingClipboardImagePath(paths: string[], target: string): void {
+    const index = paths.indexOf(target);
+    if (index >= 0) {
+        paths.splice(index, 1);
+    }
+}
+
+function createTurndownService(): TurndownService {
+    const service = new TurndownService({
+        headingStyle: 'atx',
+        codeBlockStyle: 'fenced',
+        bulletListMarker: '-',
+        strongDelimiter: '**',
+        emDelimiter: '_',
+        linkStyle: 'inlined',
+    });
+
+    service.addRule('clipboard-table', {
+        filter: 'table',
+        replacement(_content, node) {
+            return `\n\n${formatPlainTextTable(node as HTMLTableElement)}\n\n`;
+        },
+    });
+
+    service.addRule('clipboard-strikethrough', {
+        filter: (node) => ['DEL', 'S', 'STRIKE'].includes(node.nodeName),
+        replacement(content) {
+            return content.trim() ? `~~${content}~~` : '';
+        },
+    });
+
+    service.addRule('clipboard-mark', {
+        filter: 'mark',
+        replacement(content) {
+            return content.trim() ? `==${content}==` : '';
+        },
+    });
+
+    service.addRule('clipboard-image-placeholder', {
+        filter: 'img',
+        replacement(_content, node) {
+            const image = node as HTMLImageElement;
+            const source = image.currentSrc || image.src || image.getAttribute('src');
+            return source ? `![${escapeMarkdownTableText(image.alt || '')}](${source})` : '';
+        },
+    });
+
+    service.addRule('clipboard-linked-image', {
+        filter: (node) => {
+            if (node.nodeName !== 'A') {
+                return false;
+            }
+
+            const link = node as HTMLAnchorElement;
+            return Boolean(link.querySelector('img') && !link.textContent?.trim());
+        },
+        replacement(content) {
+            return content;
+        },
+    });
+
+    return service;
+}
+
+function formatPlainTextTable(table: HTMLTableElement): string {
+    const rows = Array.from(table.rows)
+        .map((row) =>
+            Array.from(row.cells).map((cell) =>
+                normalizeTableCellText(cell.textContent ?? '').replace(/\t/g, ' ')
+            )
+        )
+        .filter((row) => row.length > 0);
+
+    if (rows.length === 0) {
+        return '';
+    }
+
+    const columnCount = Math.max(...rows.map((row) => row.length));
+    return rows
+        .map((row) => Array.from({ length: columnCount }, (_value, index) => row[index] ?? ''))
+        .map((row) => row.join('\t'))
+        .join('\n');
+}
+
+function normalizeTableCellText(text: string): string {
+    return text.replace(/\s+/g, ' ').trim();
+}
+
+function normalizeMarkdown(markdown: string): string {
+    return normalizeMarkdownListMarkerSpacing(markdown)
+        .replace(/\r\n/g, '\n')
+        .replace(/\r/g, '\n')
+        .split('\n')
+        .map((line) => line.trimEnd())
+        .join('\n')
+        .replace(/\n{3,}/g, '\n\n')
+        .trim();
+}
+
+function normalizeMarkdownListMarkerSpacing(markdown: string): string {
+    const lines = markdown.replace(/\r\n/g, '\n').replace(/\r/g, '\n').split('\n');
+    let inFence = false;
+
+    return lines
+        .map((line) => {
+            if (/^\s*```/.test(line)) {
+                inFence = !inFence;
+                return line;
+            }
+            if (inFence) {
+                return line;
+            }
+
+            return line
+                .replace(/^(\s*)([-+*])\s{2,}(?=\S)/, '$1$2 ')
+                .replace(/^(\s*)(\d+\.)\s{2,}(?=\S)/, '$1$2 ');
+        })
+        .join('\n');
+}
+
+function normalizePlainText(
+    text: string | null | undefined,
+    preserveBoundaryWhitespace = false
+): string | null {
+    const normalized = text?.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+    const output = preserveBoundaryWhitespace ? normalized : normalized?.trim();
+    if (!output || !output.trim()) {
+        return null;
+    }
+
+    return output;
+}
+
+function pruneClipboardArtifacts(document: Document): void {
+    document
+        .querySelectorAll(
+            [
+                'style',
+                'script',
+                'noscript',
+                'template',
+                'meta',
+                'link',
+                'title',
+                '[hidden]',
+                '[aria-hidden="true"]',
+            ].join(',')
+        )
+        .forEach((node) => node.remove());
+
+    document.querySelectorAll<HTMLElement>('[style]').forEach((element) => {
+        if (isHiddenInlineStyle(element.getAttribute('style') ?? '')) {
+            element.remove();
+        }
+    });
+}
+
+function isHiddenInlineStyle(style: string): boolean {
+    const normalized = style.replace(/\s+/g, '').toLowerCase();
+    return (
+        normalized.includes('display:none') ||
+        normalized.includes('visibility:hidden') ||
+        normalized.includes('opacity:0')
+    );
+}
+
+function absolutizeClipboardReferences(document: Document, sourceUrl: string | null): void {
+    if (!sourceUrl) {
+        return;
+    }
+
+    const base = parseUrl(sourceUrl);
+    if (!base) {
+        return;
+    }
+
+    document.querySelectorAll<HTMLAnchorElement>('a[href]').forEach((link) => {
+        const href = resolveUrl(link.getAttribute('href'), base);
+        if (href && isAllowedLinkUrl(href)) {
+            link.href = href;
+        } else {
+            link.removeAttribute('href');
+        }
+    });
+
+    document.querySelectorAll<HTMLImageElement>('img[src]').forEach((image) => {
+        const source = resolveUrl(image.getAttribute('src'), base);
+        if (source && isAllowedImageUrl(source)) {
+            image.src = source;
+        } else {
+            image.removeAttribute('src');
+        }
+    });
+}
+
+function parseUrl(value: string): URL | null {
+    try {
+        return new URL(value);
+    } catch {
+        return null;
+    }
+}
+
+function resolveUrl(value: string | null, base: URL): string | null {
+    if (!value?.trim()) {
+        return null;
+    }
+
+    try {
+        return new URL(value, base).toString();
+    } catch {
+        return null;
+    }
+}
+
+function isAllowedLinkUrl(value: string): boolean {
+    return /^(https?|file|mailto|tel|ftp):/i.test(value) || value.startsWith('#');
+}
+
+function isAllowedImageUrl(value: string): boolean {
+    return /^(https?|file|blob|cid|data:image\/)/i.test(value);
+}
+
+function detectHtmlClipboardFeatures(document: Document): HtmlClipboardFeatures {
+    return {
+        hasBlockquote: Boolean(document.querySelector('blockquote')),
+        hasCode: Boolean(document.querySelector('pre, code')),
+        hasHeading: Boolean(document.querySelector('h1, h2, h3, h4, h5, h6')),
+        hasImage: Boolean(document.querySelector('img')),
+        hasLink: Boolean(document.querySelector('a[href]')),
+        hasList: Boolean(document.querySelector('ul, ol, li')),
+        hasTable: Boolean(document.querySelector('table')),
+    };
+}
+
+function shouldPreferHtmlMarkdown(plain: string, htmlText: HtmlClipboardText): boolean {
+    const markdown = htmlText.markdown;
+    if (!markdown) {
+        return false;
+    }
+
+    const features = htmlText.features;
+    if (features.hasLink && markdownAddsLinkDestinations(plain, markdown)) {
+        return true;
+    }
+    if (features.hasCode && markdownAddsCodeSyntax(plain, markdown)) {
+        return true;
+    }
+    if (features.hasTable) {
+        return !plainTextHasTableStructure(plain);
+    }
+    if (features.hasList) {
+        return !plainTextHasListStructure(plain);
+    }
+    if (features.hasHeading || features.hasBlockquote) {
+        return !plainTextHasLineStructure(plain) && plainTextHasLineStructure(markdown);
+    }
+
+    return false;
+}
+
+function plainTextHasLineStructure(text: string): boolean {
+    return text.includes('\n');
+}
+
+function plainTextHasTableStructure(text: string): boolean {
+    return text.includes('\t') || looksLikeMarkdownTable(text);
+}
+
+function plainTextHasListStructure(text: string): boolean {
+    return /^(?:\s*(?:[-+*•‣◦∙]|\d+[.)])\s+)/m.test(text);
+}
+
+function markdownAddsCodeSyntax(plain: string, markdown: string): boolean {
+    return (/`[^`]+`/.test(markdown) || /^```/m.test(markdown)) && !/`[^`]+`|^```/m.test(plain);
+}
+
+function markdownAddsLinkDestinations(plain: string, markdown: string): boolean {
+    return extractMarkdownLinkDestinations(markdown).some(
+        (destination) => !plain.includes(destination)
+    );
+}
+
+function extractMarkdownLinkDestinations(markdown: string): string[] {
+    const destinations: string[] = [];
+    const linkPattern = /(?<!!)\[[^\]]+]\(([^)\s]+)(?:\s+"[^"]*")?\)/g;
+    let match: RegExpExecArray | null;
+
+    while ((match = linkPattern.exec(markdown)) !== null) {
+        const destination = match[1];
+        if (destination) {
+            destinations.push(destination);
+        }
+    }
+
+    return destinations;
+}
+
+function looksLikeMarkdownTable(text: string): boolean {
+    const lines = text
+        .split('\n')
+        .map((line) => line.trim())
+        .filter(Boolean);
+    const [header, separator] = lines;
+
+    return Boolean(
+        header?.startsWith('|') &&
+        header.endsWith('|') &&
+        separator?.startsWith('|') &&
+        separator.endsWith('|') &&
+        separator
+            .replace(/^\||\|$/g, '')
+            .split('|')
+            .every((cell) => /^:?-+:?$/.test(cell.trim()))
+    );
+}
+
+function escapeMarkdownTableText(text: string): string {
+    return text.replace(/\\/g, '\\\\').replace(/\|/g, '\\|').replace(/\n/g, ' ').trim();
+}

--- a/apps/desktop/src/services/ClipboardService/html.ts
+++ b/apps/desktop/src/services/ClipboardService/html.ts
@@ -24,7 +24,7 @@ interface HtmlClipboardFeatures {
 
 const turndownService = createTurndownService();
 const clipboardAllowedUriRegexp =
-    /^(?:(?:https?|mailto|tel|ftp|file|blob|cid):|data:image\/|[^a-z]|[a-z0-9+.-]+(?:[^a-z0-9+.-:]|$))/i;
+    /^(?:(?:https?|mailto|tel|ftp|file|blob|cid):|data:image\/|[^a-z]|[a-z0-9.+-]+(?:[^a-z0-9.+:-]|$))/i;
 
 export function normalizeClipboardPayload(
     payload: ClipboardPayload | null,
@@ -174,7 +174,7 @@ function splitMarkdownImagesIntoFragments(
             textBuffer += remaining.slice(imageStart, imageStart + parsed.length);
         }
 
-        remaining = remaining.slice(imageStart + parsed.length);
+        remaining = remaining.slice(parsed.start + parsed.length);
     }
 
     pushTextFragment(fragments, textBuffer);

--- a/apps/desktop/src/services/ClipboardService/index.ts
+++ b/apps/desktop/src/services/ClipboardService/index.ts
@@ -1,6 +1,6 @@
 import { createPersistedAttachmentFromData } from '@/services/AgentService/infrastructure/attachments';
 import { native } from '@/services/NativeService';
-import type { ClipboardPayload } from '@/services/NativeService/types';
+import type { ClipboardPayload, ClipboardPayloadFragment } from '@/services/NativeService/types';
 
 import { normalizeClipboardPayload } from './html';
 
@@ -112,6 +112,10 @@ async function withPasteEventAttachments(
         ...payload,
         imagePaths: attachments.imagePaths,
         filePaths: attachments.filePaths,
+        fragments: [
+            ...(payload.fragments ?? []),
+            ...buildAttachmentFragments(attachments.imagePaths, attachments.filePaths),
+        ],
     };
 }
 
@@ -208,6 +212,16 @@ function mergeExplicitPastePayloads(
         text: eventPayload.text ?? nativePayload.text,
         html: eventPayload.html ?? nativePayload.html,
     };
+}
+
+function buildAttachmentFragments(
+    imagePaths: string[],
+    filePaths: string[]
+): ClipboardPayloadFragment[] {
+    return [
+        ...imagePaths.map((path) => ({ type: 'image', path }) as ClipboardPayloadFragment),
+        ...filePaths.map((path) => ({ type: 'file', path }) as ClipboardPayloadFragment),
+    ];
 }
 
 function hashClipboardText(value: string) {

--- a/apps/desktop/src/services/ClipboardService/index.ts
+++ b/apps/desktop/src/services/ClipboardService/index.ts
@@ -1,45 +1,222 @@
-﻿import { native } from '@/services/NativeService';
+import { createPersistedAttachmentFromData } from '@/services/AgentService/infrastructure/attachments';
+import { native } from '@/services/NativeService';
 import type { ClipboardPayload } from '@/services/NativeService/types';
+
+import { normalizeClipboardPayload } from './html';
 
 let lastAutoPasteSnapshotId: string | null = null;
 
-/**
- * 读取显式粘贴使用的剪贴板 payload。
- */
-async function readExplicitPastePayload(): Promise<ClipboardPayload | null> {
-    return native.clipboard.readClipboardPayload();
+async function readExplicitPastePayload(
+    clipboardData?: Pick<DataTransfer, 'getData' | 'items' | 'files'> | null
+): Promise<ClipboardPayload | null> {
+    const eventPayload = buildPayloadFromPasteEvent(clipboardData);
+
+    try {
+        const nativePayload = await native.clipboard.readClipboardPayload();
+        const mergedPayload = mergeExplicitPastePayloads(nativePayload, eventPayload);
+        return normalizeClipboardPayload(
+            await withPasteEventAttachments(mergedPayload, clipboardData),
+            {
+                preservePlainText: true,
+            }
+        );
+    } catch {
+        return normalizeClipboardPayload(
+            await withPasteEventAttachments(eventPayload, clipboardData),
+            {
+                preservePlainText: true,
+            }
+        );
+    }
 }
 
-/**
- * 消费快捷键 auto-paste 使用的剪贴板 payload。
- */
 async function consumeShortcutAutoPastePayload(maxAgeMs: number): Promise<ClipboardPayload | null> {
     const payload = await native.clipboard.consumeShortcutAutoPastePayload(maxAgeMs);
     if (!payload) {
         return null;
     }
 
-    // native 已做一次去重；前端再挡一层，避免页面重复 focus 或异步重入时重复投影。
     if (payload.snapshotId === lastAutoPasteSnapshotId) {
         return null;
     }
 
     lastAutoPasteSnapshotId = payload.snapshotId;
-    return payload;
+    return normalizeClipboardPayload(payload);
 }
 
-/**
- * 将纯文本写入系统剪贴板。
- */
 async function writeText(text: string) {
     await native.clipboard.writeClipboardText(text);
 }
 
-/**
- * 重置前端 auto-paste 快照去重状态。
- */
 function resetAutoPasteGuard() {
     lastAutoPasteSnapshotId = null;
+}
+
+function buildPayloadFromPasteEvent(
+    clipboardData?: Pick<DataTransfer, 'getData' | 'items' | 'files'> | null
+): ClipboardPayload | null {
+    const text = readPasteEventData(clipboardData, 'text/plain');
+    const html = readPasteEventData(clipboardData, 'text/html');
+    const fileCount = readClipboardEventFiles(clipboardData).length;
+
+    if (!text && !html && fileCount === 0) {
+        return null;
+    }
+
+    const observedAt = Date.now();
+    return {
+        snapshotId: `paste-event-${hashClipboardText(
+            [text, html, fileCount > 0 ? `files:${fileCount}` : ''].filter(Boolean).join('\n')
+        )}`,
+        observedAt,
+        text,
+        html,
+        htmlSourceUrl: null,
+        htmlImages: [],
+        imagePaths: [],
+        filePaths: [],
+        fragments: text ? [{ type: 'text', text }] : [],
+    };
+}
+
+function readPasteEventData(
+    clipboardData: Pick<DataTransfer, 'getData'> | null | undefined,
+    type: string
+) {
+    const value = clipboardData?.getData(type)?.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+    return value && value.length > 0 ? value : null;
+}
+
+function clipboardPayloadHasAttachmentData(payload: ClipboardPayload): boolean {
+    return Boolean(
+        payload.imagePaths.length ||
+        payload.filePaths.length ||
+        payload.fragments?.some((fragment) => fragment.type !== 'text')
+    );
+}
+
+async function withPasteEventAttachments(
+    payload: ClipboardPayload | null,
+    clipboardData?: Pick<DataTransfer, 'items' | 'files'> | null
+): Promise<ClipboardPayload | null> {
+    if (!payload || clipboardPayloadHasAttachmentData(payload)) {
+        return payload;
+    }
+
+    const attachments = await readPasteEventAttachments(clipboardData);
+    if (!attachments.imagePaths.length && !attachments.filePaths.length) {
+        return payload;
+    }
+
+    return {
+        ...payload,
+        imagePaths: attachments.imagePaths,
+        filePaths: attachments.filePaths,
+    };
+}
+
+async function readPasteEventAttachments(
+    clipboardData?: Pick<DataTransfer, 'items' | 'files'> | null
+): Promise<{ imagePaths: string[]; filePaths: string[] }> {
+    const files = readClipboardEventFiles(clipboardData);
+    if (!files.length) {
+        return { imagePaths: [], filePaths: [] };
+    }
+
+    const persisted = await Promise.all(files.map((file) => persistClipboardEventFile(file)));
+    return persisted.reduce(
+        (result, attachment) => {
+            if (!attachment) {
+                return result;
+            }
+
+            if (attachment.type === 'image') {
+                result.imagePaths.push(attachment.path);
+            } else {
+                result.filePaths.push(attachment.path);
+            }
+            return result;
+        },
+        { imagePaths: [] as string[], filePaths: [] as string[] }
+    );
+}
+
+function readClipboardEventFiles(
+    clipboardData?: Pick<DataTransfer, 'items' | 'files'> | null
+): File[] {
+    const itemFiles = Array.from(clipboardData?.items ?? [])
+        .filter((item) => item.kind === 'file')
+        .map((item) => item.getAsFile())
+        .filter((file): file is File => file !== null);
+    if (itemFiles.length > 0) {
+        return itemFiles;
+    }
+
+    return Array.from(clipboardData?.files ?? []);
+}
+
+async function persistClipboardEventFile(file: File): Promise<{
+    type: 'image' | 'file';
+    path: string;
+} | null> {
+    const type = file.type.startsWith('image/') ? 'image' : 'file';
+    const name = resolveClipboardEventFileName(file, type);
+
+    try {
+        const attachment = await createPersistedAttachmentFromData({
+            type,
+            name,
+            originPath: `clipboard:${name}`,
+            mimeType: file.type || undefined,
+            size: file.size,
+            data: new Uint8Array(await file.arrayBuffer()),
+        });
+
+        return {
+            type,
+            path: attachment.path,
+        };
+    } catch {
+        return null;
+    }
+}
+
+function resolveClipboardEventFileName(file: File, type: 'image' | 'file') {
+    const trimmedName = file.name.trim();
+    if (trimmedName) {
+        return trimmedName;
+    }
+
+    return type === 'image' ? 'pasted-image' : 'pasted-file';
+}
+
+function mergeExplicitPastePayloads(
+    nativePayload: ClipboardPayload | null,
+    eventPayload: ClipboardPayload | null
+): ClipboardPayload | null {
+    if (!nativePayload) {
+        return eventPayload;
+    }
+    if (!eventPayload) {
+        return nativePayload;
+    }
+
+    return {
+        ...nativePayload,
+        snapshotId: eventPayload.snapshotId,
+        observedAt: eventPayload.observedAt,
+        text: eventPayload.text ?? nativePayload.text,
+        html: eventPayload.html ?? nativePayload.html,
+    };
+}
+
+function hashClipboardText(value: string) {
+    let hash = 5381;
+    for (let index = 0; index < value.length; index += 1) {
+        hash = (hash * 33) ^ value.charCodeAt(index);
+    }
+
+    return (hash >>> 0).toString(16);
 }
 
 export const clipboardService = {

--- a/apps/desktop/src/services/NativeService/types.ts
+++ b/apps/desktop/src/services/NativeService/types.ts
@@ -178,10 +178,18 @@ export type ClipboardPayloadFragment =
           path: string;
       };
 
+export interface ClipboardHtmlImage {
+    source: string;
+    path: string | null;
+}
+
 export interface ClipboardPayload {
     snapshotId: string;
     observedAt: number;
     text: string | null;
+    html?: string | null;
+    htmlSourceUrl?: string | null;
+    htmlImages?: ClipboardHtmlImage[];
     imagePaths: string[];
     filePaths: string[];
     fragments?: ClipboardPayloadFragment[];

--- a/apps/desktop/src/views/SearchView/components/SearchBar/composables/useSearchLogic.ts
+++ b/apps/desktop/src/views/SearchView/components/SearchBar/composables/useSearchLogic.ts
@@ -136,9 +136,11 @@ export function useSearchInput(
         const ed = editor.value;
         const host = editorHostRef.value;
         if (!ed || !host) return;
+        if (!ed.state.selection.empty) return;
 
         requestAnimationFrame(() => {
             const { view } = ed;
+            if (!view.state.selection.empty) return;
             const coords = view.coordsAtPos(view.state.selection.$anchor.pos);
             if (!coords) return;
 

--- a/apps/desktop/src/views/SearchView/components/SearchBar/index.vue
+++ b/apps/desktop/src/views/SearchView/components/SearchBar/index.vue
@@ -34,7 +34,7 @@
                 disabled ? 'pointer-events-none opacity-60' : '',
                 isMultiLine ? 'items-start' : 'items-center',
             ]"
-            :style="{ maxHeight: 'calc(1.5em * 3 + 8px)' }"
+            :style="{ maxHeight: 'calc(1.5em * 7 + 8px)' }"
             @click="onEditorClick"
             @mousedown.capture="handleEditorSelectionMouseDown"
             @mousedown="handleEditorMouseDown"
@@ -63,7 +63,11 @@
     import { type ModelCapabilities, useSearchInput } from './composables/useSearchLogic';
     import { insertAttachmentTag } from './tags/attachment';
     import type { SearchCursorContext, SearchModelOverride } from './types';
-    import { isSearchTagDomTarget, resolveMouseEventTarget } from './utils/tiptap';
+    import {
+        insertPlainTextAtSelection,
+        isSearchTagDomTarget,
+        resolveMouseEventTarget,
+    } from './utils/tiptap';
 
     defineOptions({
         name: 'SearchBar',
@@ -276,26 +280,7 @@
         if (!ed || !text) return;
 
         try {
-            // 使用 ProseMirror 底层 API 精确控制插入位置
-            const { view } = ed;
-            const { state } = view;
-            const { from, to } = state.selection;
-
-            let tr = state.tr;
-
-            // 删除选中的内容（如果有）
-            if (from !== to) {
-                tr = tr.delete(from, to);
-            }
-
-            // 将换行符替换为空格，避免创建新段落
-            const normalizedText = text.replace(/\n/g, ' ');
-
-            // 在光标位置插入纯文本
-            tr = tr.insertText(normalizedText, tr.selection.from);
-
-            // 应用 transaction
-            view.dispatch(tr);
+            insertPlainTextAtSelection(ed, text);
         } catch (error) {
             console.error('Failed to insert text at cursor:', error);
         }
@@ -312,7 +297,6 @@
         if (!ed) return;
 
         try {
-            const cursorPos = ed.view.state.selection.from;
             insertAttachmentTag(
                 ed,
                 {
@@ -322,7 +306,7 @@
                     preview: preview || undefined,
                     alias: alias || '',
                 },
-                { textOffset: cursorPos }
+                { atCurrentSelection: true }
             );
         } catch (error) {
             console.error('Failed to insert attachment at cursor:', error);

--- a/apps/desktop/src/views/SearchView/components/SearchBar/tags/attachment/index.ts
+++ b/apps/desktop/src/views/SearchView/components/SearchBar/tags/attachment/index.ts
@@ -139,6 +139,9 @@ export function insertAttachmentTag(
             if (!attachmentTagType) return false;
             const node = attachmentTagType.create(attrs);
             const pos = resolveAttachmentTagInsertPosition(state, options);
+            if (options.atCurrentSelection && !state.selection.empty) {
+                tr.delete(state.selection.from, state.selection.to);
+            }
             tr.insert(pos, node);
             tr.setSelection(TextSelection.create(tr.doc, pos + node.nodeSize));
             return true;
@@ -154,7 +157,7 @@ function resolveAttachmentTagInsertPosition(
     options: InsertAttachmentTagOptions
 ) {
     if (options.atCurrentSelection) {
-        return state.selection.to;
+        return state.selection.from;
     }
 
     // 普通附件仍跟随当前光标；mixed payload 才按纯文本 offset 定位。

--- a/apps/desktop/src/views/SearchView/components/SearchBar/tags/attachment/index.ts
+++ b/apps/desktop/src/views/SearchView/components/SearchBar/tags/attachment/index.ts
@@ -116,6 +116,7 @@ const AttachmentTagNode = createSearchTagNode({
 interface InsertAttachmentTagOptions {
     textOffset?: number;
     sameOffsetIndex?: number;
+    atCurrentSelection?: boolean;
 }
 
 /**
@@ -126,7 +127,11 @@ export function insertAttachmentTag(
     attrs: AttachmentTagAttrs,
     options: InsertAttachmentTagOptions = {}
 ) {
-    const chain = editor.chain().focus(typeof options.textOffset === 'number' ? undefined : 'end');
+    const chain = editor
+        .chain()
+        .focus(
+            typeof options.textOffset === 'number' || options.atCurrentSelection ? undefined : 'end'
+        );
 
     chain
         .command(({ tr, state }: { tr: Transaction; state: EditorState }) => {
@@ -148,6 +153,10 @@ function resolveAttachmentTagInsertPosition(
     state: EditorState,
     options: InsertAttachmentTagOptions
 ) {
+    if (options.atCurrentSelection) {
+        return state.selection.to;
+    }
+
     // 普通附件仍跟随当前光标；mixed payload 才按纯文本 offset 定位。
     if (typeof options.textOffset !== 'number') {
         return state.selection.to;

--- a/apps/desktop/src/views/SearchView/components/SearchBar/utils/tiptap.ts
+++ b/apps/desktop/src/views/SearchView/components/SearchBar/utils/tiptap.ts
@@ -1,7 +1,7 @@
 import type { Editor, JSONContent } from '@tiptap/core';
 import { Extension } from '@tiptap/core';
 import Placeholder, { type PlaceholderOptions } from '@tiptap/extension-placeholder';
-import type { Node as PmNode } from '@tiptap/pm/model';
+import { Fragment, type Node as PmNode } from '@tiptap/pm/model';
 import type { EditorState, Transaction } from '@tiptap/pm/state';
 import { NodeSelection, Plugin, PluginKey, Selection, TextSelection } from '@tiptap/pm/state';
 import { Decoration, DecorationSet } from '@tiptap/pm/view';
@@ -590,6 +590,52 @@ export function setEditorText(editor: Editor, text: string) {
     setEditorJSON(editor, {
         type: 'doc',
         content: paragraphs,
+    });
+}
+
+/**
+ * 在当前选区插入纯文本，并保留剪贴板/系统文本里的换行。
+ */
+export function insertPlainTextAtSelection(editor: Editor, text: string) {
+    const normalizedText = text.replace(/\r\n?/g, '\n');
+    if (!normalizedText) {
+        return false;
+    }
+
+    return editor.commands.command(({ state, dispatch }) => {
+        const hardBreakType = state.schema.nodes.hardBreak;
+        const lines = normalizedText.split('\n');
+        const nodes: PmNode[] = [];
+
+        for (let index = 0; index < lines.length; index += 1) {
+            const line = lines[index];
+            if (line) {
+                nodes.push(state.schema.text(line));
+            }
+
+            if (index < lines.length - 1) {
+                if (!hardBreakType) {
+                    return false;
+                }
+                nodes.push(hardBreakType.create());
+            }
+        }
+
+        if (!nodes.length) {
+            return false;
+        }
+
+        let tr = state.tr;
+        if (!state.selection.empty) {
+            tr = tr.delete(state.selection.from, state.selection.to);
+        }
+
+        const insertPos = tr.selection.from;
+        const fragment = Fragment.fromArray(nodes);
+        tr = tr.insert(insertPos, fragment);
+        tr = tr.setSelection(TextSelection.create(tr.doc, insertPos + fragment.size));
+        dispatch?.(tr.scrollIntoView());
+        return true;
     });
 }
 

--- a/apps/desktop/src/views/SearchView/index.vue
+++ b/apps/desktop/src/views/SearchView/index.vue
@@ -18,6 +18,7 @@
     import { mcpManager } from '@/services/AgentService/infrastructure/mcp';
     import type { SessionTaskStatus } from '@/services/AgentService/task/types';
     import { clipboardService } from '@/services/ClipboardService';
+    import type { ClipboardPayload } from '@/services/NativeService/types';
     import { useAskUserStore } from '@/stores/askUser';
     import { useMcpStore } from '@/stores/mcp';
     import { useSettingsStore } from '@/stores/settings';
@@ -72,7 +73,11 @@
         SearchModelDropdownState,
         SearchModelOverride,
     } from './types';
-    import { canAutoPasteIntoDraft } from './utils/clipboardDraft';
+    import {
+        canAutoPasteIntoDraft,
+        clipboardPayloadHasAttachmentFragments,
+        trimClipboardPayloadTextBoundary,
+    } from './utils/clipboardDraft';
     defineOptions({
         name: 'SearchViewPage',
     });
@@ -592,21 +597,29 @@
         event.preventDefault();
         event.stopPropagation();
 
-        const payload = await clipboardService.readExplicitPastePayload();
+        const payload = await clipboardService.readExplicitPastePayload(event.clipboardData);
         if (!payload) return;
 
-        const hasOnlyText = !payload.imagePaths?.length && !payload.filePaths?.length;
+        const hasOnlyText =
+            !clipboardPayloadHasAttachmentFragments(payload) &&
+            !payload.imagePaths?.length &&
+            !payload.filePaths?.length;
 
         if (hasOnlyText && payload.text) {
-            const trimmedText = payload.text.trim();
-            if (trimmedText) {
+            const trimmedText = trimClipboardPayloadTextBoundary(payload).text;
+            if (trimmedText?.trim()) {
                 searchBar.value?.insertTextAtCursor(trimmedText);
             }
             return;
         }
 
+        if (clipboardPayloadHasAttachmentFragments(payload)) {
+            await insertClipboardPayloadAtCursor(payload);
+            return;
+        }
+
         if (payload.text?.trim()) {
-            searchBar.value?.insertTextAtCursor(payload.text.trim());
+            searchBar.value?.insertTextAtCursor(payload.text);
         }
 
         const attachmentsToInsert: Array<{ path: string; type: 'image' | 'file' }> = [];
@@ -634,6 +647,43 @@
                 );
             } catch (error) {
                 console.error(`Failed to insert ${type} attachment:`, error);
+            }
+        }
+    }
+
+    async function insertClipboardPayloadAtCursor(payload: ClipboardPayload) {
+        const normalizedPayload = trimClipboardPayloadTextBoundary(payload);
+        if (!normalizedPayload.fragments?.length) {
+            return;
+        }
+
+        for (const fragment of normalizedPayload.fragments) {
+            if (fragment.type === 'text') {
+                if (fragment.text) {
+                    searchBar.value?.insertTextAtCursor(fragment.text);
+                }
+                continue;
+            }
+
+            try {
+                const attachment = await createAttachmentFromClipboardPath(
+                    fragment.type,
+                    fragment.path
+                );
+                attachments.value.push(attachment);
+                searchBar.value?.insertAttachmentAtCursor(
+                    attachment.id,
+                    attachment.name ||
+                        t(
+                            fragment.type === 'image'
+                                ? 'conversation.attachment.unnamedImage'
+                                : 'conversation.attachment.unnamedFile'
+                        ),
+                    fragment.type,
+                    attachment.preview
+                );
+            } catch (error) {
+                console.error(`Failed to insert ${fragment.type} attachment:`, error);
             }
         }
     }

--- a/apps/desktop/src/views/SearchView/utils/clipboardDraft.ts
+++ b/apps/desktop/src/views/SearchView/utils/clipboardDraft.ts
@@ -34,6 +34,13 @@ export function canAutoPasteIntoDraft(input: {
 }
 
 /**
+ * 判断 payload 是否包含需要保序投影的附件 fragment。
+ */
+export function clipboardPayloadHasAttachmentFragments(payload: ClipboardPayload) {
+    return Boolean(payload.fragments?.some((fragment) => fragment.type !== 'text'));
+}
+
+/**
  * 将剪贴板 payload 投影到搜索草稿。
  */
 export async function applyClipboardPayloadToDraft<TAttachment>(
@@ -135,7 +142,7 @@ function setDraftInsertionOffset<TAttachment>(attachment: TAttachment, offset: n
 /**
  * 裁剪剪贴板 payload 的首尾空白。
  */
-function trimClipboardPayloadTextBoundary(payload: ClipboardPayload): ClipboardPayload {
+export function trimClipboardPayloadTextBoundary(payload: ClipboardPayload): ClipboardPayload {
     if (payload.fragments?.length) {
         return {
             ...payload,

--- a/apps/desktop/tests/SearchView/SearchBar/tiptap.test.ts
+++ b/apps/desktop/tests/SearchView/SearchBar/tiptap.test.ts
@@ -3,6 +3,7 @@ import { Schema } from '@tiptap/pm/model';
 import { EditorState, TextSelection, type Transaction } from '@tiptap/pm/state';
 import { describe, expect, it } from 'vitest';
 
+import { insertAttachmentTag } from '@/views/SearchView/components/SearchBar/tags/attachment';
 import {
     getEditorText,
     insertPlainTextAtSelection,
@@ -87,6 +88,50 @@ function createCommandEditorFromDoc(
     }
 
     return editor as Editor;
+}
+
+function createChainEditorFromDoc(
+    doc: ReturnType<typeof schema.node>,
+    selection?: { from: number; to?: number }
+): Editor {
+    const editor = {
+        state: EditorState.create({
+            schema,
+            doc,
+        }),
+        chain: () => {
+            const callbacks: Array<(props: { tr: Transaction; state: EditorState }) => boolean> =
+                [];
+            const chain = {
+                focus: () => chain,
+                command: (
+                    callback: (props: { tr: Transaction; state: EditorState }) => boolean
+                ) => {
+                    callbacks.push(callback);
+                    return chain;
+                },
+                run: () =>
+                    callbacks.every((callback) => {
+                        const tr = editor.state.tr;
+                        const result = callback({ tr, state: editor.state });
+                        if (result) {
+                            editor.state = editor.state.apply(tr);
+                        }
+                        return result;
+                    }),
+            };
+            return chain;
+        },
+    };
+
+    if (selection) {
+        const tr = editor.state.tr.setSelection(
+            TextSelection.create(editor.state.doc, selection.from, selection.to ?? selection.from)
+        );
+        editor.state = editor.state.apply(tr);
+    }
+
+    return editor as unknown as Editor;
 }
 
 describe('SearchBar tiptap utilities', () => {
@@ -191,5 +236,31 @@ describe('SearchBar tiptap utilities', () => {
         expect(insertPlainTextAtSelection(editor, 'X\n\nY')).toBe(true);
 
         expect(getEditorText(editor)).toBe('left X\n\nY right');
+    });
+
+    it('replaces selected text when inserting an attachment at the current selection', () => {
+        const doc = schema.nodes.doc!.create(null, [
+            schema.nodes.paragraph!.create(null, [schema.text('left OLD right')]),
+        ]);
+        const editor = createChainEditorFromDoc(doc, {
+            from: 1 + 'left '.length,
+            to: 1 + 'left OLD'.length,
+        });
+
+        insertAttachmentTag(
+            editor,
+            {
+                attachmentId: 'image-1',
+                alias: '',
+                fileName: 'image.png',
+                fileType: 'image',
+            },
+            { atCurrentSelection: true }
+        );
+
+        const paragraph = editor.state.doc.child(0);
+        expect(getEditorText(editor)).toBe('left  right');
+        expect(paragraph.child(1)?.type.name).toBe('attachmentTag');
+        expect(paragraph.child(1)?.attrs.attachmentId).toBe('image-1');
     });
 });

--- a/apps/desktop/tests/SearchView/SearchBar/tiptap.test.ts
+++ b/apps/desktop/tests/SearchView/SearchBar/tiptap.test.ts
@@ -1,8 +1,12 @@
 import type { Editor } from '@tiptap/core';
 import { Schema } from '@tiptap/pm/model';
+import { EditorState, TextSelection, type Transaction } from '@tiptap/pm/state';
 import { describe, expect, it } from 'vitest';
 
-import { getEditorText } from '@/views/SearchView/components/SearchBar/utils/tiptap';
+import {
+    getEditorText,
+    insertPlainTextAtSelection,
+} from '@/views/SearchView/components/SearchBar/utils/tiptap';
 
 const schema = new Schema({
     nodes: {
@@ -44,6 +48,45 @@ function createEditorFromDoc(doc: ReturnType<typeof schema.node>): Editor {
             doc,
         },
     } as Editor;
+}
+
+function createCommandEditorFromDoc(
+    doc: ReturnType<typeof schema.node>,
+    selection?: { from: number; to?: number }
+): Editor {
+    const editor = {
+        state: EditorState.create({
+            schema,
+            doc,
+        }),
+        view: {
+            dispatch: (tr: Transaction) => {
+                editor.state = editor.state.apply(tr);
+            },
+        },
+        commands: {
+            command: (
+                callback: (props: {
+                    state: EditorState;
+                    dispatch?: (tr: Transaction) => void;
+                }) => boolean
+            ) => {
+                return callback({
+                    state: editor.state,
+                    dispatch: editor.view.dispatch,
+                });
+            },
+        },
+    };
+
+    if (selection) {
+        const tr = editor.state.tr.setSelection(
+            TextSelection.create(editor.state.doc, selection.from, selection.to ?? selection.from)
+        );
+        editor.state = editor.state.apply(tr);
+    }
+
+    return editor as Editor;
 }
 
 describe('SearchBar tiptap utilities', () => {
@@ -123,5 +166,30 @@ describe('SearchBar tiptap utilities', () => {
         ]);
 
         expect(getEditorText(createEditorFromDoc(doc))).toBe('before\nafter');
+    });
+
+    it('inserts pasted plain text without flattening line breaks', () => {
+        const doc = schema.nodes.doc!.create(null, [
+            schema.nodes.paragraph!.create(null, [schema.text('before ')]),
+        ]);
+        const editor = createCommandEditorFromDoc(doc, { from: 1 + 'before '.length });
+
+        expect(insertPlainTextAtSelection(editor, 'Python\t动态\r\nRust\t静态')).toBe(true);
+
+        expect(getEditorText(editor)).toBe('before Python\t动态\nRust\t静态');
+    });
+
+    it('replaces selected text while preserving consecutive line breaks', () => {
+        const doc = schema.nodes.doc!.create(null, [
+            schema.nodes.paragraph!.create(null, [schema.text('left OLD right')]),
+        ]);
+        const editor = createCommandEditorFromDoc(doc, {
+            from: 1 + 'left '.length,
+            to: 1 + 'left OLD'.length,
+        });
+
+        expect(insertPlainTextAtSelection(editor, 'X\n\nY')).toBe(true);
+
+        expect(getEditorText(editor)).toBe('left X\n\nY right');
     });
 });

--- a/apps/desktop/tests/SearchView/SearchBarLayout.test.ts
+++ b/apps/desktop/tests/SearchView/SearchBarLayout.test.ts
@@ -105,4 +105,12 @@ describe('SearchBar layout', () => {
         expect(searchBar.classes()).toContain('items-start');
         expect(searchBar.classes()).not.toContain('items-center');
     });
+
+    it('allows the input editor to grow up to seven text lines', () => {
+        const wrapper = mountSearchBar();
+
+        const editorHost = wrapper.get('[data-testid="search-editor-host"]');
+
+        expect(editorHost.attributes('style')).toContain('max-height: calc(10.5em + 8px)');
+    });
 });

--- a/apps/desktop/tests/SearchView/utils/clipboardDraft.test.ts
+++ b/apps/desktop/tests/SearchView/utils/clipboardDraft.test.ts
@@ -5,6 +5,7 @@ import type { ClipboardPayload } from '@/services/NativeService/types';
 import {
     applyClipboardPayloadToDraft,
     canAutoPasteIntoDraft,
+    clipboardPayloadHasAttachmentFragments,
 } from '@/views/SearchView/utils/clipboardDraft';
 
 interface DraftAttachment {
@@ -132,5 +133,33 @@ describe('clipboardDraft', () => {
                 draftInsertionOffset: 5,
             },
         ]);
+    });
+
+    it('detects attachment fragments separately from plain text fragments', () => {
+        expect(
+            clipboardPayloadHasAttachmentFragments({
+                snapshotId: 'text-fragments',
+                observedAt: Date.now(),
+                text: 'hello',
+                imagePaths: [],
+                filePaths: [],
+                fragments: [{ type: 'text', text: 'hello' }],
+            })
+        ).toBe(false);
+
+        expect(
+            clipboardPayloadHasAttachmentFragments({
+                snapshotId: 'mixed-fragments',
+                observedAt: Date.now(),
+                text: 'hello world',
+                imagePaths: ['D:/clip/image.png'],
+                filePaths: [],
+                fragments: [
+                    { type: 'text', text: 'hello ' },
+                    { type: 'image', path: 'D:/clip/image.png' },
+                    { type: 'text', text: ' world' },
+                ],
+            })
+        ).toBe(true);
     });
 });

--- a/apps/desktop/tests/components/MarkdownContent-i18n.test.ts
+++ b/apps/desktop/tests/components/MarkdownContent-i18n.test.ts
@@ -749,6 +749,64 @@ describe('MarkdownContent i18n', () => {
         wrapper.unmount();
     });
 
+    it('drops unsafe clipboard URL schemes while preserving safe image data URLs', async () => {
+        const { default: MarkdownContent } = await import('@components/MarkdownContent.vue');
+        const wrapper = mount(MarkdownContent, {
+            props: {
+                content: 'Safe docs bad js image',
+            },
+            attachTo: document.body,
+        });
+
+        const container = wrapper.element as HTMLElement;
+        container.innerHTML = `
+            <div class="markstream-vue">
+                <p>
+                    Safe <a href="https://example.com/docs">docs</a>
+                    <a href="data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==">bad</a>
+                    <a href="javascript:alert(1)">js</a>
+                </p>
+                <p>
+                    <img src="data:image/png;base64,AAAA" alt="Inline image">
+                    <img src="data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==" alt="Bad image">
+                </p>
+            </div>
+        `;
+
+        const range = document.createRange();
+        range.selectNodeContents(container.querySelector('.markstream-vue')!);
+        const selection = window.getSelection()!;
+        selection.removeAllRanges();
+        selection.addRange(range);
+
+        const clipboardData = new ClipboardDataStub();
+        const copyEvent = new Event('copy', {
+            bubbles: true,
+            cancelable: true,
+        }) as ClipboardEvent;
+        Object.defineProperty(copyEvent, 'clipboardData', {
+            value: clipboardData,
+        });
+
+        const prevented = !container.dispatchEvent(copyEvent);
+
+        expect(prevented).toBe(true);
+        expect(clipboardData.getData('text/plain')).toBe(
+            'Safe [docs](https://example.com/docs) bad js\n[Inline image]'
+        );
+        expect(clipboardData.getData('text/html')).toContain(
+            '<a href="https://example.com/docs">docs</a>'
+        );
+        expect(clipboardData.getData('text/html')).toContain(
+            '<img src="data:image/png;base64,AAAA" alt="Inline image">'
+        );
+        expect(clipboardData.getData('text/html')).not.toContain('javascript:');
+        expect(clipboardData.getData('text/html')).not.toContain('data:text/html');
+
+        selection.removeAllRanges();
+        wrapper.unmount();
+    });
+
     it('preserves inline spacing while skipping non-content clipboard artifacts', async () => {
         const { default: MarkdownContent } = await import('@components/MarkdownContent.vue');
         const wrapper = mount(MarkdownContent, {

--- a/apps/desktop/tests/components/MarkdownContent-i18n.test.ts
+++ b/apps/desktop/tests/components/MarkdownContent-i18n.test.ts
@@ -353,6 +353,63 @@ describe('MarkdownContent i18n', () => {
         wrapper.unmount();
     });
 
+    it('preserves inline semantics inside copied table cell HTML', async () => {
+        const { default: MarkdownContent } = await import('@components/MarkdownContent.vue');
+        const wrapper = mount(MarkdownContent, {
+            props: {
+                content: '| Link | Preview |\n| --- | --- |\n| Docs | code |',
+            },
+            attachTo: document.body,
+        });
+
+        const container = wrapper.element as HTMLElement;
+        container.innerHTML = `
+            <div class="markstream-vue">
+                <table class="table-node" style="border-collapse: separate;">
+                    <tbody>
+                        <tr>
+                            <td class="px-3"><a class="link-token" style="color: blue;" href="https://example.com/docs">Docs</a></td>
+                            <td class="px-3"><img src="data:image/png;base64,AAAA" alt="Inline image"><span>Preview</span></td>
+                        </tr>
+                        <tr>
+                            <td class="px-3"><code class="language-ts">code</code></td>
+                            <td class="px-3"><a href="javascript:alert(1)">unsafe</a></td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        `;
+
+        const table = container.querySelector('table')!;
+        const range = document.createRange();
+        range.selectNode(table);
+        const selection = window.getSelection()!;
+        selection.removeAllRanges();
+        selection.addRange(range);
+
+        const clipboardData = new ClipboardDataStub();
+        const copyEvent = new Event('copy', {
+            bubbles: true,
+            cancelable: true,
+        }) as ClipboardEvent;
+        Object.defineProperty(copyEvent, 'clipboardData', {
+            value: clipboardData,
+        });
+
+        const prevented = !container.dispatchEvent(copyEvent);
+
+        expect(prevented).toBe(true);
+        expect(clipboardData.getData('text/plain')).toBe('Docs\tPreview\ncode\tunsafe');
+        expect(clipboardData.getData('text/html')).toBe(
+            '<table border="1" cellspacing="0" cellpadding="4" style="border-collapse: collapse;"><tbody><tr><td style="border: 1px solid #000; padding: 4px;"><a href="https://example.com/docs">Docs</a></td><td style="border: 1px solid #000; padding: 4px;"><img src="data:image/png;base64,AAAA" alt="Inline image">Preview</td></tr><tr><td style="border: 1px solid #000; padding: 4px;"><code>code</code></td><td style="border: 1px solid #000; padding: 4px;"><a>unsafe</a></td></tr></tbody></table>'
+        );
+        expect(clipboardData.getData('text/html')).not.toContain('class=');
+        expect(clipboardData.getData('text/html')).not.toContain('javascript:');
+
+        selection.removeAllRanges();
+        wrapper.unmount();
+    });
+
     it('preserves surrounding selected text when cleaning copied table HTML', async () => {
         const { default: MarkdownContent } = await import('@components/MarkdownContent.vue');
         const wrapper = mount(MarkdownContent, {
@@ -406,6 +463,54 @@ describe('MarkdownContent i18n', () => {
         expect(clipboardData.getData('text/html')).not.toContain('border-collapse: separate');
 
         selection.removeAllRanges();
+        wrapper.unmount();
+    });
+
+    it('clips copied selections to the markdown container bounds', async () => {
+        const { default: MarkdownContent } = await import('@components/MarkdownContent.vue');
+        const wrapper = mount(MarkdownContent, {
+            props: {
+                content: 'Inside text',
+            },
+            attachTo: document.body,
+        });
+
+        const container = wrapper.element as HTMLElement;
+        const outside = document.createElement('p');
+        outside.textContent = 'Outside';
+        container.parentNode?.insertBefore(outside, container);
+        container.innerHTML = `
+            <div class="markstream-vue">
+                <p>Inside <strong>text</strong></p>
+            </div>
+        `;
+
+        const insideText = container.querySelector('strong')!.firstChild!;
+        const range = document.createRange();
+        range.setStart(outside.firstChild!, 0);
+        range.setEnd(insideText, insideText.textContent!.length);
+        const selection = window.getSelection()!;
+        selection.removeAllRanges();
+        selection.addRange(range);
+
+        const clipboardData = new ClipboardDataStub();
+        const copyEvent = new Event('copy', {
+            bubbles: true,
+            cancelable: true,
+        }) as ClipboardEvent;
+        Object.defineProperty(copyEvent, 'clipboardData', {
+            value: clipboardData,
+        });
+
+        const prevented = !container.dispatchEvent(copyEvent);
+
+        expect(prevented).toBe(true);
+        expect(clipboardData.getData('text/plain')).toBe('Inside text');
+        expect(clipboardData.getData('text/html')).toBe('<p>Inside <strong>text</strong></p>');
+        expect(clipboardData.getData('text/plain')).not.toContain('Outside');
+
+        selection.removeAllRanges();
+        outside.remove();
         wrapper.unmount();
     });
 

--- a/apps/desktop/tests/components/MarkdownContent-i18n.test.ts
+++ b/apps/desktop/tests/components/MarkdownContent-i18n.test.ts
@@ -61,6 +61,18 @@ vi.mock('@/services/ClipboardService', () => ({
     },
 }));
 
+class ClipboardDataStub {
+    private readonly data = new Map<string, string>();
+
+    setData(type: string, value: string) {
+        this.data.set(type, value);
+    }
+
+    getData(type: string) {
+        return this.data.get(type) ?? '';
+    }
+}
+
 describe('MarkdownContent i18n', () => {
     beforeEach(async () => {
         vi.clearAllMocks();
@@ -271,6 +283,121 @@ describe('MarkdownContent i18n', () => {
             body: 'Copied',
         });
 
+        wrapper.unmount();
+    });
+
+    it('copies selected tables as semantic clipboard HTML without rendered table styling', async () => {
+        const { default: MarkdownContent } = await import('@components/MarkdownContent.vue');
+        const wrapper = mount(MarkdownContent, {
+            props: {
+                content: '| Name | Value |\n| --- | --- |\n| Alpha | 1 |',
+            },
+            attachTo: document.body,
+        });
+
+        const container = wrapper.element as HTMLElement;
+        container.innerHTML = `
+            <div class="markstream-vue">
+                <table class="table-node" style="border-collapse: separate; border-spacing: 0;">
+                    <thead>
+                        <tr>
+                            <th class="px-3">Name</th>
+                            <th class="px-3">Value</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="px-3">Alpha</td>
+                            <td class="px-3">1</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        `;
+
+        const table = container.querySelector('table')!;
+        const range = document.createRange();
+        range.selectNode(table);
+        const selection = window.getSelection()!;
+        selection.removeAllRanges();
+        selection.addRange(range);
+
+        const clipboardData = new ClipboardDataStub();
+        const copyEvent = new Event('copy', {
+            bubbles: true,
+            cancelable: true,
+        }) as ClipboardEvent;
+        Object.defineProperty(copyEvent, 'clipboardData', {
+            value: clipboardData,
+        });
+
+        const prevented = !container.dispatchEvent(copyEvent);
+
+        expect(prevented).toBe(true);
+        expect(clipboardData.getData('text/plain')).toBe('Name\tValue\nAlpha\t1');
+        expect(clipboardData.getData('text/html')).toBe(
+            '<table><thead><tr><th>Name</th><th>Value</th></tr></thead><tbody><tr><td>Alpha</td><td>1</td></tr></tbody></table>'
+        );
+        expect(clipboardData.getData('text/html')).not.toContain('table-node');
+        expect(clipboardData.getData('text/html')).not.toContain('border-collapse');
+
+        selection.removeAllRanges();
+        wrapper.unmount();
+    });
+
+    it('preserves surrounding selected text when cleaning copied table HTML', async () => {
+        const { default: MarkdownContent } = await import('@components/MarkdownContent.vue');
+        const wrapper = mount(MarkdownContent, {
+            props: {
+                content: 'Before\n\n| Name | Value |\n| --- | --- |\n| Alpha | 1 |\n\nAfter',
+            },
+            attachTo: document.body,
+        });
+
+        const container = wrapper.element as HTMLElement;
+        container.innerHTML = `
+            <div class="markstream-vue">
+                <p>Before</p>
+                <table class="table-node" style="border-collapse: separate;">
+                    <tbody>
+                        <tr>
+                            <td class="px-3">Alpha</td>
+                            <td class="px-3">1</td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p>After</p>
+            </div>
+        `;
+
+        const range = document.createRange();
+        range.selectNodeContents(container.querySelector('.markstream-vue')!);
+        const selection = window.getSelection()!;
+        selection.removeAllRanges();
+        selection.addRange(range);
+
+        const clipboardData = new ClipboardDataStub();
+        const copyEvent = new Event('copy', {
+            bubbles: true,
+            cancelable: true,
+        }) as ClipboardEvent;
+        Object.defineProperty(copyEvent, 'clipboardData', {
+            value: clipboardData,
+        });
+
+        const prevented = !container.dispatchEvent(copyEvent);
+
+        expect(prevented).toBe(true);
+        expect(clipboardData.getData('text/plain')).toBe('Before\nAlpha\t1\nAfter');
+        expect(clipboardData.getData('text/html')).toContain('<p>Before</p>');
+        expect(clipboardData.getData('text/html')).toContain(
+            '<table><tbody><tr><td>Alpha</td><td>1</td></tr></tbody></table>'
+        );
+        expect(clipboardData.getData('text/html')).toContain('<p>After</p>');
+        expect(clipboardData.getData('text/html')).not.toContain('table-node');
+        expect(clipboardData.getData('text/html')).not.toContain('border-collapse');
+
+        selection.removeAllRanges();
         wrapper.unmount();
     });
 });

--- a/apps/desktop/tests/components/MarkdownContent-i18n.test.ts
+++ b/apps/desktop/tests/components/MarkdownContent-i18n.test.ts
@@ -73,6 +73,13 @@ class ClipboardDataStub {
     }
 }
 
+function requiredTextNode(nodes: NodeListOf<Element>, index: number): Text {
+    const textNode = nodes.item(index)?.firstChild;
+    expect(textNode).toBeInstanceOf(Text);
+
+    return textNode as Text;
+}
+
 describe('MarkdownContent i18n', () => {
     beforeEach(async () => {
         vi.clearAllMocks();
@@ -286,7 +293,7 @@ describe('MarkdownContent i18n', () => {
         wrapper.unmount();
     });
 
-    it('copies selected tables as semantic clipboard HTML without rendered table styling', async () => {
+    it('copies selected tables as Word-compatible grid table clipboard HTML', async () => {
         const { default: MarkdownContent } = await import('@components/MarkdownContent.vue');
         const wrapper = mount(MarkdownContent, {
             props: {
@@ -336,10 +343,11 @@ describe('MarkdownContent i18n', () => {
         expect(prevented).toBe(true);
         expect(clipboardData.getData('text/plain')).toBe('Name\tValue\nAlpha\t1');
         expect(clipboardData.getData('text/html')).toBe(
-            '<table><thead><tr><th>Name</th><th>Value</th></tr></thead><tbody><tr><td>Alpha</td><td>1</td></tr></tbody></table>'
+            '<table border="1" cellspacing="0" cellpadding="4" style="border-collapse: collapse;"><thead><tr><th style="border: 1px solid #000; padding: 4px;">Name</th><th style="border: 1px solid #000; padding: 4px;">Value</th></tr></thead><tbody><tr><td style="border: 1px solid #000; padding: 4px;">Alpha</td><td style="border: 1px solid #000; padding: 4px;">1</td></tr></tbody></table>'
         );
         expect(clipboardData.getData('text/html')).not.toContain('table-node');
-        expect(clipboardData.getData('text/html')).not.toContain('border-collapse');
+        expect(clipboardData.getData('text/html')).not.toContain('border-collapse: separate');
+        expect(clipboardData.getData('text/html')).not.toContain('border-spacing');
 
         selection.removeAllRanges();
         wrapper.unmount();
@@ -391,11 +399,406 @@ describe('MarkdownContent i18n', () => {
         expect(clipboardData.getData('text/plain')).toBe('Before\nAlpha\t1\nAfter');
         expect(clipboardData.getData('text/html')).toContain('<p>Before</p>');
         expect(clipboardData.getData('text/html')).toContain(
-            '<table><tbody><tr><td>Alpha</td><td>1</td></tr></tbody></table>'
+            '<table border="1" cellspacing="0" cellpadding="4" style="border-collapse: collapse;"><tbody><tr><td style="border: 1px solid #000; padding: 4px;">Alpha</td><td style="border: 1px solid #000; padding: 4px;">1</td></tr></tbody></table>'
         );
         expect(clipboardData.getData('text/html')).toContain('<p>After</p>');
         expect(clipboardData.getData('text/html')).not.toContain('table-node');
-        expect(clipboardData.getData('text/html')).not.toContain('border-collapse');
+        expect(clipboardData.getData('text/html')).not.toContain('border-collapse: separate');
+
+        selection.removeAllRanges();
+        wrapper.unmount();
+    });
+
+    it('copies mixed markdown selections as clean semantic clipboard HTML and readable plain text', async () => {
+        const { default: MarkdownContent } = await import('@components/MarkdownContent.vue');
+        const wrapper = mount(MarkdownContent, {
+            props: {
+                content:
+                    '## Title\n\nIntro **bold**\n\n- First\n- Second\n\n```ts\nconst x = 1;\n```',
+            },
+            attachTo: document.body,
+        });
+
+        const container = wrapper.element as HTMLElement;
+        container.innerHTML = `
+            <div class="markstream-vue" style="color: red;">
+                <h2 class="heading-token" style="font-size: 28px;">Title</h2>
+                <p class="paragraph-token" style="margin: 0;">Intro <strong class="font-bold">bold</strong></p>
+                <ul class="list-token" style="padding-left: 32px;">
+                    <li class="item-token"><span style="color: blue;">First</span></li>
+                    <li class="item-token">Second</li>
+                </ul>
+                <pre class="code-block" style="background: #111;"><code class="language-ts">const x = 1;</code></pre>
+            </div>
+        `;
+
+        const range = document.createRange();
+        range.selectNodeContents(container.querySelector('.markstream-vue')!);
+        const selection = window.getSelection()!;
+        selection.removeAllRanges();
+        selection.addRange(range);
+
+        const clipboardData = new ClipboardDataStub();
+        const copyEvent = new Event('copy', {
+            bubbles: true,
+            cancelable: true,
+        }) as ClipboardEvent;
+        Object.defineProperty(copyEvent, 'clipboardData', {
+            value: clipboardData,
+        });
+
+        const prevented = !container.dispatchEvent(copyEvent);
+
+        expect(prevented).toBe(true);
+        expect(clipboardData.getData('text/plain')).toBe(
+            'Title\nIntro bold\n- First\n- Second\nconst x = 1;'
+        );
+        expect(clipboardData.getData('text/html')).toBe(
+            '<h2>Title</h2><p>Intro <strong>bold</strong></p><ul><li>First</li><li>Second</li></ul><pre><code>const x = 1;</code></pre>'
+        );
+        expect(clipboardData.getData('text/html')).not.toContain('class=');
+        expect(clipboardData.getData('text/html')).not.toContain('style=');
+
+        selection.removeAllRanges();
+        wrapper.unmount();
+    });
+
+    it('flattens paragraph wrappers inside copied list items for Word-compatible list HTML', async () => {
+        const { default: MarkdownContent } = await import('@components/MarkdownContent.vue');
+        const wrapper = mount(MarkdownContent, {
+            props: {
+                content:
+                    '- **Objective**(目标): 建立清晰目标\n- Key Results: 可量化结果\n\n1. 公开透明\n2. 季度周期',
+            },
+            attachTo: document.body,
+        });
+
+        const container = wrapper.element as HTMLElement;
+        container.innerHTML = `
+            <div class="markstream-vue">
+                <ul class="list-token">
+                    <li class="item-token"><p><strong>Objective</strong>(目标): 建立清晰目标</p></li>
+                    <li class="item-token"><p>Key Results: 可量化结果</p></li>
+                </ul>
+                <ol class="list-token">
+                    <li class="item-token"><p>公开透明</p></li>
+                    <li class="item-token"><p>季度周期</p></li>
+                </ol>
+            </div>
+        `;
+
+        const range = document.createRange();
+        range.selectNodeContents(container.querySelector('.markstream-vue')!);
+        const selection = window.getSelection()!;
+        selection.removeAllRanges();
+        selection.addRange(range);
+
+        const clipboardData = new ClipboardDataStub();
+        const copyEvent = new Event('copy', {
+            bubbles: true,
+            cancelable: true,
+        }) as ClipboardEvent;
+        Object.defineProperty(copyEvent, 'clipboardData', {
+            value: clipboardData,
+        });
+
+        const prevented = !container.dispatchEvent(copyEvent);
+
+        expect(prevented).toBe(true);
+        expect(clipboardData.getData('text/plain')).toBe(
+            '- Objective(目标): 建立清晰目标\n- Key Results: 可量化结果\n1. 公开透明\n2. 季度周期'
+        );
+        expect(clipboardData.getData('text/html')).toBe(
+            '<ul><li><strong>Objective</strong>(目标): 建立清晰目标</li><li>Key Results: 可量化结果</li></ul><ol><li>公开透明</li><li>季度周期</li></ol>'
+        );
+        expect(clipboardData.getData('text/html')).not.toContain('<li><p>');
+
+        selection.removeAllRanges();
+        wrapper.unmount();
+    });
+
+    it('flattens nested renderer wrappers inside copied list items for Word-compatible list HTML', async () => {
+        const { default: MarkdownContent } = await import('@components/MarkdownContent.vue');
+        const wrapper = mount(MarkdownContent, {
+            props: {
+                content:
+                    '1. 设定太多目标：贪多嚼不烂\n2. 全是常规工作：OKR 应聚焦突破性目标\n3. 缺乏衡量标准：关键结果必须可量化',
+            },
+            attachTo: document.body,
+        });
+
+        const container = wrapper.element as HTMLElement;
+        container.innerHTML = `
+            <div class="markstream-vue">
+                <ol class="list-node list-decimal">
+                    <li class="list-item">
+                        <div class="markdown-renderer">
+                            <span class="node-slot">
+                                <span class="node-content">
+                                    <p class="paragraph-node">设定太多目标：贪多嚼不烂</p>
+                                </span>
+                            </span>
+                        </div>
+                    </li>
+                    <li class="list-item">
+                        <div class="markdown-renderer">
+                            <span class="node-slot">
+                                <span class="node-content">
+                                    <p class="paragraph-node">全是常规工作：OKR 应聚焦突破性目标</p>
+                                </span>
+                            </span>
+                        </div>
+                    </li>
+                    <li class="list-item">
+                        <div class="markdown-renderer">
+                            <span class="node-slot">
+                                <span class="node-content">
+                                    <p class="paragraph-node">缺乏衡量标准：关键结果必须可量化</p>
+                                </span>
+                            </span>
+                        </div>
+                    </li>
+                </ol>
+            </div>
+        `;
+
+        const range = document.createRange();
+        range.selectNodeContents(container.querySelector('.markstream-vue')!);
+        const selection = window.getSelection()!;
+        selection.removeAllRanges();
+        selection.addRange(range);
+
+        const clipboardData = new ClipboardDataStub();
+        const copyEvent = new Event('copy', {
+            bubbles: true,
+            cancelable: true,
+        }) as ClipboardEvent;
+        Object.defineProperty(copyEvent, 'clipboardData', {
+            value: clipboardData,
+        });
+
+        const prevented = !container.dispatchEvent(copyEvent);
+
+        expect(prevented).toBe(true);
+        expect(clipboardData.getData('text/plain')).toBe(
+            '1. 设定太多目标：贪多嚼不烂\n2. 全是常规工作：OKR 应聚焦突破性目标\n3. 缺乏衡量标准：关键结果必须可量化'
+        );
+        expect(clipboardData.getData('text/html')).toBe(
+            '<ol><li>设定太多目标：贪多嚼不烂</li><li>全是常规工作：OKR 应聚焦突破性目标</li><li>缺乏衡量标准：关键结果必须可量化</li></ol>'
+        );
+        expect(clipboardData.getData('text/html')).not.toContain('<p');
+        expect(clipboardData.getData('text/html')).not.toContain('markdown-renderer');
+
+        selection.removeAllRanges();
+        wrapper.unmount();
+    });
+
+    it('wraps partially selected list items in their list parent for Word-compatible clipboard HTML', async () => {
+        const { default: MarkdownContent } = await import('@components/MarkdownContent.vue');
+        const wrapper = mount(MarkdownContent, {
+            props: {
+                content:
+                    '1. 设定太多目标：贪多嚼不烂\n2. 全是常规工作：OKR 应聚焦突破性目标\n3. 缺乏衡量标准：关键结果必须可量化',
+            },
+            attachTo: document.body,
+        });
+
+        const container = wrapper.element as HTMLElement;
+        container.innerHTML = `
+            <div class="markstream-vue">
+                <ol class="list-node list-decimal">
+                    <li class="list-item"><p class="paragraph-node">设定太多目标：贪多嚼不烂</p></li>
+                    <li class="list-item"><p class="paragraph-node">全是常规工作：OKR 应聚焦突破性目标</p></li>
+                    <li class="list-item"><p class="paragraph-node">缺乏衡量标准：关键结果必须可量化</p></li>
+                </ol>
+            </div>
+        `;
+
+        const paragraphs = container.querySelectorAll('.paragraph-node');
+        const firstText = requiredTextNode(paragraphs, 0);
+        const lastText = requiredTextNode(paragraphs, 2);
+        const range = document.createRange();
+        range.setStart(firstText, 0);
+        range.setEnd(lastText, lastText.textContent!.length);
+        const selection = window.getSelection()!;
+        selection.removeAllRanges();
+        selection.addRange(range);
+
+        const clipboardData = new ClipboardDataStub();
+        const copyEvent = new Event('copy', {
+            bubbles: true,
+            cancelable: true,
+        }) as ClipboardEvent;
+        Object.defineProperty(copyEvent, 'clipboardData', {
+            value: clipboardData,
+        });
+
+        const prevented = !container.dispatchEvent(copyEvent);
+
+        expect(prevented).toBe(true);
+        expect(clipboardData.getData('text/plain')).toBe(
+            '1. 设定太多目标：贪多嚼不烂\n2. 全是常规工作：OKR 应聚焦突破性目标\n3. 缺乏衡量标准：关键结果必须可量化'
+        );
+        expect(clipboardData.getData('text/html')).toBe(
+            '<ol><li>设定太多目标：贪多嚼不烂</li><li>全是常规工作：OKR 应聚焦突破性目标</li><li>缺乏衡量标准：关键结果必须可量化</li></ol>'
+        );
+
+        selection.removeAllRanges();
+        wrapper.unmount();
+    });
+
+    it('preserves ordered list numbering when a copied list selection starts after the first item', async () => {
+        const { default: MarkdownContent } = await import('@components/MarkdownContent.vue');
+        const wrapper = mount(MarkdownContent, {
+            props: {
+                content: '1. 跳过第一项\n2. 保留第二项编号\n3. 保留第三项编号',
+            },
+            attachTo: document.body,
+        });
+
+        const container = wrapper.element as HTMLElement;
+        container.innerHTML = `
+            <div class="markstream-vue">
+                <ol class="list-node list-decimal">
+                    <li class="list-item"><p class="paragraph-node">跳过第一项</p></li>
+                    <li class="list-item"><p class="paragraph-node">保留第二项编号</p></li>
+                    <li class="list-item"><p class="paragraph-node">保留第三项编号</p></li>
+                </ol>
+            </div>
+        `;
+
+        const paragraphs = container.querySelectorAll('.paragraph-node');
+        const secondText = requiredTextNode(paragraphs, 1);
+        const thirdText = requiredTextNode(paragraphs, 2);
+        const range = document.createRange();
+        range.setStart(secondText, 0);
+        range.setEnd(thirdText, thirdText.textContent!.length);
+        const selection = window.getSelection()!;
+        selection.removeAllRanges();
+        selection.addRange(range);
+
+        const clipboardData = new ClipboardDataStub();
+        const copyEvent = new Event('copy', {
+            bubbles: true,
+            cancelable: true,
+        }) as ClipboardEvent;
+        Object.defineProperty(copyEvent, 'clipboardData', {
+            value: clipboardData,
+        });
+
+        const prevented = !container.dispatchEvent(copyEvent);
+
+        expect(prevented).toBe(true);
+        expect(clipboardData.getData('text/plain')).toBe('2. 保留第二项编号\n3. 保留第三项编号');
+        expect(clipboardData.getData('text/html')).toBe(
+            '<ol start="2"><li>保留第二项编号</li><li>保留第三项编号</li></ol>'
+        );
+
+        selection.removeAllRanges();
+        wrapper.unmount();
+    });
+
+    it('preserves link targets and document structure in copied plain text fallbacks', async () => {
+        const { default: MarkdownContent } = await import('@components/MarkdownContent.vue');
+        const wrapper = mount(MarkdownContent, {
+            props: {
+                content:
+                    '## Install\n\nRead [docs](https://example.com/docs) first.\n\n> Keep warning\n\n---',
+            },
+            attachTo: document.body,
+        });
+
+        const container = wrapper.element as HTMLElement;
+        container.innerHTML = `
+            <div class="markstream-vue" style="color: red;">
+                <h2 class="heading-token">Install</h2>
+                <p>Read <a class="link-token" style="color: blue;" href="https://example.com/docs">docs</a> first.</p>
+                <blockquote class="quote-token"><p>Keep warning</p></blockquote>
+                <hr class="rule-token">
+            </div>
+        `;
+
+        const range = document.createRange();
+        range.selectNodeContents(container.querySelector('.markstream-vue')!);
+        const selection = window.getSelection()!;
+        selection.removeAllRanges();
+        selection.addRange(range);
+
+        const clipboardData = new ClipboardDataStub();
+        const copyEvent = new Event('copy', {
+            bubbles: true,
+            cancelable: true,
+        }) as ClipboardEvent;
+        Object.defineProperty(copyEvent, 'clipboardData', {
+            value: clipboardData,
+        });
+
+        const prevented = !container.dispatchEvent(copyEvent);
+
+        expect(prevented).toBe(true);
+        expect(clipboardData.getData('text/plain')).toBe(
+            'Install\nRead [docs](https://example.com/docs) first.\nKeep warning'
+        );
+        expect(clipboardData.getData('text/html')).toBe(
+            '<h2>Install</h2><p>Read <a href="https://example.com/docs">docs</a> first.</p><blockquote><p>Keep warning</p></blockquote><hr>'
+        );
+        expect(clipboardData.getData('text/html')).not.toContain('class=');
+        expect(clipboardData.getData('text/html')).not.toContain('style=');
+
+        selection.removeAllRanges();
+        wrapper.unmount();
+    });
+
+    it('preserves inline spacing while skipping non-content clipboard artifacts', async () => {
+        const { default: MarkdownContent } = await import('@components/MarkdownContent.vue');
+        const wrapper = mount(MarkdownContent, {
+            props: {
+                content: 'Alpha Beta Gamma',
+            },
+            attachTo: document.body,
+        });
+
+        const container = wrapper.element as HTMLElement;
+        container.innerHTML = `
+            <div class="markstream-vue">
+                <p>
+                    <strong>Alpha</strong> <em>Beta</em>
+                    <button>Copy</button>
+                    <span aria-hidden="true">Hidden</span>
+                    <span style="display: none;">Invisible</span>
+                    <style>.word-rule { color: red; }</style>
+                    <script>window.noise = true;</script>
+                    Gamma
+                </p>
+            </div>
+        `;
+
+        const range = document.createRange();
+        range.selectNodeContents(container.querySelector('p')!);
+        const selection = window.getSelection()!;
+        selection.removeAllRanges();
+        selection.addRange(range);
+
+        const clipboardData = new ClipboardDataStub();
+        const copyEvent = new Event('copy', {
+            bubbles: true,
+            cancelable: true,
+        }) as ClipboardEvent;
+        Object.defineProperty(copyEvent, 'clipboardData', {
+            value: clipboardData,
+        });
+
+        const prevented = !container.dispatchEvent(copyEvent);
+
+        expect(prevented).toBe(true);
+        expect(clipboardData.getData('text/plain')).toBe('Alpha Beta Gamma');
+        expect(clipboardData.getData('text/html')).toBe(
+            '<strong>Alpha</strong> <em>Beta</em> Gamma'
+        );
+        expect(clipboardData.getData('text/html')).not.toContain('Copy');
+        expect(clipboardData.getData('text/html')).not.toContain('Hidden');
+        expect(clipboardData.getData('text/html')).not.toContain('word-rule');
+        expect(clipboardData.getData('text/html')).not.toContain('script');
 
         selection.removeAllRanges();
         wrapper.unmount();

--- a/apps/desktop/tests/composables/SearchView/SearchBar/useSearchLogic.test.ts
+++ b/apps/desktop/tests/composables/SearchView/SearchBar/useSearchLogic.test.ts
@@ -48,6 +48,7 @@ const {
         isEmpty = false;
         state = {
             selection: {
+                empty: true,
                 $anchor: {
                     pos: 1,
                 },
@@ -558,6 +559,59 @@ describe('useSearchInput', () => {
         expect(editorInstances[0]?.view.dispatch).toHaveBeenCalledWith(
             editorInstances[0]?.state.tr
         );
+
+        mounted.unmount();
+    });
+
+    it('does not force the editor scroll position while the user is extending a text selection', async () => {
+        const editorHost = document.createElement('div');
+        Object.defineProperty(editorHost, 'clientHeight', {
+            configurable: true,
+            value: 60,
+        });
+        editorHost.getBoundingClientRect = vi.fn(() => ({
+            top: 0,
+            bottom: 60,
+            left: 0,
+            right: 500,
+            width: 500,
+            height: 60,
+            x: 0,
+            y: 0,
+            toJSON: () => ({}),
+        }));
+        editorHost.scrollTop = 80;
+        const mounted = await mountComposable(() =>
+            useSearchInput({
+                searchBarContainerRef: ref(null),
+                editorHostRef: ref(editorHost),
+                queryText: ref('line one\nline two\nline three\nline four'),
+                attachments: ref([]),
+                modelOverride: ref({
+                    modelId: null,
+                    providerId: null,
+                }),
+                emitQueryText: vi.fn(),
+                emitModelChange: vi.fn(),
+                emitModelOverrideChange: vi.fn(),
+                emitRemoveAttachmentRequest: vi.fn(),
+                emitDragStart: vi.fn(),
+                emitDragEnd: vi.fn(),
+            })
+        );
+
+        mounted.result.initEditor();
+        const editor = editorInstances[0]!;
+        editor.view.coordsAtPos.mockReturnValue({
+            top: -120,
+            bottom: -100,
+        });
+        editor.state.selection.empty = false;
+
+        (editor.options.onSelectionUpdate as () => void)();
+
+        expect(editor.view.coordsAtPos).not.toHaveBeenCalled();
+        expect(editorHost.scrollTop).toBe(80);
 
         mounted.unmount();
     });

--- a/apps/desktop/tests/services/ClipboardService/html.test.ts
+++ b/apps/desktop/tests/services/ClipboardService/html.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeClipboardPayload } from '@/services/ClipboardService/html';
+import type { ClipboardPayload } from '@/services/NativeService/types';
+
+function createPayload(overrides: Partial<ClipboardPayload>): ClipboardPayload {
+    return {
+        snapshotId: 'clip-1',
+        observedAt: 1,
+        text: null,
+        imagePaths: [],
+        filePaths: [],
+        fragments: [],
+        ...overrides,
+    };
+}
+
+describe('ClipboardService HTML normalization', () => {
+    it('strips Word style artifacts while preserving visible paragraph breaks', () => {
+        const payload = normalizeClipboardPayload(
+            createPayload({
+                text: 'Visible Word text\nSecond line',
+                html: `
+                    <html>
+                        <head>
+                            <style>p.MsoNormal { margin: 0cm; }</style>
+                            <script>window.__officePaste = true;</script>
+                        </head>
+                        <body>
+                            <p class="MsoNormal">Visible Word text</p>
+                            <style>.late-rule { color: red; }</style>
+                            <p>Second line</p>
+                        </body>
+                    </html>
+                `,
+            })
+        );
+
+        expect(payload?.text).toBe('Visible Word text\nSecond line');
+        expect(payload?.fragments).toEqual([
+            { type: 'text', text: 'Visible Word text\nSecond line' },
+        ]);
+        expect(payload?.text).not.toContain('MsoNormal');
+        expect(payload?.text).not.toContain('margin');
+    });
+
+    it('prefers plain visible text over HTML inline formatting Markdown', () => {
+        const payload = normalizeClipboardPayload(
+            createPayload({
+                text: 'Important text',
+                html: '<p><strong>Important</strong> <em>text</em></p>',
+            })
+        );
+
+        expect(payload?.text).toBe('Important text');
+        expect(payload?.fragments).toEqual([{ type: 'text', text: 'Important text' }]);
+    });
+
+    it('keeps structured plain list text instead of reformatting it from HTML', () => {
+        const payload = normalizeClipboardPayload(
+            createPayload({
+                text: '• First item\n• Second item',
+                html: '<ul><li>First item</li><li>Second item</li></ul>',
+            })
+        );
+
+        expect(payload?.text).toBe('• First item\n• Second item');
+    });
+
+    it('uses HTML list structure when paste event plain text was flattened', () => {
+        const payload = normalizeClipboardPayload(
+            createPayload({
+                text: 'First item Second item',
+                html: '<ul><li>First item</li><li>Second item</li></ul>',
+            })
+        );
+
+        expect(payload?.text).toBe('- First item\n- Second item');
+    });
+
+    it('keeps table clipboard text as plain rows instead of Markdown tables', () => {
+        const payload = normalizeClipboardPayload(
+            createPayload({
+                text: 'Name\tAge\nAlice\t28',
+                html: `
+                    <table>
+                        <tr><th>Name</th><th>Age</th></tr>
+                        <tr><td>Alice</td><td>28</td></tr>
+                    </table>
+                `,
+            })
+        );
+
+        expect(payload?.text).toBe('Name\tAge\nAlice\t28');
+        expect(payload?.fragments).toEqual([{ type: 'text', text: 'Name\tAge\nAlice\t28' }]);
+        expect(payload?.text).not.toContain('| --- |');
+    });
+
+    it('uses HTML structure when plain text was flattened', () => {
+        const payload = normalizeClipboardPayload(
+            createPayload({
+                text: 'Install Read docs first.',
+                html: '<h2>Install</h2><p>Read <a href="https://example.com/docs">docs</a> first.</p>',
+            })
+        );
+
+        expect(payload?.text).toBe('## Install\n\nRead [docs](https://example.com/docs) first.');
+    });
+
+    it('keeps plain text line breaks when HTML has no stronger structure', () => {
+        const payload = normalizeClipboardPayload(
+            createPayload({
+                text: '毕业设计开题报告\n题目： 基于大语言模型的桌面效率 Agent 系统设计与实现\n姓 名： 谢志勇',
+                html: '<span>毕业设计开题报告 题目： 基于大语言模型的桌面效率 Agent 系统设计与实现 姓 名： 谢志勇</span>',
+            })
+        );
+
+        expect(payload?.text).toBe(
+            '毕业设计开题报告\n题目： 基于大语言模型的桌面效率 Agent 系统设计与实现\n姓 名： 谢志勇'
+        );
+    });
+
+    it('splits HTML image Markdown back into ordered image fragments', () => {
+        const payload = normalizeClipboardPayload(
+            createPayload({
+                text: 'Before\nAfter',
+                html: '<p>Before</p><img src="https://example.com/full.png" alt="Preview"><p>After</p>',
+                htmlImages: [{ source: 'https://example.com/full.png', path: 'D:/clip/full.png' }],
+                fragments: [{ type: 'image', path: 'D:/clip/full.png' }],
+            })
+        );
+
+        expect(payload?.fragments).toEqual([
+            { type: 'text', text: 'Before' },
+            { type: 'image', path: 'D:/clip/full.png' },
+            { type: 'text', text: 'After' },
+        ]);
+    });
+
+    it('splits linked HTML images without leaving Markdown link wrapper text', () => {
+        const payload = normalizeClipboardPayload(
+            createPayload({
+                text: 'Before\nAfter',
+                html: '<p>Before</p><a href="https://example.com/full.png"><img src="https://example.com/thumb.png" alt="Preview"></a><p>After</p>',
+                htmlImages: [{ source: 'https://example.com/full.png', path: 'D:/clip/full.png' }],
+                fragments: [{ type: 'image', path: 'D:/clip/full.png' }],
+            })
+        );
+
+        expect(payload?.fragments).toEqual([
+            { type: 'text', text: 'Before' },
+            { type: 'image', path: 'D:/clip/full.png' },
+            { type: 'text', text: 'After' },
+        ]);
+    });
+
+    it('splits repeated HTML images into repeated image fragments', () => {
+        const payload = normalizeClipboardPayload(
+            createPayload({
+                text: 'Before\nBetween\nAfter',
+                html: '<p>Before</p><img src="https://example.com/reused.png" alt="Preview"><p>Between</p><img src="https://example.com/reused.png" alt="Preview"><p>After</p>',
+                htmlImages: [
+                    { source: 'https://example.com/reused.png', path: 'D:/clip/reused.png' },
+                    { source: 'https://example.com/reused.png', path: 'D:/clip/reused.png' },
+                ],
+                fragments: [{ type: 'image', path: 'D:/clip/reused.png' }],
+            })
+        );
+
+        expect(payload?.fragments).toEqual([
+            { type: 'text', text: 'Before' },
+            { type: 'image', path: 'D:/clip/reused.png' },
+            { type: 'text', text: 'Between' },
+            { type: 'image', path: 'D:/clip/reused.png' },
+            { type: 'text', text: 'After' },
+        ]);
+    });
+
+    it('preserves inline spacing around HTML image fragments', () => {
+        const payload = normalizeClipboardPayload(
+            createPayload({
+                text: 'See image above',
+                html: '<p>See <img src="https://example.com/inline.png" alt="inline"> above</p>',
+                htmlImages: [
+                    { source: 'https://example.com/inline.png', path: 'D:/clip/inline.png' },
+                ],
+                fragments: [{ type: 'image', path: 'D:/clip/inline.png' }],
+            })
+        );
+
+        expect(payload?.fragments).toEqual([
+            { type: 'text', text: 'See ' },
+            { type: 'image', path: 'D:/clip/inline.png' },
+            { type: 'text', text: ' above' },
+        ]);
+    });
+
+    it('keeps HTML image ordering even when chosen plain text differs from HTML markdown', () => {
+        const payload = normalizeClipboardPayload(
+            createPayload({
+                text: 'See image above',
+                html: '<p>See <img src="https://example.com/inline.png" alt="inline"> above</p>',
+                htmlImages: [
+                    { source: 'https://example.com/inline.png', path: 'D:/clip/inline.png' },
+                ],
+                imagePaths: ['D:/clip/inline.png'],
+                fragments: [{ type: 'image', path: 'D:/clip/inline.png' }],
+            })
+        );
+
+        expect(payload?.text).toBe('See image above');
+        expect(payload?.fragments).toEqual([
+            { type: 'text', text: 'See ' },
+            { type: 'image', path: 'D:/clip/inline.png' },
+            { type: 'text', text: ' above' },
+        ]);
+    });
+
+    it('keeps native image fallback when HTML image sources cannot be resolved', () => {
+        const payload = normalizeClipboardPayload(
+            createPayload({
+                text: 'See image above',
+                html: '<p>See <img src="blob:https://example.com/unresolved" alt="inline"> above</p>',
+                htmlImages: [{ source: 'blob:https://example.com/unresolved', path: null }],
+                imagePaths: ['D:/clip/native-inline.png'],
+                fragments: [{ type: 'image', path: 'D:/clip/native-inline.png' }],
+            })
+        );
+
+        expect(payload?.fragments).toEqual([
+            { type: 'text', text: 'See ' },
+            { type: 'image', path: 'D:/clip/native-inline.png' },
+            { type: 'text', text: ' above' },
+        ]);
+    });
+});

--- a/apps/desktop/tests/services/ClipboardService/html.test.ts
+++ b/apps/desktop/tests/services/ClipboardService/html.test.ts
@@ -233,4 +233,23 @@ describe('ClipboardService HTML normalization', () => {
             { type: 'text', text: ' above' },
         ]);
     });
+
+    it('preserves safe image data URLs while stripping dangerous data links from HTML paste', () => {
+        const payload = normalizeClipboardPayload(
+            createPayload({
+                text: null,
+                html: `
+                    <p>
+                        Keep <a href="data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==">bad</a>
+                        <img src="data:image/png;base64,AAAA" alt="preview">
+                        <img src="data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==" alt="drop">
+                    </p>
+                `,
+            })
+        );
+
+        expect(payload?.text).toContain('Keep bad');
+        expect(payload?.text).toContain('![preview](data:image/png;base64,AAAA)');
+        expect(payload?.text).not.toContain('data:text/html');
+    });
 });

--- a/apps/desktop/tests/services/ClipboardService/index.test.ts
+++ b/apps/desktop/tests/services/ClipboardService/index.test.ts
@@ -141,4 +141,19 @@ describe('ClipboardService explicit paste', () => {
             { type: 'image', path: 'D:/persisted/pasted.png' },
         ]);
     });
+
+    it('emits fragments for file-only browser paste-event attachments', async () => {
+        readClipboardPayloadMock.mockRejectedValue(new Error('clipboard busy'));
+        const file = new File([new Uint8Array([1, 2, 3])], 'report.pdf', {
+            type: 'application/pdf',
+        });
+
+        const payload = await clipboardService.readExplicitPastePayload(
+            createClipboardDataWithFiles({}, [file], [{ kind: 'file', getAsFile: () => file }])
+        );
+
+        expect(payload?.text).toBeNull();
+        expect(payload?.filePaths).toEqual(['D:/persisted/report.pdf']);
+        expect(payload?.fragments).toEqual([{ type: 'file', path: 'D:/persisted/report.pdf' }]);
+    });
 });

--- a/apps/desktop/tests/services/ClipboardService/index.test.ts
+++ b/apps/desktop/tests/services/ClipboardService/index.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ClipboardPayload } from '@/services/NativeService/types';
+
+const { readClipboardPayloadMock, createPersistedAttachmentFromDataMock } = vi.hoisted(() => ({
+    readClipboardPayloadMock: vi.fn(),
+    createPersistedAttachmentFromDataMock: vi.fn(),
+}));
+
+vi.mock('@/services/NativeService', () => ({
+    native: {
+        clipboard: {
+            readClipboardPayload: readClipboardPayloadMock,
+            consumeShortcutAutoPastePayload: vi.fn(),
+            writeClipboardText: vi.fn(),
+        },
+    },
+}));
+
+vi.mock('@/services/AgentService/infrastructure/attachments', () => ({
+    createPersistedAttachmentFromData: createPersistedAttachmentFromDataMock,
+}));
+
+import { clipboardService } from '@/services/ClipboardService';
+
+function createClipboardData(data: Record<string, string>): DataTransfer {
+    return {
+        getData: vi.fn((type: string) => data[type] ?? ''),
+    } as unknown as DataTransfer;
+}
+
+function createClipboardDataWithFiles(
+    data: Record<string, string>,
+    files: File[],
+    items?: Array<{ kind: string; getAsFile: () => File | null }>
+): DataTransfer {
+    return {
+        getData: vi.fn((type: string) => data[type] ?? ''),
+        files,
+        items: items ?? [],
+    } as unknown as DataTransfer;
+}
+
+function createNativePayload(overrides: Partial<ClipboardPayload>): ClipboardPayload {
+    return {
+        snapshotId: 'native-1',
+        observedAt: 1,
+        text: null,
+        html: null,
+        htmlSourceUrl: null,
+        htmlImages: [],
+        imagePaths: [],
+        filePaths: [],
+        fragments: [],
+        ...overrides,
+    };
+}
+
+describe('ClipboardService explicit paste', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        createPersistedAttachmentFromDataMock.mockImplementation(
+            async (input: { type: 'image' | 'file'; name: string }) => ({
+                path: `D:/persisted/${input.name}`,
+                type: input.type,
+            })
+        );
+    });
+
+    it('falls back to the paste event text when native clipboard reads fail', async () => {
+        readClipboardPayloadMock.mockRejectedValue(new Error('clipboard busy'));
+
+        const payload = await clipboardService.readExplicitPastePayload(
+            createClipboardData({
+                'text/plain': 'Line one\nLine two',
+            })
+        );
+
+        expect(payload?.text).toBe('Line one\nLine two');
+        expect(payload?.fragments).toEqual([{ type: 'text', text: 'Line one\nLine two' }]);
+    });
+
+    it('uses paste event table text as plain rows while keeping native attachments', async () => {
+        readClipboardPayloadMock.mockResolvedValue(
+            createNativePayload({
+                imagePaths: ['D:/clip/image.png'],
+                fragments: [{ type: 'image', path: 'D:/clip/image.png' }],
+            })
+        );
+
+        const payload = await clipboardService.readExplicitPastePayload(
+            createClipboardData({
+                'text/plain': 'Name\tAge\nAlice\t28',
+                'text/html':
+                    '<table><tr><th>Name</th><th>Age</th></tr><tr><td>Alice</td><td>28</td></tr></table>',
+            })
+        );
+
+        expect(payload?.text).toBe('Name\tAge\nAlice\t28');
+        expect(payload?.imagePaths).toEqual(['D:/clip/image.png']);
+        expect(payload?.fragments).toEqual([
+            { type: 'text', text: 'Name\tAge\nAlice\t28' },
+            { type: 'image', path: 'D:/clip/image.png' },
+        ]);
+    });
+
+    it('preserves explicit paste boundary whitespace from the browser paste event', async () => {
+        readClipboardPayloadMock.mockRejectedValue(new Error('clipboard busy'));
+
+        const payload = await clipboardService.readExplicitPastePayload(
+            createClipboardData({
+                'text/plain': '  keep me  ',
+            })
+        );
+
+        expect(payload?.text).toBe('  keep me  ');
+        expect(payload?.fragments).toEqual([{ type: 'text', text: '  keep me  ' }]);
+    });
+
+    it('falls back to persisted browser paste-event files when native clipboard reads fail', async () => {
+        readClipboardPayloadMock.mockRejectedValue(new Error('clipboard busy'));
+        const imageFile = new File([new Uint8Array([1, 2, 3])], 'pasted.png', {
+            type: 'image/png',
+        });
+
+        const payload = await clipboardService.readExplicitPastePayload(
+            createClipboardDataWithFiles(
+                {
+                    'text/plain': 'caption',
+                    'text/html': '<p>caption</p><img src="blob:https://example.com/1">',
+                },
+                [imageFile],
+                [{ kind: 'file', getAsFile: () => imageFile }]
+            )
+        );
+
+        expect(createPersistedAttachmentFromDataMock).toHaveBeenCalledTimes(1);
+        expect(payload?.imagePaths).toEqual(['D:/persisted/pasted.png']);
+        expect(payload?.fragments).toEqual([
+            { type: 'text', text: 'caption' },
+            { type: 'image', path: 'D:/persisted/pasted.png' },
+        ]);
+    });
+});


### PR DESCRIPTION
## Summary
- Generalize clipboard handling so paste into TouchAI keeps visible structure, strips Word/WPS CSS/style garbage, preserves newlines, and projects rich clipboard fragments into ordered text plus attachments.
- Improve copy out of TouchAI by serializing semantic HTML plus Word-friendly table markup and cleaner plain text for mixed selections, lists, links, images, code blocks, and tables.
- Smooth the search input UX by preserving multiline plain-text insertion, increasing the input max height to 7 lines, and keeping long selection interactions stable.

## Related issue or RFC
- Closes #459

## AI assistance disclosure
- Tool(s) used: OpenAI Codex
- Scope of assistance: implemented the clipboard/search fixes, added regression tests, ran local validation, and prepared this PR update
- Human review or rewrite performed: I reviewed the diff, ran the full local validation flow, and requested an additional subagent review on the final uncommitted patch before submitting
- Architecture or boundary impact: none beyond desktop clipboard/search behavior and Tauri clipboard metadata extraction

## Testing evidence
- `pnpm test:pr` (passed locally on 2026-06-17 with temp/Rust artifacts redirected to `G:`)
- `pnpm --filter @touchai/desktop test:rust` (passed locally, 113 tests)
- `pnpm --filter @touchai/desktop test:coverage` (passed locally, 158 files / 1005 tests)
- Focused clipboard regression runs passed during implementation, including `tests/services/ClipboardService/html.test.ts`, `tests/services/ClipboardService/index.test.ts`, `tests/SearchView/utils/clipboardDraft.test.ts`, `tests/SearchView/SearchBar/tiptap.test.ts`, and `tests/components/MarkdownContent-i18n.test.ts`
- I did not rerun `pnpm test:e2e` locally for this patch set; the existing PR already had a green Windows Desktop E2E Smoke run, and CI remains the first browser-level proof for the final delta.

## Risk notes
- Touches desktop clipboard ingestion/serialization, search input insertion, and search selection behavior only.
- No database, MCP, schema, or cross-boundary architecture changes.
- Uses existing mature libraries on the frontend (`DOMPurify` and `turndown`) rather than introducing a new clipboard conversion dependency.

## Screenshots or recordings
- Not captured; this change is covered by automated tests and local manual verification during development.

## Checklist
- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [x] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [x] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [x] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [ ] I updated docs when behavior changed.