### PR TITLE
fix(release): skip empty scheduled nightly releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,8 @@ jobs:
             tag: ${{ steps.release.outputs.tag }}
             prerelease: ${{ steps.release.outputs.prerelease }}
             release_name: ${{ steps.release.outputs.release_name }}
+            should_publish: ${{ steps.release.outputs.should_publish }}
+            skip_reason: ${{ steps.release.outputs.skip_reason }}
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
               with:
@@ -50,11 +52,13 @@ jobs:
               env:
                   RELEASE_CHANNEL: ${{ github.event.inputs.channel }}
                   RELEASE_VERSION: ${{ github.event.inputs.version }}
+                  TARGET_COMMIT: ${{ github.sha }}
               run: node scripts/ci/resolve-release-metadata.mjs
 
     publish-release:
         name: Publish prerelease release
         needs: resolve
+        if: ${{ needs.resolve.outputs.should_publish == 'true' }}
         permissions:
             contents: write
             deployments: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,13 @@ jobs:
                   TARGET_COMMIT: ${{ github.sha }}
               run: node scripts/ci/resolve-release-metadata.mjs
 
+            - name: Summarize skipped prerelease
+              if: ${{ steps.release.outputs.should_publish != 'true' && steps.release.outputs.skip_reason != '' }}
+              run: |
+                  echo "### Prerelease skipped" >> "$GITHUB_STEP_SUMMARY"
+                  echo "${{ steps.release.outputs.skip_reason }}" >> "$GITHUB_STEP_SUMMARY"
+                  echo "::notice title=Prerelease skipped::${{ steps.release.outputs.skip_reason }}"
+
     publish-release:
         name: Publish prerelease release
         needs: resolve

--- a/.github/workflows/velopack-build.yml
+++ b/.github/workflows/velopack-build.yml
@@ -264,6 +264,8 @@ jobs:
             - name: Hydrate previous Velopack release assets
               shell: pwsh
               working-directory: apps/desktop
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                   node scripts/ci/hydrate-velopack-history.mjs "$env:VELOPACK_RELEASE" "${{ inputs.channel }}"
 

--- a/apps/desktop/scripts/ci/hydrate-velopack-history.d.mts
+++ b/apps/desktop/scripts/ci/hydrate-velopack-history.d.mts
@@ -1,0 +1,5 @@
+export function hydrateVelopackHistory(
+    projectRoot: string,
+    releaseDir: string,
+    channel: string
+): Promise<void>;

--- a/apps/desktop/scripts/ci/hydrate-velopack-history.mjs
+++ b/apps/desktop/scripts/ci/hydrate-velopack-history.mjs
@@ -2,7 +2,12 @@ import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
+import { channelFromTag, githubRepositoryFromProduct } from '../update-release-assets.mjs';
+
+const GITHUB_API_BASE_URL = 'https://api.github.com';
+const GITHUB_USER_AGENT = 'touchai-velopack-history-hydrate/1.0.0';
 const HISTORY_FETCH_TIMEOUT_MS = 30_000;
+const MAX_RELEASE_PAGES = 10;
 
 function assertNonEmptyString(value, label) {
     if (typeof value !== 'string' || !value.trim()) {
@@ -25,6 +30,7 @@ function assertAbsoluteHttpsUrl(value, label) {
 
 async function readProduct(projectRoot) {
     const product = JSON.parse(await readFile(join(projectRoot, 'product.json'), 'utf8'));
+    assertNonEmptyString(product?.repository?.url, 'repository.url');
     assertAbsoluteHttpsUrl(product?.services?.updates?.baseUrl, 'services.updates.baseUrl');
     return product;
 }
@@ -52,6 +58,106 @@ async function fetchPublicAsset(url) {
         throw new Error(`Failed to fetch ${url}: HTTP ${response.status}`);
     }
     return response;
+}
+
+function githubHeaders(token) {
+    const headers = new Headers({
+        accept: 'application/vnd.github+json',
+        'user-agent': GITHUB_USER_AGENT,
+        'x-github-api-version': '2022-11-28',
+    });
+    if (token) {
+        headers.set('authorization', `Bearer ${token}`);
+    }
+    return headers;
+}
+
+async function fetchGithubReleases(repository, fetchImpl, token) {
+    const releases = [];
+    for (let page = 1; page <= MAX_RELEASE_PAGES; page += 1) {
+        const response = await fetchImpl(
+            `${GITHUB_API_BASE_URL}/repos/${repository}/releases?per_page=100&page=${page}`,
+            { headers: githubHeaders(token) }
+        );
+        if (!response.ok) {
+            throw new Error(`Failed to fetch GitHub releases: HTTP ${response.status}`);
+        }
+
+        const pageReleases = await response.json();
+        if (!Array.isArray(pageReleases)) {
+            throw new Error('GitHub releases response must be an array.');
+        }
+
+        releases.push(...pageReleases);
+        if (pageReleases.length < 100) {
+            break;
+        }
+    }
+    return releases;
+}
+
+function retentionForChannel(product, channel) {
+    const retentionByChannel = product.services?.updates?.deployment?.r2HotAssetVersions ?? {};
+    if (!Object.hasOwn(retentionByChannel, channel)) {
+        const expected = Object.keys(retentionByChannel).sort().join(', ');
+        throw new Error(`Unsupported release channel "${channel}". Expected one of: ${expected}.`);
+    }
+
+    const value = retentionByChannel[channel];
+    const parsed = Number.parseInt(String(value ?? ''), 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+}
+
+function releaseTime(release) {
+    const value = release.published_at ?? release.created_at ?? '';
+    const time = Date.parse(value);
+    return Number.isFinite(time) ? time : 0;
+}
+
+function retainedReleaseTags(releases, channel, keepVersions) {
+    return new Set(
+        releases
+            .filter((release) => channelFromTag(release?.tag_name) === channel)
+            .sort((left, right) => releaseTime(right) - releaseTime(left))
+            .slice(0, keepVersions)
+            .map((release) => release.tag_name)
+            .filter(Boolean)
+    );
+}
+
+function releaseTagFromFeedAsset(asset) {
+    if (typeof asset?.Version === 'string' && asset.Version.trim()) {
+        return `v${asset.Version}`;
+    }
+    return null;
+}
+
+async function retainedHistoryTags(product, channel) {
+    const keepVersions = retentionForChannel(product, channel);
+    if (keepVersions <= 0) {
+        return new Set();
+    }
+
+    const repository = githubRepositoryFromProduct(product, {
+        invalidHostMessage: 'repository.url must use github.com for Velopack history hydration.',
+    });
+    const releases = await fetchGithubReleases(
+        repository,
+        globalThis.fetch,
+        process.env.GITHUB_TOKEN ?? null
+    );
+    return retainedReleaseTags(releases, channel, keepVersions);
+}
+
+function pruneFeedAssets(feed, retainedTags) {
+    if (!Array.isArray(feed.Assets)) {
+        return feed;
+    }
+
+    return {
+        ...feed,
+        Assets: feed.Assets.filter((asset) => retainedTags.has(releaseTagFromFeedAsset(asset))),
+    };
 }
 
 function updateAssetUrl(product, fileName) {
@@ -82,7 +188,7 @@ export async function hydrateVelopackHistory(projectRoot, releaseDir, channel) {
     }
 
     const feedText = await feedResponse.text();
-    const feed = JSON.parse(feedText);
+    const feed = pruneFeedAssets(JSON.parse(feedText), await retainedHistoryTags(product, channel));
     await writeFile(join(releaseDir, feedName), `${JSON.stringify(feed, null, 4)}\n`, 'utf8');
 
     const assets = Array.isArray(feed.Assets) ? feed.Assets.filter(isVelopackPackage) : [];

--- a/apps/desktop/scripts/ci/plan-r2-release-asset-prune.mjs
+++ b/apps/desktop/scripts/ci/plan-r2-release-asset-prune.mjs
@@ -6,6 +6,7 @@ import {
     assertNonEmptyString,
     channelFromAssetName,
     channelFromTag,
+    deriveReleaseTagFromAssetName,
     githubRepositoryFromProduct,
     isDownloadAssetName,
     relativeUpdatePath,
@@ -76,14 +77,73 @@ async function fetchGithubReleases(repository, fetchImpl, token) {
     return releases;
 }
 
+async function existingFeed(product, channel, fetchImpl) {
+    const url = `${product.services.updates.baseUrl.replace(/\/+$/g, '')}/releases.${channel}.json`;
+    const response = await fetchImpl(url);
+    if (response.status === 404) {
+        return null;
+    }
+    if (!response.ok) {
+        throw new Error(`Failed to fetch existing ${channel} update feed: HTTP ${response.status}`);
+    }
+
+    const feed = await response.json();
+    if (!feed || typeof feed !== 'object' || Array.isArray(feed)) {
+        throw new Error(`Existing ${channel} update feed must be an object.`);
+    }
+    return feed;
+}
+
+function staleReleaseAssetKeys(releases, keepVersions, updatePath, channel) {
+    const channelReleases = releases
+        .filter((release) => channelFromTag(release?.tag_name) === channel)
+        .sort((left, right) => releaseTime(right) - releaseTime(left));
+    const retainedTags = new Set(
+        channelReleases
+            .slice(0, keepVersions)
+            .map((release) => release.tag_name)
+            .filter(Boolean)
+    );
+    const keys = [];
+
+    for (const release of channelReleases.slice(keepVersions)) {
+        for (const asset of release.assets ?? []) {
+            const fileName = asset?.name;
+            if (!isDownloadAssetName(fileName) || channelFromAssetName(fileName) !== channel) {
+                continue;
+            }
+            keys.push(`${updatePath}/${fileName}`);
+        }
+    }
+
+    return { keys, retainedTags };
+}
+
+function staleFeedAssetKeys(feed, retainedTags, updatePath, channel) {
+    if (!Array.isArray(feed?.Assets)) {
+        return [];
+    }
+
+    const keys = [];
+    for (const asset of feed.Assets) {
+        const fileName = asset?.FileName;
+        if (!isDownloadAssetName(fileName) || channelFromAssetName(fileName) !== channel) {
+            continue;
+        }
+
+        const releaseTag = deriveReleaseTagFromAssetName(fileName);
+        if (!releaseTag || !retainedTags.has(releaseTag)) {
+            keys.push(`${updatePath}/${fileName}`);
+        }
+    }
+    return keys;
+}
+
 export async function planR2ReleaseAssetPrune(projectRoot, channel, options = {}) {
     assertNonEmptyString(channel, 'release channel');
 
     const product = await readProduct(projectRoot);
     const keepVersions = retentionForChannel(product, channel);
-    if (keepVersions <= 0) {
-        return [];
-    }
 
     const repository = githubRepositoryFromProduct(product, {
         invalidHostMessage: 'repository.url must use github.com for R2 release asset pruning.',
@@ -95,21 +155,20 @@ export async function planR2ReleaseAssetPrune(projectRoot, channel, options = {}
     }
 
     const releases = await fetchGithubReleases(repository, fetchImpl, options.token ?? null);
-    const channelReleases = releases
-        .filter((release) => channelFromTag(release?.tag_name) === channel)
-        .sort((left, right) => releaseTime(right) - releaseTime(left));
-    const staleReleases = channelReleases.slice(keepVersions);
-    const keys = [];
-
-    for (const release of staleReleases) {
-        for (const asset of release.assets ?? []) {
-            const fileName = asset?.name;
-            if (!isDownloadAssetName(fileName) || channelFromAssetName(fileName) !== channel) {
-                continue;
-            }
-            keys.push(`${updatePath}/${fileName}`);
-        }
-    }
+    const { keys, retainedTags } = staleReleaseAssetKeys(
+        releases,
+        keepVersions,
+        updatePath,
+        channel
+    );
+    keys.push(
+        ...staleFeedAssetKeys(
+            await existingFeed(product, channel, fetchImpl),
+            retainedTags,
+            updatePath,
+            channel
+        )
+    );
 
     return [...new Set(keys)];
 }

--- a/apps/desktop/scripts/ci/resolve-release-metadata.d.mts
+++ b/apps/desktop/scripts/ci/resolve-release-metadata.d.mts
@@ -12,6 +12,12 @@ export function resolveReleaseMetadata(input: {
     runNumber?: string | number;
     runAttempt?: string | number;
     date?: Date;
+    targetCommit?: string | null;
+    latestNightly?: {
+        tag: string;
+        commit: string;
+    } | null;
+    git?: (args: string[]) => string;
     productConfig: {
         displayName: string;
         services?: {
@@ -26,4 +32,6 @@ export function resolveReleaseMetadata(input: {
     tag: string;
     prerelease: 'True' | 'False';
     releaseName: string;
+    shouldPublish: boolean;
+    skipReason: string | null;
 };

--- a/apps/desktop/scripts/ci/resolve-release-metadata.mjs
+++ b/apps/desktop/scripts/ci/resolve-release-metadata.mjs
@@ -16,6 +16,18 @@ function normalizeOptionalString(value) {
     return normalized.length > 0 ? normalized : null;
 }
 
+function git(projectRoot, args, gitImpl = null) {
+    if (gitImpl) {
+        return normalizeOptionalString(gitImpl(args)) ?? '';
+    }
+
+    return execFileSync('git', args, {
+        cwd: projectRoot,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+}
+
 function normalizeChannel(value) {
     const normalized = normalizeOptionalString(value)?.toLowerCase() ?? null;
     if (!normalized) {
@@ -74,6 +86,68 @@ function compareCoreVersions(left, right) {
     return 0;
 }
 
+function compareSemverIdentifiers(left, right) {
+    if (left === right) {
+        return 0;
+    }
+
+    const leftNumber = /^\d+$/.test(left) ? Number(left) : null;
+    const rightNumber = /^\d+$/.test(right) ? Number(right) : null;
+    if (leftNumber !== null && rightNumber !== null) {
+        return leftNumber - rightNumber;
+    }
+    if (leftNumber !== null) {
+        return -1;
+    }
+    if (rightNumber !== null) {
+        return 1;
+    }
+    return left.localeCompare(right);
+}
+
+function comparePrereleaseVersions(left, right) {
+    const leftParts = left.split('.');
+    const rightParts = right.split('.');
+    const count = Math.max(leftParts.length, rightParts.length);
+
+    for (let index = 0; index < count; index += 1) {
+        const leftIdentifier = leftParts[index];
+        const rightIdentifier = rightParts[index];
+        if (leftIdentifier === undefined) {
+            return -1;
+        }
+        if (rightIdentifier === undefined) {
+            return 1;
+        }
+
+        const difference = compareSemverIdentifiers(leftIdentifier, rightIdentifier);
+        if (difference !== 0) {
+            return difference;
+        }
+    }
+
+    return 0;
+}
+
+function compareSemverVersions(left, right) {
+    const coreDifference = compareCoreVersions(left.version, right.version);
+    if (coreDifference !== 0) {
+        return coreDifference;
+    }
+
+    if (!left.prerelease && !right.prerelease) {
+        return 0;
+    }
+    if (!left.prerelease) {
+        return 1;
+    }
+    if (!right.prerelease) {
+        return -1;
+    }
+
+    return comparePrereleaseVersions(left.prerelease, right.prerelease);
+}
+
 function nextPatchVersion(version) {
     const [major, minor, patch] = parseSemver(version).core.split('.').map(Number);
     return `${major}.${minor}.${patch + 1}`;
@@ -87,11 +161,7 @@ function latestStableVersionFromGit(projectRoot) {
 
     let output;
     try {
-        output = execFileSync('git', ['tag', '--list', 'v*'], {
-            cwd: normalizedProjectRoot,
-            encoding: 'utf8',
-            stdio: ['ignore', 'pipe', 'ignore'],
-        });
+        output = git(normalizedProjectRoot, ['tag', '--list', 'v*']);
     } catch {
         return null;
     }
@@ -115,6 +185,94 @@ function latestStableVersionFromGit(projectRoot) {
 
     stableVersions.sort(compareCoreVersions);
     return stableVersions.at(-1) ?? null;
+}
+
+function targetCommitFromGit(projectRoot, gitImpl = null) {
+    const normalizedProjectRoot = normalizeOptionalString(projectRoot);
+    if (!normalizedProjectRoot) {
+        return null;
+    }
+
+    try {
+        return normalizeOptionalString(git(normalizedProjectRoot, ['rev-parse', 'HEAD'], gitImpl));
+    } catch {
+        return null;
+    }
+}
+
+function commitFromTag(projectRoot, tag, gitImpl = null) {
+    const normalizedProjectRoot = normalizeOptionalString(projectRoot);
+    if (!normalizedProjectRoot) {
+        return null;
+    }
+
+    try {
+        return normalizeOptionalString(
+            git(normalizedProjectRoot, ['rev-list', '-n', '1', tag], gitImpl)
+        );
+    } catch {
+        return null;
+    }
+}
+
+function parseNightlyTag(tag) {
+    const normalized = normalizeOptionalString(tag);
+    if (!normalized?.startsWith('v')) {
+        return null;
+    }
+
+    try {
+        const parsed = parseSemver(normalized.slice(1));
+        return channelFromTagVersion(parsed) === 'nightly'
+            ? {
+                  tag: normalized,
+                  ...parsed,
+              }
+            : null;
+    } catch {
+        return null;
+    }
+}
+
+function latestNightlyFromGit(projectRoot, gitImpl = null) {
+    const normalizedProjectRoot = normalizeOptionalString(projectRoot);
+    if (!normalizedProjectRoot) {
+        return null;
+    }
+
+    let output;
+    try {
+        output = git(normalizedProjectRoot, ['tag', '--list', 'v*-nightly.*'], gitImpl);
+    } catch {
+        return null;
+    }
+
+    const latest = output
+        .split(/\r?\n/)
+        .map(parseNightlyTag)
+        .filter(Boolean)
+        .sort(compareSemverVersions)
+        .at(-1);
+    if (!latest) {
+        return null;
+    }
+
+    const commit = commitFromTag(normalizedProjectRoot, latest.tag, gitImpl);
+    return commit ? { tag: latest.tag, commit } : null;
+}
+
+function normalizeLatestNightly(projectRoot, latestNightly, gitImpl = null) {
+    if (latestNightly === null) {
+        return null;
+    }
+
+    const tag = normalizeOptionalString(latestNightly?.tag);
+    const commit = normalizeOptionalString(latestNightly?.commit);
+    if (tag && commit) {
+        return { tag, commit };
+    }
+
+    return latestNightlyFromGit(projectRoot, gitImpl);
 }
 
 function dateStamp(date) {
@@ -193,6 +351,42 @@ function releaseName(version, productConfig) {
     return `${displayName} v${version}`;
 }
 
+function resolvePublicationDecision(input, eventName) {
+    if (eventName !== 'schedule') {
+        return {
+            shouldPublish: true,
+            skipReason: null,
+        };
+    }
+
+    const projectRoot = normalizeOptionalString(input.projectRoot) ?? process.cwd();
+    const gitImpl = typeof input.git === 'function' ? input.git : null;
+    const targetCommit =
+        normalizeOptionalString(input.targetCommit) ?? targetCommitFromGit(projectRoot, gitImpl);
+    if (!targetCommit) {
+        return {
+            shouldPublish: true,
+            skipReason: null,
+        };
+    }
+
+    const latestNightly = normalizeLatestNightly(projectRoot, input.latestNightly, gitImpl);
+    if (!latestNightly) {
+        return {
+            shouldPublish: true,
+            skipReason: null,
+        };
+    }
+
+    const alreadyPublished = latestNightly.commit === targetCommit;
+    return {
+        shouldPublish: !alreadyPublished,
+        skipReason: alreadyPublished
+            ? `Latest nightly ${latestNightly.tag} already points at ${targetCommit}.`
+            : null,
+    };
+}
+
 export function resolveReleaseMetadata(input) {
     const eventName = normalizeOptionalString(input.eventName) ?? 'workflow_dispatch';
     const tagVersion =
@@ -229,6 +423,7 @@ export function resolveReleaseMetadata(input) {
         tag: `v${parsedVersion.version}`,
         prerelease: channel === 'stable' ? 'False' : 'True',
         releaseName: releaseName(parsedVersion.version, input.productConfig),
+        ...resolvePublicationDecision(input, eventName),
     };
 }
 
@@ -255,6 +450,8 @@ async function writeGithubOutput(metadata) {
             `tag=${metadata.tag}`,
             `prerelease=${metadata.prerelease}`,
             `release_name=${metadata.releaseName}`,
+            `should_publish=${metadata.shouldPublish ? 'true' : 'false'}`,
+            `skip_reason=${metadata.skipReason ?? ''}`,
             '',
         ].join('\n'),
         'utf8'
@@ -276,6 +473,7 @@ async function main() {
         packageVersion,
         runNumber: process.env.GITHUB_RUN_NUMBER,
         runAttempt: process.env.GITHUB_RUN_ATTEMPT,
+        targetCommit: process.env.TARGET_COMMIT ?? process.env.GITHUB_SHA,
         projectRoot,
         productConfig,
     });

--- a/apps/desktop/scripts/ci/resolve-release-metadata.mjs
+++ b/apps/desktop/scripts/ci/resolve-release-metadata.mjs
@@ -153,7 +153,7 @@ function nextPatchVersion(version) {
     return `${major}.${minor}.${patch + 1}`;
 }
 
-function latestStableVersionFromGit(projectRoot) {
+function latestStableVersionFromGit(projectRoot, gitImpl = null) {
     const normalizedProjectRoot = normalizeOptionalString(projectRoot);
     if (!normalizedProjectRoot) {
         return null;
@@ -161,7 +161,7 @@ function latestStableVersionFromGit(projectRoot) {
 
     let output;
     try {
-        output = git(normalizedProjectRoot, ['tag', '--list', 'v*']);
+        output = git(normalizedProjectRoot, ['tag', '--list', 'v*'], gitImpl);
     } catch {
         return null;
     }
@@ -293,9 +293,10 @@ function runPart(value, fallback) {
 }
 
 function generatedNightlyVersion(packageVersion, input) {
+    const gitImpl = typeof input.git === 'function' ? input.git : null;
     const baseVersion =
         normalizeOptionalString(input.stableBaseVersion) ??
-        latestStableVersionFromGit(input.projectRoot) ??
+        latestStableVersionFromGit(input.projectRoot, gitImpl) ??
         packageVersion;
     const runNumber = runPart(input.runNumber, '0');
     const runAttempt = runPart(input.runAttempt, '1');

--- a/apps/desktop/tests/ci/hydrate-velopack-history.test.ts
+++ b/apps/desktop/tests/ci/hydrate-velopack-history.test.ts
@@ -101,7 +101,7 @@ describe('hydrateVelopackHistory', () => {
                 });
             }
 
-            if (url.includes('api.github.com')) {
+            if (new URL(url).hostname === 'api.github.com') {
                 return new Response(
                     JSON.stringify([
                         release('v0.3.0-nightly.20260524.4', '2026-05-24T00:00:00Z'),

--- a/apps/desktop/tests/ci/hydrate-velopack-history.test.ts
+++ b/apps/desktop/tests/ci/hydrate-velopack-history.test.ts
@@ -1,0 +1,151 @@
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { APP_PRODUCT_CONFIG } from '@/config/product';
+
+type HydrateVelopackHistory = (
+    projectRoot: string,
+    releaseDir: string,
+    channel: string
+) => Promise<void>;
+
+async function loadHydrator(): Promise<HydrateVelopackHistory | undefined> {
+    try {
+        const module = await import('../../scripts/ci/hydrate-velopack-history.mjs');
+        return module.hydrateVelopackHistory as HydrateVelopackHistory;
+    } catch {
+        return undefined;
+    }
+}
+
+async function createFixture(product: unknown) {
+    const root = await mkdtemp(join(tmpdir(), 'touchai-velopack-history-'));
+    await writeFile(join(root, 'product.json'), `${JSON.stringify(product, null, 4)}\n`, 'utf8');
+    return root;
+}
+
+function productWithNightlyRetention(keepVersions: number) {
+    const product = JSON.parse(JSON.stringify(APP_PRODUCT_CONFIG));
+    product.services.updates.deployment = {
+        ...product.services.updates.deployment,
+        r2HotAssetVersions: {
+            stable: 2,
+            beta: 2,
+            nightly: keepVersions,
+        },
+    };
+    return product;
+}
+
+function release(tagName: string, publishedAt: string) {
+    return {
+        tag_name: tagName,
+        published_at: publishedAt,
+        assets: [],
+    };
+}
+
+async function exists(path: string) {
+    try {
+        await stat(path);
+        return true;
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') {
+            return false;
+        }
+        throw error;
+    }
+}
+
+describe('hydrateVelopackHistory', () => {
+    it('keeps only retained GitHub release versions from the existing channel feed', async () => {
+        const hydrateVelopackHistory = await loadHydrator();
+        const product = productWithNightlyRetention(2);
+        const root = await createFixture(product);
+        const releaseDir = join(root, 'release');
+        const feedUrl = `${product.services.updates.baseUrl}/releases.nightly.json`;
+        const keptPackage = 'TouchAI-nightly-0.3.0-nightly.20260523.3-windows-full.nupkg';
+        const oldPackage = 'TouchAI-nightly-0.3.0-nightly.20260522.2-windows-full.nupkg';
+        const orphanPackage = 'TouchAI-nightly-0.3.0-nightly.20260521.1-windows-full.nupkg';
+        const feed = {
+            Assets: [
+                {
+                    PackageId: product.identifier,
+                    Version: '0.3.0-nightly.20260523.3',
+                    Type: 'Full',
+                    FileName: keptPackage,
+                },
+                {
+                    PackageId: product.identifier,
+                    Version: '0.3.0-nightly.20260522.2',
+                    Type: 'Full',
+                    FileName: oldPackage,
+                },
+                {
+                    PackageId: product.identifier,
+                    Version: '0.3.0-nightly.20260521.1',
+                    Type: 'Full',
+                    FileName: orphanPackage,
+                },
+            ],
+        };
+        const fetchMock = vi.fn<typeof fetch>(async (input) => {
+            const url = input.toString();
+
+            if (url === feedUrl) {
+                return new Response(JSON.stringify(feed), {
+                    headers: { 'content-type': 'application/json' },
+                });
+            }
+
+            if (url.includes('api.github.com')) {
+                return new Response(
+                    JSON.stringify([
+                        release('v0.3.0-nightly.20260524.4', '2026-05-24T00:00:00Z'),
+                        release('v0.3.0-nightly.20260523.3', '2026-05-23T00:00:00Z'),
+                        release('v0.3.0-nightly.20260522.2', '2026-05-22T00:00:00Z'),
+                    ]),
+                    { headers: { 'content-type': 'application/json' } }
+                );
+            }
+
+            if (url.endsWith(keptPackage)) {
+                return new Response('kept package');
+            }
+
+            return new Response(null, { status: 404 });
+        });
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+        try {
+            await mkdir(releaseDir, { recursive: true });
+            expect(hydrateVelopackHistory).toBeTypeOf('function');
+            await hydrateVelopackHistory?.(root, releaseDir, 'nightly');
+
+            const hydratedFeed = JSON.parse(
+                await readFile(join(releaseDir, 'releases.nightly.json'), 'utf8')
+            );
+            expect(
+                hydratedFeed.Assets.map((asset: { FileName: string }) => asset.FileName)
+            ).toEqual([keptPackage]);
+            await expect(readFile(join(releaseDir, keptPackage), 'utf8')).resolves.toBe(
+                'kept package'
+            );
+            await expect(exists(join(releaseDir, oldPackage))).resolves.toBe(false);
+            await expect(exists(join(releaseDir, orphanPackage))).resolves.toBe(false);
+            expect(fetchMock).not.toHaveBeenCalledWith(
+                `${product.services.updates.baseUrl}/${oldPackage}`
+            );
+            expect(fetchMock).not.toHaveBeenCalledWith(
+                `${product.services.updates.baseUrl}/${orphanPackage}`
+            );
+        } finally {
+            globalThis.fetch = originalFetch;
+            await rm(root, { recursive: true, force: true });
+        }
+    });
+});

--- a/apps/desktop/tests/ci/plan-r2-release-asset-prune.test.ts
+++ b/apps/desktop/tests/ci/plan-r2-release-asset-prune.test.ts
@@ -53,14 +53,27 @@ function release(tagName: string, publishedAt: string, assetNames: string[]) {
     };
 }
 
+function githubReleasesResponse(releases: ReturnType<typeof release>[]) {
+    return new Response(JSON.stringify(releases), {
+        headers: {
+            'content-type': 'application/json',
+        },
+    });
+}
+
+function notFoundResponse() {
+    return new Response(null, { status: 404 });
+}
+
 describe('planR2ReleaseAssetPrune', () => {
     it('plans deletion for old channel assets that already exist on GitHub Releases', async () => {
         const planner = await loadPlanner();
         const product = productWithRetention();
         const root = await createFixture(product);
-        const fetchMock = vi.fn<typeof fetch>(async () => {
-            return new Response(
-                JSON.stringify([
+        const fetchMock = vi.fn<typeof fetch>(async (input) => {
+            const url = input.toString();
+            if (url.includes('api.github.com')) {
+                return githubReleasesResponse([
                     release('v0.2.0-beta.4', '2026-05-24T00:00:00Z', [
                         'TouchAI-beta-0.2.0-beta.4-windows-full.nupkg',
                     ]),
@@ -73,13 +86,10 @@ describe('planR2ReleaseAssetPrune', () => {
                         'release-notes.md',
                     ]),
                     release('v0.2.0', '2026-05-21T00:00:00Z', ['TouchAI-0.2.0-windows-full.nupkg']),
-                ]),
-                {
-                    headers: {
-                        'content-type': 'application/json',
-                    },
-                }
-            );
+                ]);
+            }
+
+            return notFoundResponse();
         });
 
         try {
@@ -111,16 +121,75 @@ describe('planR2ReleaseAssetPrune', () => {
         const planner = await loadPlanner();
         const product = productWithRetention();
         const root = await createFixture(product);
-        const fetchMock = vi.fn<typeof fetch>(async () => {
-            return new Response(
-                JSON.stringify([
+        const fetchMock = vi.fn<typeof fetch>(async (input) => {
+            const url = input.toString();
+            if (url.includes('api.github.com')) {
+                return githubReleasesResponse([
                     release('v0.3.0-nightly.20260524.1', '2026-05-24T00:00:00Z', [
                         'TouchAI-nightly-0.3.0-nightly.20260524.1-windows-full.nupkg',
                     ]),
                     release('v0.3.0-nightly.20260523.1', '2026-05-23T00:00:00Z', [
                         'TouchAI-nightly-0.3.0-nightly.20260523.1-windows-full.nupkg',
                     ]),
-                ]),
+                ]);
+            }
+
+            return notFoundResponse();
+        });
+
+        try {
+            expect(planner?.planR2ReleaseAssetPrune).toBeTypeOf('function');
+            await expect(
+                planner!.planR2ReleaseAssetPrune(root, 'nightly', {
+                    fetch: fetchMock as unknown as typeof fetch,
+                    token: 'token',
+                })
+            ).resolves.toEqual([]);
+        } finally {
+            await rm(root, { recursive: true, force: true });
+        }
+    });
+
+    it('plans deletion for existing feed assets outside retained GitHub releases', async () => {
+        const planner = await loadPlanner();
+        const product = productWithRetention();
+        product.services.updates.deployment.r2HotAssetVersions.nightly = 2;
+        const root = await createFixture(product);
+        const currentPackage = 'TouchAI-nightly-0.3.0-nightly.20260524.4-windows-full.nupkg';
+        const retainedPackage = 'TouchAI-nightly-0.3.0-nightly.20260523.3-windows-full.nupkg';
+        const oldPackage = 'TouchAI-nightly-0.3.0-nightly.20260522.2-windows-full.nupkg';
+        const orphanPackage = 'TouchAI-nightly-0.3.0-nightly.20260521.1-windows-full.nupkg';
+        const fetchMock = vi.fn<typeof fetch>(async (input) => {
+            const url = input.toString();
+            if (url.includes('api.github.com')) {
+                return githubReleasesResponse([
+                    release('v0.3.0-nightly.20260524.4', '2026-05-24T00:00:00Z', [currentPackage]),
+                    release('v0.3.0-nightly.20260523.3', '2026-05-23T00:00:00Z', [retainedPackage]),
+                    release('v0.3.0-nightly.20260522.2', '2026-05-22T00:00:00Z', [oldPackage]),
+                ]);
+            }
+
+            return new Response(
+                JSON.stringify({
+                    Assets: [
+                        {
+                            Version: '0.3.0-nightly.20260524.4',
+                            FileName: currentPackage,
+                        },
+                        {
+                            Version: '0.3.0-nightly.20260523.3',
+                            FileName: retainedPackage,
+                        },
+                        {
+                            Version: '0.3.0-nightly.20260522.2',
+                            FileName: oldPackage,
+                        },
+                        {
+                            Version: '0.3.0-nightly.20260521.1',
+                            FileName: orphanPackage,
+                        },
+                    ],
+                }),
                 { headers: { 'content-type': 'application/json' } }
             );
         });
@@ -132,7 +201,7 @@ describe('planR2ReleaseAssetPrune', () => {
                     fetch: fetchMock as unknown as typeof fetch,
                     token: 'token',
                 })
-            ).resolves.toEqual([]);
+            ).resolves.toEqual([`touchai-app/v1/${oldPackage}`, `touchai-app/v1/${orphanPackage}`]);
         } finally {
             await rm(root, { recursive: true, force: true });
         }

--- a/apps/desktop/tests/ci/plan-r2-release-asset-prune.test.ts
+++ b/apps/desktop/tests/ci/plan-r2-release-asset-prune.test.ts
@@ -72,7 +72,7 @@ describe('planR2ReleaseAssetPrune', () => {
         const root = await createFixture(product);
         const fetchMock = vi.fn<typeof fetch>(async (input) => {
             const url = input.toString();
-            if (url.includes('api.github.com')) {
+            if (new URL(url).hostname === 'api.github.com') {
                 return githubReleasesResponse([
                     release('v0.2.0-beta.4', '2026-05-24T00:00:00Z', [
                         'TouchAI-beta-0.2.0-beta.4-windows-full.nupkg',
@@ -123,7 +123,7 @@ describe('planR2ReleaseAssetPrune', () => {
         const root = await createFixture(product);
         const fetchMock = vi.fn<typeof fetch>(async (input) => {
             const url = input.toString();
-            if (url.includes('api.github.com')) {
+            if (new URL(url).hostname === 'api.github.com') {
                 return githubReleasesResponse([
                     release('v0.3.0-nightly.20260524.1', '2026-05-24T00:00:00Z', [
                         'TouchAI-nightly-0.3.0-nightly.20260524.1-windows-full.nupkg',
@@ -161,7 +161,7 @@ describe('planR2ReleaseAssetPrune', () => {
         const orphanPackage = 'TouchAI-nightly-0.3.0-nightly.20260521.1-windows-full.nupkg';
         const fetchMock = vi.fn<typeof fetch>(async (input) => {
             const url = input.toString();
-            if (url.includes('api.github.com')) {
+            if (new URL(url).hostname === 'api.github.com') {
                 return githubReleasesResponse([
                     release('v0.3.0-nightly.20260524.4', '2026-05-24T00:00:00Z', [currentPackage]),
                     release('v0.3.0-nightly.20260523.3', '2026-05-23T00:00:00Z', [retainedPackage]),

--- a/apps/desktop/tests/ci/release-workflow-environments.test.ts
+++ b/apps/desktop/tests/ci/release-workflow-environments.test.ts
@@ -67,8 +67,11 @@ describe('release workflow deployment environments', () => {
         const workflow = await readWorkflow('release.yml');
 
         expect(workflow).toContain('should_publish: ${{ steps.release.outputs.should_publish }}');
+        expect(workflow).toContain('TARGET_COMMIT: ${{ github.sha }}');
         expect(workflow).toContain('node scripts/ci/resolve-release-metadata.mjs');
         expect(workflow).toContain("if: ${{ needs.resolve.outputs.should_publish == 'true' }}");
+        expect(workflow).toContain('$GITHUB_STEP_SUMMARY');
+        expect(workflow).toContain('::notice title=Prerelease skipped::');
         expect(workflow).not.toContain('check-nightly-release-needed.mjs');
     });
 

--- a/apps/desktop/tests/ci/release-workflow-environments.test.ts
+++ b/apps/desktop/tests/ci/release-workflow-environments.test.ts
@@ -63,6 +63,15 @@ describe('release workflow deployment environments', () => {
         expect(workflow).toContain('deployment-environment: prerelease');
     });
 
+    it('skips scheduled nightly publishing when main has not changed', async () => {
+        const workflow = await readWorkflow('release.yml');
+
+        expect(workflow).toContain('should_publish: ${{ steps.release.outputs.should_publish }}');
+        expect(workflow).toContain('node scripts/ci/resolve-release-metadata.mjs');
+        expect(workflow).toContain("if: ${{ needs.resolve.outputs.should_publish == 'true' }}");
+        expect(workflow).not.toContain('check-nightly-release-needed.mjs');
+    });
+
     it('packs Windows releases as MSI without conflicting Velopack installer flags', async () => {
         const workflow = await readWorkflow('velopack-build.yml');
 

--- a/apps/desktop/tests/ci/resolve-release-metadata.test.ts
+++ b/apps/desktop/tests/ci/resolve-release-metadata.test.ts
@@ -8,6 +8,8 @@ type ReleaseMetadata = {
     tag: string;
     prerelease: 'True' | 'False';
     releaseName: string;
+    shouldPublish: boolean;
+    skipReason: string | null;
 };
 
 type ResolveReleaseMetadata = (input: {
@@ -23,6 +25,12 @@ type ResolveReleaseMetadata = (input: {
     runAttempt?: string | number;
     date?: Date;
     productConfig?: typeof APP_PRODUCT_CONFIG;
+    targetCommit?: string | null;
+    latestNightly?: {
+        tag: string;
+        commit: string;
+    } | null;
+    git?: (args: string[]) => string;
 }) => ReleaseMetadata;
 
 async function loadResolver(): Promise<ResolveReleaseMetadata | undefined> {
@@ -61,6 +69,8 @@ describe('resolveReleaseMetadata', () => {
             tag: 'v1.2.3',
             prerelease: 'False',
             releaseName: 'TouchAI v1.2.3',
+            shouldPublish: true,
+            skipReason: null,
         });
     });
 
@@ -105,6 +115,92 @@ describe('resolveReleaseMetadata', () => {
             tag: 'v1.2.4-nightly.20260522.42.3',
             prerelease: 'True',
             releaseName: 'TouchAI v1.2.4-nightly.20260522.42.3',
+            shouldPublish: true,
+            skipReason: null,
+        });
+    });
+
+    it('skips scheduled nightly when the latest nightly already points at the target commit', async () => {
+        const resolveReleaseMetadata = await loadResolver();
+
+        expect(resolveReleaseMetadata).toBeTypeOf('function');
+        expect(
+            resolveReleaseMetadata?.(
+                releaseInput({
+                    eventName: 'schedule',
+                    packageVersion: '1.2.3',
+                    runNumber: 42,
+                    runAttempt: 3,
+                    date: new Date('2026-05-22T18:00:00Z'),
+                    targetCommit: 'abc123',
+                    latestNightly: {
+                        tag: 'v1.2.1-nightly.20260705.75.1',
+                        commit: 'abc123',
+                    },
+                })
+            )
+        ).toMatchObject({
+            channel: 'nightly',
+            shouldPublish: false,
+            skipReason: 'Latest nightly v1.2.1-nightly.20260705.75.1 already points at abc123.',
+        });
+    });
+
+    it('keeps manual nightly dispatches publishable even when the commit is unchanged', async () => {
+        const resolveReleaseMetadata = await loadResolver();
+
+        expect(resolveReleaseMetadata).toBeTypeOf('function');
+        expect(
+            resolveReleaseMetadata?.(
+                releaseInput({
+                    eventName: 'workflow_dispatch',
+                    inputChannel: 'nightly',
+                    inputVersion: '1.2.3-nightly.1',
+                    packageVersion: '1.2.3',
+                    targetCommit: 'abc123',
+                    latestNightly: {
+                        tag: 'v1.2.1-nightly.20260705.75.1',
+                        commit: 'abc123',
+                    },
+                })
+            )
+        ).toMatchObject({
+            channel: 'nightly',
+            shouldPublish: true,
+            skipReason: null,
+        });
+    });
+
+    it('reads the latest nightly tag from git when no override is provided', async () => {
+        const resolveReleaseMetadata = await loadResolver();
+        const gitResponses = new Map([
+            [
+                'tag --list v*-nightly.*',
+                [
+                    'v1.2.1-nightly.20260618.58.1',
+                    'v1.2.1-nightly.20260629.69.1',
+                    'v1.2.1-nightly.20260605.42.1',
+                ].join('\n'),
+            ],
+            ['rev-list -n 1 v1.2.1-nightly.20260629.69.1', 'head456'],
+        ]);
+
+        expect(resolveReleaseMetadata).toBeTypeOf('function');
+        expect(
+            resolveReleaseMetadata?.(
+                releaseInput({
+                    eventName: 'schedule',
+                    packageVersion: '1.2.3',
+                    runNumber: 42,
+                    runAttempt: 3,
+                    date: new Date('2026-05-22T18:00:00Z'),
+                    targetCommit: 'head456',
+                    git: (args) => gitResponses.get(args.join(' ')) ?? '',
+                })
+            )
+        ).toMatchObject({
+            shouldPublish: false,
+            skipReason: 'Latest nightly v1.2.1-nightly.20260629.69.1 already points at head456.',
         });
     });
 
@@ -129,6 +225,8 @@ describe('resolveReleaseMetadata', () => {
             tag: 'v2.0.1-nightly.20260522.42.1',
             prerelease: 'True',
             releaseName: 'TouchAI v2.0.1-nightly.20260522.42.1',
+            shouldPublish: true,
+            skipReason: null,
         });
     });
 
@@ -170,6 +268,8 @@ describe('resolveReleaseMetadata', () => {
             tag: 'v1.3.0-beta.1',
             prerelease: 'True',
             releaseName: 'TouchAI v1.3.0-beta.1',
+            shouldPublish: true,
+            skipReason: null,
         });
     });
 

--- a/apps/desktop/tests/ci/resolve-release-metadata.test.ts
+++ b/apps/desktop/tests/ci/resolve-release-metadata.test.ts
@@ -204,6 +204,28 @@ describe('resolveReleaseMetadata', () => {
         });
     });
 
+    it('publishes scheduled nightly when no prior nightly tag exists', async () => {
+        const resolveReleaseMetadata = await loadResolver();
+
+        expect(resolveReleaseMetadata).toBeTypeOf('function');
+        expect(
+            resolveReleaseMetadata?.(
+                releaseInput({
+                    eventName: 'schedule',
+                    packageVersion: '1.2.3',
+                    runNumber: 42,
+                    runAttempt: 3,
+                    date: new Date('2026-05-22T18:00:00Z'),
+                    targetCommit: 'abc123',
+                    git: () => '',
+                })
+            )
+        ).toMatchObject({
+            shouldPublish: true,
+            skipReason: null,
+        });
+    });
+
     it('uses the latest stable base when generating nightly versions', async () => {
         const resolveReleaseMetadata = await loadResolver();
 
@@ -225,6 +247,34 @@ describe('resolveReleaseMetadata', () => {
             tag: 'v2.0.1-nightly.20260522.42.1',
             prerelease: 'True',
             releaseName: 'TouchAI v2.0.1-nightly.20260522.42.1',
+            shouldPublish: true,
+            skipReason: null,
+        });
+    });
+
+    it('uses the injected git implementation when reading the latest stable base', async () => {
+        const resolveReleaseMetadata = await loadResolver();
+        const gitResponses = new Map([
+            ['tag --list v*-nightly.*', ''],
+            ['tag --list v*', ['v1.9.0', 'v2.0.0', 'v2.0.0-beta.1'].join('\n')],
+        ]);
+
+        expect(resolveReleaseMetadata).toBeTypeOf('function');
+        expect(
+            resolveReleaseMetadata?.(
+                releaseInput({
+                    eventName: 'schedule',
+                    packageVersion: '1.2.3',
+                    projectRoot: 'repo',
+                    runNumber: 42,
+                    runAttempt: 1,
+                    date: new Date('2026-05-22T18:00:00Z'),
+                    targetCommit: 'abc123',
+                    git: (args) => gitResponses.get(args.join(' ')) ?? '',
+                })
+            )
+        ).toMatchObject({
+            version: '2.0.1-nightly.20260522.42.1',
             shouldPublish: true,
             skipReason: null,
         });


### PR DESCRIPTION
## Summary

- Adds a scheduled-nightly publish decision to the existing release metadata resolver.
- Skips the reusable release build when the latest nightly already points at the scheduled run commit, and surfaces the skip reason in the workflow summary.
- Keeps manual beta/nightly dispatches publishable and covers the behavior with CI tests.
- Prunes stale nightly update history from the existing Velopack/R2 flow so deleted or out-of-retention nightly versions stop staying in `releases.nightly.json`.

## Related issue or RFC

Link the issue or RFC:

- Closes #503

For code changes, link the tracking issue. Only documentation wording, link fixes, or comment-only cleanups may skip the issue-first flow.

## AI assistance disclosure

If AI tools materially assisted this contribution, disclose that here or point to the relevant commit trailer.

- Tool(s) used: OpenAI Codex
- Scope of assistance: diagnosed duplicate nightly release behavior, updated release workflow/script/tests, deleted redundant duplicate nightly GitHub releases/tags, and added update feed/R2 cleanup coverage
- Human review or rewrite performed: maintainer-requested simplification folded the nightly gate into the existing resolver instead of adding a new script; CodeRabbit comments were checked and addressed where valid
- Architecture or boundary impact: CI/release automation only; no AgentService, runtime, MCP, database schema, or app runtime impact

## Testing evidence

List the commands you ran and the results you observed.

- `npx tsc --noEmit --project tsconfig.json` from `apps/desktop`: passed
- `vitest run tests/ci/resolve-release-metadata.test.ts tests/ci/release-workflow-environments.test.ts`: 2 files passed, 22 tests passed
- `vitest run --testTimeout 30000 tests/ci`: 19 files passed, 75 tests passed
- `corepack pnpm exec vitest run --configLoader runner tests/ci`: 20 files passed, 79 tests passed
- `corepack pnpm test:typecheck`: passed
- `corepack pnpm exec eslint ...` on changed release scripts/tests: passed
- `corepack pnpm exec prettier --check ...` on changed workflow/script/test files: passed
- `node --check scripts/ci/resolve-release-metadata.mjs`: passed
- `node --check scripts/ci/hydrate-velopack-history.mjs`: passed
- `node --check scripts/ci/plan-r2-release-asset-prune.mjs`: passed
- `node scripts/ci/plan-r2-release-asset-prune.mjs nightly`: dry-run found 97 stale nightly R2 keys across 28 stale versions to delete after the fixed workflow runs with Cloudflare secrets
- Remote GitHub cleanup: deleted 22 duplicate nightly releases/tags; current remote nightly tags are 13 with 0 duplicate commit groups
- `corepack pnpm test:pr`: attempted locally; frontend check/unit phase passed with 155 files and 978 tests, Rust check passed, then local Rust test compilation failed in this Windows workstation environment. Attempts with alternate artifact roots were blocked by local disk/FS conditions: `D:` hit `rustc`/link `STATUS_STACK_BUFFER_OVERRUN`, `E:`/`G:` lacked free space, and the available `L:` cloud-backed path failed with filesystem privilege errors. CI should provide the first valid full `pnpm test:pr` proof.

Did you follow TDD (test-first) for feature and fix work? Strongly recommended. See [docs/testing/testing.md](../docs/testing/testing.md).

```text
pnpm test:pr
```

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: none
- database baseline or migration impact: none
- release or packaging impact: scheduled nightly runs now skip publishing when the current commit is already covered by the latest nightly; manual prerelease runs remain publishable; nightly update feed history and R2 pruning now follow the configured retention window instead of preserving deleted duplicate nightly versions

## Screenshots or recordings

Not applicable; CI/release workflow change only.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [x] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [x] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.
