### PR TITLE
fix(release): prune orphaned R2 release assets

### DIFF
--- a/.github/workflows/velopack-build.yml
+++ b/.github/workflows/velopack-build.yml
@@ -661,6 +661,20 @@ jobs:
                   CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
               run: pnpm dlx wrangler@3.90.0 deploy --config "$WRANGLER_UPDATE_PROXY_CONFIG"
 
+            - name: Plan archived R2 release asset pruning
+              working-directory: apps/desktop
+              shell: bash
+              env:
+                  RELEASE_CHANNEL: ${{ inputs.channel }}
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+                  CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+                  CLOUDFLARE_R2_BUCKET_NAME: ${{ needs.prepare-release.outputs.cloudflare_r2_bucket_name }}
+              run: |
+                  set -euo pipefail
+                  prune_plan="$RUNNER_TEMP/touchai-r2-prune-plan.txt"
+                  node scripts/ci/plan-r2-release-asset-prune.mjs "$RELEASE_CHANNEL" > "$prune_plan"
+
             - name: Deploy update release feeds to Cloudflare R2
               shell: bash
               env:
@@ -680,15 +694,17 @@ jobs:
               working-directory: apps/desktop
               shell: bash
               env:
-                  RELEASE_CHANNEL: ${{ inputs.channel }}
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
                   CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
                   CLOUDFLARE_R2_BUCKET_NAME: ${{ needs.prepare-release.outputs.cloudflare_r2_bucket_name }}
               run: |
                   set -euo pipefail
                   prune_plan="$RUNNER_TEMP/touchai-r2-prune-plan.txt"
-                  node scripts/ci/plan-r2-release-asset-prune.mjs "$RELEASE_CHANNEL" > "$prune_plan"
+                  if [ ! -f "$prune_plan" ]; then
+                    echo "::error title=R2 prune plan missing::Expected $prune_plan to be generated before feed deployment."
+                    exit 1
+                  fi
+
                   if [ ! -s "$prune_plan" ]; then
                     echo "No archived R2 release assets to prune."
                     exit 0

--- a/apps/desktop/scripts/ci/plan-r2-release-asset-prune.mjs
+++ b/apps/desktop/scripts/ci/plan-r2-release-asset-prune.mjs
@@ -15,6 +15,8 @@ import {
 const GITHUB_API_BASE_URL = 'https://api.github.com';
 const GITHUB_USER_AGENT = 'touchai-r2-release-asset-prune/1.0.0';
 const MAX_RELEASE_PAGES = 10;
+const CLOUDFLARE_API_BASE_URL = 'https://api.cloudflare.com/client/v4';
+const MAX_R2_OBJECT_PAGES = 100;
 
 async function readProduct(projectRoot) {
     const product = JSON.parse(await readFile(join(projectRoot, 'product.json'), 'utf8'));
@@ -53,6 +55,13 @@ function githubHeaders(token) {
     return headers;
 }
 
+function cloudflareHeaders(token) {
+    return new Headers({
+        accept: 'application/json',
+        authorization: `Bearer ${token}`,
+    });
+}
+
 async function fetchGithubReleases(repository, fetchImpl, token) {
     const releases = [];
     for (let page = 1; page <= MAX_RELEASE_PAGES; page += 1) {
@@ -75,6 +84,112 @@ async function fetchGithubReleases(repository, fetchImpl, token) {
         }
     }
     return releases;
+}
+
+function cloudflareConfig(options) {
+    const cloudflare = options.cloudflare ?? null;
+    if (!cloudflare) {
+        return null;
+    }
+
+    assertNonEmptyString(cloudflare.accountId, 'cloudflare.accountId');
+    assertNonEmptyString(cloudflare.bucketName, 'cloudflare.bucketName');
+    assertNonEmptyString(cloudflare.token, 'cloudflare.token');
+    return {
+        accountId: cloudflare.accountId,
+        apiBaseUrl: cloudflare.apiBaseUrl ?? CLOUDFLARE_API_BASE_URL,
+        bucketName: cloudflare.bucketName,
+        token: cloudflare.token,
+    };
+}
+
+function cloudflareConfigFromEnv(env) {
+    const config = {
+        accountId: env.CLOUDFLARE_ACCOUNT_ID,
+        bucketName: env.CLOUDFLARE_R2_BUCKET_NAME,
+        token: env.CLOUDFLARE_API_TOKEN,
+    };
+    const values = Object.values(config).filter((value) => typeof value === 'string' && value);
+    if (values.length === 0) {
+        return null;
+    }
+    if (values.length !== Object.keys(config).length) {
+        throw new Error(
+            'CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID, and CLOUDFLARE_R2_BUCKET_NAME must all be set to include existing R2 objects in the prune plan.'
+        );
+    }
+    return config;
+}
+
+function r2ObjectsFromResponse(payload) {
+    if (Array.isArray(payload?.result)) {
+        return payload.result;
+    }
+    if (Array.isArray(payload?.result?.objects)) {
+        return payload.result.objects;
+    }
+    if (Array.isArray(payload?.objects)) {
+        return payload.objects;
+    }
+    throw new Error('Cloudflare R2 objects response must include an object array.');
+}
+
+function r2PaginationFromResponse(payload) {
+    const info = payload?.result_info ?? payload?.result ?? payload ?? {};
+    return {
+        cursor: typeof info.cursor === 'string' ? info.cursor : null,
+        truncated: Boolean(info.is_truncated ?? info.truncated ?? false),
+    };
+}
+
+async function fetchR2ObjectKeys(config, updatePath, fetchImpl) {
+    const keys = [];
+    let cursor = null;
+
+    for (let page = 1; page <= MAX_R2_OBJECT_PAGES; page += 1) {
+        const params = new URLSearchParams({
+            per_page: '1000',
+            prefix: `${updatePath}/`,
+        });
+        if (cursor) {
+            params.set('cursor', cursor);
+        }
+
+        const response = await fetchImpl(
+            `${config.apiBaseUrl.replace(/\/+$/g, '')}/accounts/${encodeURIComponent(
+                config.accountId
+            )}/r2/buckets/${encodeURIComponent(config.bucketName)}/objects?${params}`,
+            { headers: cloudflareHeaders(config.token) }
+        );
+        if (!response.ok) {
+            throw new Error(`Failed to fetch Cloudflare R2 objects: HTTP ${response.status}`);
+        }
+
+        const payload = await response.json();
+        if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+            throw new Error('Cloudflare R2 objects response must be an object.');
+        }
+        if (payload.success === false) {
+            throw new Error('Cloudflare R2 objects response reported failure.');
+        }
+
+        for (const object of r2ObjectsFromResponse(payload)) {
+            if (typeof object?.key === 'string') {
+                keys.push(object.key);
+            }
+        }
+
+        const pagination = r2PaginationFromResponse(payload);
+        if (!pagination.truncated) {
+            return keys;
+        }
+        if (!pagination.cursor) {
+            throw new Error('Cloudflare R2 objects response is truncated but missing a cursor.');
+        }
+        cursor = pagination.cursor;
+    }
+
+    throw new Error(`Cloudflare R2 objects exceeded ${MAX_R2_OBJECT_PAGES} pages.`);
 }
 
 async function existingFeed(product, channel, fetchImpl) {
@@ -139,6 +254,29 @@ function staleFeedAssetKeys(feed, retainedTags, updatePath, channel) {
     return keys;
 }
 
+function staleR2ObjectKeys(objectKeys, retainedTags, updatePath, channel) {
+    const prefix = `${updatePath}/`;
+    const keys = [];
+
+    for (const key of objectKeys) {
+        if (typeof key !== 'string' || !key.startsWith(prefix)) {
+            continue;
+        }
+
+        const fileName = key.slice(prefix.length);
+        if (!isDownloadAssetName(fileName) || channelFromAssetName(fileName) !== channel) {
+            continue;
+        }
+
+        const releaseTag = deriveReleaseTagFromAssetName(fileName);
+        if (!releaseTag || !retainedTags.has(releaseTag)) {
+            keys.push(key);
+        }
+    }
+
+    return keys;
+}
+
 export async function planR2ReleaseAssetPrune(projectRoot, channel, options = {}) {
     assertNonEmptyString(channel, 'release channel');
 
@@ -154,6 +292,7 @@ export async function planR2ReleaseAssetPrune(projectRoot, channel, options = {}
         throw new Error('fetch is required to plan R2 release asset pruning.');
     }
 
+    const configuredCloudflare = cloudflareConfig(options);
     const releases = await fetchGithubReleases(repository, fetchImpl, options.token ?? null);
     const { keys, retainedTags } = staleReleaseAssetKeys(
         releases,
@@ -169,6 +308,16 @@ export async function planR2ReleaseAssetPrune(projectRoot, channel, options = {}
             channel
         )
     );
+    if (configuredCloudflare) {
+        keys.push(
+            ...staleR2ObjectKeys(
+                await fetchR2ObjectKeys(configuredCloudflare, updatePath, fetchImpl),
+                retainedTags,
+                updatePath,
+                channel
+            )
+        );
+    }
 
     return [...new Set(keys)];
 }
@@ -184,6 +333,7 @@ function parseArgs(argv) {
 async function main() {
     const { channel } = parseArgs(process.argv.slice(2));
     const keys = await planR2ReleaseAssetPrune(process.cwd(), channel, {
+        cloudflare: cloudflareConfigFromEnv(process.env),
         token: process.env.GITHUB_TOKEN ?? null,
     });
     if (keys.length > 0) {

--- a/apps/desktop/scripts/ci/plan-r2-release-asset-prune.mjs
+++ b/apps/desktop/scripts/ci/plan-r2-release-asset-prune.mjs
@@ -264,6 +264,9 @@ function staleR2ObjectKeys(objectKeys, retainedTags, updatePath, channel) {
         }
 
         const fileName = key.slice(prefix.length);
+        if (fileName.includes('/')) {
+            continue;
+        }
         if (!isDownloadAssetName(fileName) || channelFromAssetName(fileName) !== channel) {
             continue;
         }

--- a/apps/desktop/tests/ci/plan-r2-release-asset-prune.test.ts
+++ b/apps/desktop/tests/ci/plan-r2-release-asset-prune.test.ts
@@ -11,6 +11,11 @@ type PlanModule = {
         projectRoot: string,
         channel: string,
         options?: {
+            cloudflare?: {
+                accountId: string;
+                bucketName: string;
+                token: string;
+            };
             fetch?: typeof fetch;
             token?: string | null;
         }
@@ -202,6 +207,82 @@ describe('planR2ReleaseAssetPrune', () => {
                     token: 'token',
                 })
             ).resolves.toEqual([`touchai-app/v1/${oldPackage}`, `touchai-app/v1/${orphanPackage}`]);
+        } finally {
+            await rm(root, { recursive: true, force: true });
+        }
+    });
+
+    it('plans deletion for stale R2 objects that are absent from the existing feed', async () => {
+        const planner = await loadPlanner();
+        const product = productWithRetention();
+        product.services.updates.deployment.r2HotAssetVersions.nightly = 2;
+        const root = await createFixture(product);
+        const currentPackage = 'TouchAI-nightly-0.3.0-nightly.20260524.4-windows-full.nupkg';
+        const retainedPackage = 'TouchAI-nightly-0.3.0-nightly.20260523.3-windows-full.nupkg';
+        const orphanPackage = 'TouchAI-nightly-0.3.0-nightly.20260521.1-windows-full.nupkg';
+        const fetchMock = vi.fn<typeof fetch>(async (input, init) => {
+            const url = new URL(input.toString());
+            if (url.hostname === 'api.github.com') {
+                return githubReleasesResponse([
+                    release('v0.3.0-nightly.20260524.4', '2026-05-24T00:00:00Z', [currentPackage]),
+                    release('v0.3.0-nightly.20260523.3', '2026-05-23T00:00:00Z', [retainedPackage]),
+                ]);
+            }
+
+            if (url.hostname === 'api.cloudflare.com') {
+                expect(url.pathname).toBe(
+                    '/client/v4/accounts/account-id/r2/buckets/bucket/objects'
+                );
+                expect(url.searchParams.get('prefix')).toBe('touchai-app/v1/');
+                expect(url.searchParams.get('per_page')).toBe('1000');
+                expect((init?.headers as Headers).get('authorization')).toBe('Bearer cf-token');
+                return new Response(
+                    JSON.stringify({
+                        success: true,
+                        result: [
+                            { key: `touchai-app/v1/${currentPackage}` },
+                            { key: `touchai-app/v1/${retainedPackage}` },
+                            { key: `touchai-app/v1/${orphanPackage}` },
+                            { key: 'touchai-app/v1/TouchAI-0.2.0-windows.msi' },
+                        ],
+                        result_info: {
+                            is_truncated: false,
+                        },
+                    }),
+                    { headers: { 'content-type': 'application/json' } }
+                );
+            }
+
+            return new Response(
+                JSON.stringify({
+                    Assets: [
+                        {
+                            Version: '0.3.0-nightly.20260524.4',
+                            FileName: currentPackage,
+                        },
+                        {
+                            Version: '0.3.0-nightly.20260523.3',
+                            FileName: retainedPackage,
+                        },
+                    ],
+                }),
+                { headers: { 'content-type': 'application/json' } }
+            );
+        });
+
+        try {
+            expect(planner?.planR2ReleaseAssetPrune).toBeTypeOf('function');
+            await expect(
+                planner!.planR2ReleaseAssetPrune(root, 'nightly', {
+                    cloudflare: {
+                        accountId: 'account-id',
+                        bucketName: 'bucket',
+                        token: 'cf-token',
+                    },
+                    fetch: fetchMock as unknown as typeof fetch,
+                    token: 'token',
+                })
+            ).resolves.toEqual([`touchai-app/v1/${orphanPackage}`]);
         } finally {
             await rm(root, { recursive: true, force: true });
         }

--- a/apps/desktop/tests/ci/plan-r2-release-asset-prune.test.ts
+++ b/apps/desktop/tests/ci/plan-r2-release-asset-prune.test.ts
@@ -243,6 +243,7 @@ describe('planR2ReleaseAssetPrune', () => {
                             { key: `touchai-app/v1/${currentPackage}` },
                             { key: `touchai-app/v1/${retainedPackage}` },
                             { key: `touchai-app/v1/${orphanPackage}` },
+                            { key: `touchai-app/v1/staging/${orphanPackage}` },
                             { key: 'touchai-app/v1/TouchAI-0.2.0-windows.msi' },
                         ],
                         result_info: {

--- a/apps/desktop/tests/ci/release-workflow-environments.test.ts
+++ b/apps/desktop/tests/ci/release-workflow-environments.test.ts
@@ -126,9 +126,23 @@ describe('release workflow deployment environments', () => {
 
     it('prunes only old R2 release assets after GitHub release upload succeeds', async () => {
         const workflow = await readWorkflow('velopack-build.yml');
+        const planIndex = workflow.indexOf('Plan archived R2 release asset pruning');
+        const deployIndex = workflow.indexOf('Deploy update release feeds to Cloudflare R2');
+        const pruneIndex = workflow.indexOf('Prune archived R2 release assets');
+        const planCommand = 'node scripts/ci/plan-r2-release-asset-prune.mjs "$RELEASE_CHANNEL"';
+        const planCommandIndex = workflow.indexOf(planCommand);
+        const pruneStep = workflow.slice(pruneIndex);
 
         expect(workflow).toContain('RELEASE_CHANNEL: ${{ inputs.channel }}');
-        expect(workflow).toContain('plan-r2-release-asset-prune.mjs "$RELEASE_CHANNEL"');
+        expect(workflow).toContain('prune_plan="$RUNNER_TEMP/touchai-r2-prune-plan.txt"');
+        expect(planIndex).toBeGreaterThan(-1);
+        expect(deployIndex).toBeGreaterThan(-1);
+        expect(pruneIndex).toBeGreaterThan(-1);
+        expect(planCommandIndex).toBeGreaterThan(planIndex);
+        expect(planCommandIndex).toBeLessThan(deployIndex);
+        expect(planIndex).toBeLessThan(deployIndex);
+        expect(deployIndex).toBeLessThan(pruneIndex);
+        expect(pruneStep).not.toContain(planCommand);
         expect(workflow).toContain('wrangler@3.90.0 r2 object delete');
         expect(workflow).toMatch(
             /Upload public release assets to GitHub release[\s\S]*Deploy update release feeds to Cloudflare R2[\s\S]*Prune archived R2 release assets/


### PR DESCRIPTION
> First external contributors may need to complete the `CLA Assistant` check before merge.
> For code changes, this PR must link the related issue or RFC in the section below.

## Summary

Preserve the R2 release asset prune plan before update feeds are overwritten, and extend the existing planner to include current R2 bucket objects. This lets nightly cleanup delete orphaned release assets that are no longer present in `releases.nightly.json`, not just stale assets still visible in the public feed.

## Related issue or RFC

- Related to #503

## AI assistance disclosure

- Tool(s) used: OpenAI Codex
- Scope of assistance: implementation, tests, local verification, PR preparation
- Human review or rewrite performed: reviewed diffs and command output before submission
- Architecture or boundary impact: no application runtime, AgentService, MCP, or schema boundary changes; release workflow/planner only

## Testing evidence

TDD was followed for the release planner/workflow behavior. The new assertions first failed because the workflow did not generate the prune plan before feed deployment and because the planner returned `[]` for an R2-only orphan object; both pass after the fix.

```text
corepack pnpm exec vitest run --configLoader runner tests/ci/plan-r2-release-asset-prune.test.ts tests/ci/release-workflow-environments.test.ts
# PASS: 2 files, 16 tests

corepack pnpm test:typecheck
# PASS

corepack pnpm exec eslint scripts/ci/plan-r2-release-asset-prune.mjs tests/ci/plan-r2-release-asset-prune.test.ts tests/ci/release-workflow-environments.test.ts
# PASS

corepack pnpm exec prettier --check .github/workflows/velopack-build.yml apps/desktop/scripts/ci/plan-r2-release-asset-prune.mjs apps/desktop/tests/ci/plan-r2-release-asset-prune.test.ts apps/desktop/tests/ci/release-workflow-environments.test.ts
# PASS

git diff --check
# PASS
```

`corepack pnpm test:pr` could not complete locally due environment storage constraints: one run reached the Vitest phase and failed with `ENOSPC: no space left on device, write`; E: and G: were effectively full, D: had only a few GB free, and retrying with L: temp failed because `L:\TouchAI` could not be created/persisted. Full validation should come from GitHub CI.

## Risk notes

- `AgentService`, runtime, MCP, or schema impact: none
- database baseline or migration impact: none
- release or packaging impact: changes the release deployment workflow to list existing R2 objects via the Cloudflare R2 Objects API before feed upload, then delete stale keys from the preserved plan after upload

## Screenshots or recordings

Not applicable; CI/release workflow only.

## Checklist

- [x] The PR title follows Conventional Commits and is valid for squash merge.
- [x] This PR is either ready for review or explicitly marked as a Draft PR.
- [x] I did not use `[WIP]` or similar title prefixes.
- [x] If AI materially assisted this PR, I disclosed the tools and scope and I personally reviewed every affected change.
- [x] I can explain the why, what, and how of this change without relying on an AI tool.
- [x] If this touches `AgentService`, runtime, MCP, or schema boundaries, there is an accepted RFC.
- [x] If this changes architecture or adds a new cross-boundary abstraction, there is an accepted RFC.
- [ ] I ran `pnpm test:pr` for this code PR, or this is a docs-only change.
- [x] If I changed Rust behavior or tests, I reviewed `pnpm test:coverage:rust` or relied on CI coverage evidence.
- [x] If I changed desktop startup/window/search/popup/settings/E2E paths, I ran `pnpm test:e2e` locally or documented why CI is the first valid proof.
- [x] I added tests or explained why tests are not appropriate.
- [x] I updated docs when behavior changed.